### PR TITLE
ci: add clang-format check on changed files (S4-P6)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 120
+BreakBeforeBraces: Linux
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+SortIncludes: false

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -7,7 +7,6 @@ name: Format Check
 on:
   pull_request:
     branches: [master, main]
-  workflow_dispatch:
 
 jobs:
   clang-format:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,41 @@
+name: Format Check
+
+# Code style enforcement on changed files only. Does not require
+# reformatting the entire codebase — only new/modified C/H files
+# must pass clang-format.
+
+on:
+  pull_request:
+    branches: [master, main]
+  workflow_dispatch:
+
+jobs:
+  clang-format:
+    name: clang-format
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: Check format on changed files
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.sha }}"
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- '*.c' '*.h' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No C/H files changed, skipping format check"
+            exit 0
+          fi
+          echo "Checking format on changed files:"
+          echo "$CHANGED"
+          echo "$CHANGED" | xargs clang-format --dry-run -Werror 2>&1 || {
+            echo "::error::Format check failed. Run: clang-format -i <files>"
+            exit 1
+          }
+          echo "Format check passed"


### PR DESCRIPTION
## Summary
- `.clang-format`: LLVM-based config (4-space indent, 120 col, Linux braces)
- `.github/workflows/format-check.yml`: per-PR check on **changed files only** — no full-codebase reformat required
- Skips gracefully when no C/H files are modified

## Test plan
- [x] YAML validates
- [ ] GitHub Actions green