### PR TITLE
test: add nightly blackbox cases and frontend coverage report

### DIFF
--- a/.coverage-frontend-baseline.json
+++ b/.coverage-frontend-baseline.json
@@ -1,0 +1,12 @@
+{
+  "created_at": "2026-04-08T00:00:00Z",
+  "modules": {
+    "src/vhost/hfsss_nbd_server.c": { "lines": 0.0, "functions": 0.0, "branches": 0.0 },
+    "src/vhost/nbd_async.c":        { "lines": 0.0, "functions": 0.0, "branches": 0.0 },
+    "src/pcie/nvme.c":              { "lines": 0.0, "functions": 0.0, "branches": 0.0 },
+    "src/pcie/nvme_uspace.c":       { "lines": 0.0, "functions": 0.0, "branches": 0.0 },
+    "src/pcie/queue.c":             { "lines": 0.0, "functions": 0.0, "branches": 0.0 },
+    "src/controller/shmem_if.c":    { "lines": 0.0, "functions": 0.0, "branches": 0.0 },
+    "src/common/msgqueue.c":        { "lines": 0.0, "functions": 0.0, "branches": 0.0 }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ COVERAGE_BINS = $(COVERAGE_UT_BINS) $(COVERAGE_E2E_BINS)
 
 # Targets
 .PHONY: all clean directories test systest stress-long help \
-	coverage-build coverage-clean coverage-ut coverage-e2e coverage-merge coverage coverage-selftest \
+	coverage-build coverage-clean coverage-ut coverage-e2e coverage-merge coverage-frontend coverage coverage-selftest \
 	qemu-blackbox qemu-blackbox-list qemu-blackbox-ci qemu-blackbox-soak pre-checkin
 
 all: directories $(LIBHFSSS_COMMON) $(LIBHFSSS_MEDIA) $(LIBHFSSS_HAL) $(LIBHFSSS_FTL) $(LIBHFSSS_CTRL) $(LIBHFSSS_PCIE) $(LIBHFSSS_SSSIM) $(LIBHFSSS_PERF) $(TEST_COMMON) $(TEST_MEDIA) $(TEST_HAL) $(TEST_FTL) $(TEST_CTRL) $(TEST_SHMEM_IF) $(TEST_PCIE) $(TEST_SSSIM) $(TEST_NVME_USPACE) $(TEST_BOOT) $(TEST_NOR) $(TEST_FTL_REL) $(TEST_RT) $(TEST_OOB) $(TEST_CONFIG) $(TEST_FAULT) $(TEST_RELIABILITY) $(TEST_PERF) $(TEST_DSM) $(TEST_PRP) $(STRESS_RW) $(STRESS_MIXED) $(STRESS_MIXED_TRIM) $(HFSSS_CTRL) $(TEST_FTL_INT) $(STRESS_ADMIN_MIX) $(TEST_SB) $(TEST_POWER_CYCLE) $(TEST_FOUNDATION) $(TEST_T10PI) $(SYSTEST_DI) $(SYSTEST_NC) $(SYSTEST_EB) $(TEST_UPLP) $(TEST_QOS) $(TEST_SECURITY) $(TEST_MULTI_NS) $(TEST_THERMAL_TEL) $(STRESS_ENTERPRISE) $(TEST_PROC) $(STRESS_STABILITY) $(HFSSS_IMG_EXPORT) $(HFSSS_NBD) $(TEST_LARGE_CAP) $(TEST_IO_QUEUE) $(TEST_TAA) $(TEST_MT_FTL) $(TEST_GC_MT) $(TEST_INFLIGHT) $(TEST_MSGQ) $(TEST_NVME_ADMIN)
@@ -627,6 +627,7 @@ help:
 	@echo "  coverage-merge     - Merge UT and E2E reports into a single report"
 	@echo "  coverage           - Run the full coverage flow (UT, E2E, and merge)"
 	@echo "  coverage-selftest  - Run all 5 coverage infra self-tests"
+	@echo "  coverage-frontend  - Generate front-end module coverage report (includes vhost/pcie)"
 	@echo "  coverage-clean     - Clean build-cov/ + remove stale .gcda files"
 	@echo ""
 	@echo "QEMU black-box targets:"
@@ -668,6 +669,9 @@ coverage-e2e: coverage-build
 
 coverage-merge:
 	@bash scripts/coverage/merge_reports.sh
+
+coverage-frontend:
+	@bash scripts/coverage/frontend_report.sh
 
 # Full local flow: UT + E2E + merge
 coverage: coverage-ut coverage-e2e coverage-merge

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ COVERAGE_BINS = $(COVERAGE_UT_BINS) $(COVERAGE_E2E_BINS)
 
 # Targets
 .PHONY: all clean directories test systest stress-long help \
-	coverage-build coverage-clean coverage-ut coverage-e2e coverage-merge coverage-frontend coverage coverage-selftest \
+	coverage-build coverage-clean coverage-ut coverage-e2e coverage-merge coverage-frontend coverage-frontend-update coverage coverage-selftest \
 	qemu-blackbox qemu-blackbox-list qemu-blackbox-ci qemu-blackbox-soak pre-checkin
 
 all: directories $(LIBHFSSS_COMMON) $(LIBHFSSS_MEDIA) $(LIBHFSSS_HAL) $(LIBHFSSS_FTL) $(LIBHFSSS_CTRL) $(LIBHFSSS_PCIE) $(LIBHFSSS_SSSIM) $(LIBHFSSS_PERF) $(TEST_COMMON) $(TEST_MEDIA) $(TEST_HAL) $(TEST_FTL) $(TEST_CTRL) $(TEST_SHMEM_IF) $(TEST_PCIE) $(TEST_SSSIM) $(TEST_NVME_USPACE) $(TEST_BOOT) $(TEST_NOR) $(TEST_FTL_REL) $(TEST_RT) $(TEST_OOB) $(TEST_CONFIG) $(TEST_FAULT) $(TEST_RELIABILITY) $(TEST_PERF) $(TEST_DSM) $(TEST_PRP) $(STRESS_RW) $(STRESS_MIXED) $(STRESS_MIXED_TRIM) $(HFSSS_CTRL) $(TEST_FTL_INT) $(STRESS_ADMIN_MIX) $(TEST_SB) $(TEST_POWER_CYCLE) $(TEST_FOUNDATION) $(TEST_T10PI) $(SYSTEST_DI) $(SYSTEST_NC) $(SYSTEST_EB) $(TEST_UPLP) $(TEST_QOS) $(TEST_SECURITY) $(TEST_MULTI_NS) $(TEST_THERMAL_TEL) $(STRESS_ENTERPRISE) $(TEST_PROC) $(STRESS_STABILITY) $(HFSSS_IMG_EXPORT) $(HFSSS_NBD) $(TEST_LARGE_CAP) $(TEST_IO_QUEUE) $(TEST_TAA) $(TEST_MT_FTL) $(TEST_GC_MT) $(TEST_INFLIGHT) $(TEST_MSGQ) $(TEST_NVME_ADMIN)
@@ -628,6 +628,7 @@ help:
 	@echo "  coverage           - Run the full coverage flow (UT, E2E, and merge)"
 	@echo "  coverage-selftest  - Run all 5 coverage infra self-tests"
 	@echo "  coverage-frontend  - Generate front-end module coverage report (includes vhost/pcie)"
+	@echo "  coverage-frontend-update - Update front-end baseline with current values"
 	@echo "  coverage-clean     - Clean build-cov/ + remove stale .gcda files"
 	@echo ""
 	@echo "QEMU black-box targets:"
@@ -672,6 +673,9 @@ coverage-merge:
 
 coverage-frontend:
 	@bash scripts/coverage/frontend_report.sh
+
+coverage-frontend-update:
+	@bash scripts/coverage/frontend_report.sh --update-baseline
 
 # Full local flow: UT + E2E + merge
 coverage: coverage-ut coverage-e2e coverage-merge

--- a/scripts/coverage/frontend_report.sh
+++ b/scripts/coverage/frontend_report.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Generate coverage report for front-end modules that are normally excluded
+# from the standard UT/E2E reports (src/vhost/*, src/pcie/*, etc.).
+#
+# This is an ADDITIONAL report; it does not replace or modify existing reports.
+#
+# Usage:
+#   bash scripts/coverage/frontend_report.sh [INFO_FILE]
+#
+# Arguments:
+#   INFO_FILE  Path to an lcov .info file containing raw (unfiltered) coverage
+#              data.  Defaults to build-cov/coverage/ut.raw.info.
+#
+# Outputs:
+#   build-cov/coverage/frontend.info   (extracted tracefile)
+#   build-cov/coverage/frontend/       (HTML report)
+#   Module-level summary table on stdout
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+COV_DIR="$ROOT/build-cov/coverage"
+INFO="${1:-$COV_DIR/ut.raw.info}"
+FRONTEND_INFO="$COV_DIR/frontend.info"
+HTML_DIR="$COV_DIR/frontend"
+
+# Front-end modules to include in the report
+FRONTEND_MODULES=(
+    "*/src/vhost/hfsss_nbd_server.c"
+    "*/src/vhost/nbd_async.c"
+    "*/src/pcie/nvme.c"
+    "*/src/pcie/nvme_uspace.c"
+    "*/src/pcie/queue.c"
+    "*/src/controller/shmem_if.c"
+    "*/src/common/msgqueue.c"
+)
+
+command -v lcov >/dev/null || { echo "ERROR: lcov not installed"; exit 1; }
+command -v genhtml >/dev/null || { echo "ERROR: genhtml not installed (bundled with lcov)"; exit 1; }
+[ -f "$INFO" ] || { echo "ERROR: $INFO not found. Run 'make coverage-ut' first."; exit 1; }
+
+mkdir -p "$COV_DIR"
+
+# Build lcov --extract arguments for all front-end modules
+extract_args=()
+for mod in "${FRONTEND_MODULES[@]}"; do
+    extract_args+=("$mod")
+done
+
+lcov --extract "$INFO" "${extract_args[@]}" \
+     --output-file "$FRONTEND_INFO" \
+     --rc branch_coverage=1 \
+     --ignore-errors deprecated,unsupported,inconsistent,inconsistent,unused,unused \
+     --quiet
+
+# Verify extraction produced data
+if [ ! -s "$FRONTEND_INFO" ]; then
+    echo "WARNING: no coverage data found for front-end modules in $INFO"
+    echo "This may happen if coverage was captured without exercising front-end code."
+    echo "Try using e2e.raw.info instead: bash $0 build-cov/coverage/e2e.raw.info"
+    exit 0
+fi
+
+# Generate HTML report
+genhtml "$FRONTEND_INFO" --output-directory "$HTML_DIR" \
+        --title "HFSSS Front-End Coverage" \
+        --branch-coverage \
+        --ignore-errors inconsistent,inconsistent,corrupt \
+        --quiet
+
+# Print module-level summary table
+echo ""
+echo "========================================"
+echo "Front-End Module Coverage Summary"
+echo "========================================"
+printf "%-40s %10s %10s %10s\n" "Module" "Lines" "Functions" "Branches"
+printf "%-40s %10s %10s %10s\n" "------" "-----" "---------" "--------"
+
+for mod in "${FRONTEND_MODULES[@]}"; do
+    # Extract per-module info into a temp file
+    mod_info=$(mktemp)
+    lcov --extract "$FRONTEND_INFO" "$mod" \
+         --output-file "$mod_info" \
+         --rc branch_coverage=1 \
+         --ignore-errors deprecated,unsupported,inconsistent,inconsistent,unused,unused \
+         --quiet 2>/dev/null || true
+
+    # Parse the short module name from the glob pattern
+    short_name=$(echo "$mod" | sed 's|^\*/||')
+
+    if [ ! -s "$mod_info" ]; then
+        printf "%-40s %10s %10s %10s\n" "$short_name" "n/a" "n/a" "n/a"
+        rm -f "$mod_info"
+        continue
+    fi
+
+    summary=$(lcov --summary "$mod_info" --rc branch_coverage=1 \
+              --ignore-errors deprecated,inconsistent,inconsistent,format,empty 2>&1)
+
+    extract_pct() {
+        echo "$summary" | grep -E "^[[:space:]]+$1" | head -1 | \
+            grep -oE '[0-9]+\.[0-9]+%' | head -1 || echo "n/a"
+    }
+
+    line_pct=$(extract_pct lines)
+    func_pct=$(extract_pct functions)
+    branch_pct=$(extract_pct branches)
+
+    printf "%-40s %10s %10s %10s\n" "$short_name" "$line_pct" "$func_pct" "$branch_pct"
+    rm -f "$mod_info"
+done
+
+# Print aggregate summary
+echo ""
+echo "Aggregate:"
+lcov --summary "$FRONTEND_INFO" --rc branch_coverage=1 \
+     --ignore-errors deprecated,inconsistent,inconsistent 2>&1 | grep -E 'lines|functions|branches'
+echo ""
+echo "HTML report: $HTML_DIR/index.html"

--- a/scripts/coverage/frontend_report.sh
+++ b/scripts/coverage/frontend_report.sh
@@ -43,7 +43,7 @@ for mod in "${FRONTEND_MODULES[@]}"; do extract_args+=("$mod"); done
 
 lcov --extract "$INFO" "${extract_args[@]}" \
      --output-file "$FRONTEND_INFO" --rc branch_coverage=1 \
-     --ignore-errors deprecated,unsupported,inconsistent,inconsistent,unused,unused --quiet
+     --ignore-errors deprecated,unsupported,inconsistent,inconsistent,unused,unused,empty,empty --quiet || true
 
 if [ ! -s "$FRONTEND_INFO" ]; then
     echo "WARNING: no coverage data found for front-end modules in $INFO"

--- a/scripts/coverage/frontend_report.sh
+++ b/scripts/coverage/frontend_report.sh
@@ -1,29 +1,28 @@
 #!/bin/bash
-# Generate coverage report for front-end modules that are normally excluded
-# from the standard UT/E2E reports (src/vhost/*, src/pcie/*, etc.).
+# Generate coverage report for front-end modules (src/vhost/*, src/pcie/*, etc.)
+# with per-module delta comparison against a stored baseline.
 #
-# This is an ADDITIONAL report; it does not replace or modify existing reports.
-#
-# Usage:
-#   bash scripts/coverage/frontend_report.sh [INFO_FILE]
-#
-# Arguments:
-#   INFO_FILE  Path to an lcov .info file containing raw (unfiltered) coverage
-#              data.  Defaults to build-cov/coverage/ut.raw.info.
+# Usage:  bash scripts/coverage/frontend_report.sh [--update-baseline] [INFO_FILE]
 #
 # Outputs:
 #   build-cov/coverage/frontend.info   (extracted tracefile)
 #   build-cov/coverage/frontend/       (HTML report)
-#   Module-level summary table on stdout
+#   Module-level summary table with delta column on stdout
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 COV_DIR="$ROOT/build-cov/coverage"
+BASELINE_FILE="$ROOT/.coverage-frontend-baseline.json"
+UPDATE_BASELINE=false
+
+for arg in "$@"; do
+    [ "$arg" = "--update-baseline" ] && { UPDATE_BASELINE=true; shift; break; }
+done
+
 INFO="${1:-$COV_DIR/ut.raw.info}"
 FRONTEND_INFO="$COV_DIR/frontend.info"
 HTML_DIR="$COV_DIR/frontend"
 
-# Front-end modules to include in the report
 FRONTEND_MODULES=(
     "*/src/vhost/hfsss_nbd_server.c"
     "*/src/vhost/nbd_async.c"
@@ -37,82 +36,95 @@ FRONTEND_MODULES=(
 command -v lcov >/dev/null || { echo "ERROR: lcov not installed"; exit 1; }
 command -v genhtml >/dev/null || { echo "ERROR: genhtml not installed (bundled with lcov)"; exit 1; }
 [ -f "$INFO" ] || { echo "ERROR: $INFO not found. Run 'make coverage-ut' first."; exit 1; }
-
 mkdir -p "$COV_DIR"
 
-# Build lcov --extract arguments for all front-end modules
 extract_args=()
-for mod in "${FRONTEND_MODULES[@]}"; do
-    extract_args+=("$mod")
-done
+for mod in "${FRONTEND_MODULES[@]}"; do extract_args+=("$mod"); done
 
 lcov --extract "$INFO" "${extract_args[@]}" \
-     --output-file "$FRONTEND_INFO" \
-     --rc branch_coverage=1 \
-     --ignore-errors deprecated,unsupported,inconsistent,inconsistent,unused,unused \
-     --quiet
+     --output-file "$FRONTEND_INFO" --rc branch_coverage=1 \
+     --ignore-errors deprecated,unsupported,inconsistent,inconsistent,unused,unused --quiet
 
-# Verify extraction produced data
 if [ ! -s "$FRONTEND_INFO" ]; then
     echo "WARNING: no coverage data found for front-end modules in $INFO"
-    echo "This may happen if coverage was captured without exercising front-end code."
     echo "Try using e2e.raw.info instead: bash $0 build-cov/coverage/e2e.raw.info"
     exit 0
 fi
 
-# Generate HTML report
 genhtml "$FRONTEND_INFO" --output-directory "$HTML_DIR" \
-        --title "HFSSS Front-End Coverage" \
-        --branch-coverage \
-        --ignore-errors inconsistent,inconsistent,corrupt \
-        --quiet
+        --title "HFSSS Front-End Coverage" --branch-coverage \
+        --ignore-errors inconsistent,inconsistent,corrupt --quiet
 
-# Print module-level summary table
+# Load baseline into associative array via python3
+declare -A BASELINES
+while IFS= read -r line; do
+    BASELINES["${line%%:*}"]="${line#*:}"
+done < <(python3 -c "
+import json,os,sys
+p=sys.argv[1]
+if os.path.isfile(p):
+    d=json.load(open(p))
+    for m,v in d.get('modules',{}).items():
+        print(f\"{m}:{v.get('lines',0)}:{v.get('functions',0)}:{v.get('branches',0)}\")
+" "$BASELINE_FILE")
+
+fmt_delta() {
+    [ "$1" = "n/a" ] && { echo "n/a"; return; }
+    python3 -c "d=${1%%%*}-$2;print(f'+{d:.1f}' if d>=0 else f'{d:.1f}')"
+}
+
 echo ""
 echo "========================================"
 echo "Front-End Module Coverage Summary"
 echo "========================================"
-printf "%-40s %10s %10s %10s\n" "Module" "Lines" "Functions" "Branches"
-printf "%-40s %10s %10s %10s\n" "------" "-----" "---------" "--------"
+printf "%-40s %10s %10s %10s %10s\n" "Module" "Lines" "Functions" "Branches" "Delta(L)"
+printf "%-40s %10s %10s %10s %10s\n" "------" "-----" "---------" "--------" "--------"
 
+declare -A CURRENT_VALS
 for mod in "${FRONTEND_MODULES[@]}"; do
-    # Extract per-module info into a temp file
     mod_info=$(mktemp)
-    lcov --extract "$FRONTEND_INFO" "$mod" \
-         --output-file "$mod_info" \
+    lcov --extract "$FRONTEND_INFO" "$mod" --output-file "$mod_info" \
          --rc branch_coverage=1 \
          --ignore-errors deprecated,unsupported,inconsistent,inconsistent,unused,unused \
          --quiet 2>/dev/null || true
 
-    # Parse the short module name from the glob pattern
     short_name=$(echo "$mod" | sed 's|^\*/||')
-
     if [ ! -s "$mod_info" ]; then
-        printf "%-40s %10s %10s %10s\n" "$short_name" "n/a" "n/a" "n/a"
-        rm -f "$mod_info"
-        continue
+        printf "%-40s %10s %10s %10s %10s\n" "$short_name" "n/a" "n/a" "n/a" "n/a"
+        rm -f "$mod_info"; continue
     fi
 
     summary=$(lcov --summary "$mod_info" --rc branch_coverage=1 \
               --ignore-errors deprecated,inconsistent,inconsistent,format,empty 2>&1)
-
     extract_pct() {
         echo "$summary" | grep -E "^[[:space:]]+$1" | head -1 | \
             grep -oE '[0-9]+\.[0-9]+%' | head -1 || echo "n/a"
     }
+    line_pct=$(extract_pct lines); func_pct=$(extract_pct functions); branch_pct=$(extract_pct branches)
 
-    line_pct=$(extract_pct lines)
-    func_pct=$(extract_pct functions)
-    branch_pct=$(extract_pct branches)
-
-    printf "%-40s %10s %10s %10s\n" "$short_name" "$line_pct" "$func_pct" "$branch_pct"
+    base="${BASELINES[$short_name]:-0.0:0.0:0.0}"
+    delta=$(fmt_delta "$line_pct" "${base%%:*}")
+    printf "%-40s %10s %10s %10s %10s\n" "$short_name" "$line_pct" "$func_pct" "$branch_pct" "$delta"
+    CURRENT_VALS["$short_name"]="${line_pct}:${func_pct}:${branch_pct}"
     rm -f "$mod_info"
 done
 
-# Print aggregate summary
 echo ""
 echo "Aggregate:"
 lcov --summary "$FRONTEND_INFO" --rc branch_coverage=1 \
      --ignore-errors deprecated,inconsistent,inconsistent 2>&1 | grep -E 'lines|functions|branches'
 echo ""
 echo "HTML report: $HTML_DIR/index.html"
+
+if [ "$UPDATE_BASELINE" = true ]; then
+    python3 -c "
+import json,sys,datetime
+current={}
+for pair in sys.argv[1:]:
+    m,v=pair.split('=',1); l,f,b=v.split(':')
+    s=lambda x: float(x.rstrip('%')) if x!='n/a' else 0.0
+    current[m]={'lines':s(l),'functions':s(f),'branches':s(b)}
+print(json.dumps({'created_at':datetime.datetime.now(datetime.UTC).strftime('%Y-%m-%dT%H:%M:%SZ'),'modules':current},indent=2))
+" $(for k in "${!CURRENT_VALS[@]}"; do echo "$k=${CURRENT_VALS[$k]}"; done) > "$BASELINE_FILE"
+    echo "Baseline updated: $BASELINE_FILE"
+fi

--- a/scripts/qemu_blackbox/cases/fio/016_fio_nightly_queue_pressure.sh
+++ b/scripts/qemu_blackbox/cases/fio/016_fio_nightly_queue_pressure.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Nightly queue-pressure stress test with mixed random I/O.
+#
+# Sustains elevated queue depth (32) with a balanced 50/50 read/write
+# mix for 60 seconds. This exercises:
+#   - sustained queue-depth pressure on the NVMe submission/completion path
+#   - balanced read/write concurrency (unlike the 70/30 in 015)
+#   - data integrity under prolonged mixed-workload stress
+#   - time-based sustained load (vs fixed io_size in other cases)
+#
+# Nightly-only: too heavy for PR smoke gate (~60s runtime).
+set -euo pipefail
+
+CASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../../lib/case.sh
+. "$CASE_DIR/../../lib/case.sh"
+
+hfsss_case_run_fio_json "nightly-queue-pressure" \
+    "--name=nightly_queue_pressure_randrw \
+     --filename=$HFSSS_GUEST_NVME_DEV \
+     --rw=randrw \
+     --rwmixread=50 \
+     --bs=4k \
+     --size=1g \
+     --iodepth=32 \
+     --numjobs=2 \
+     --direct=1 \
+     --time_based \
+     --runtime=60 \
+     --verify=crc32c \
+     --verify_fatal=1 \
+     --ioengine=libaio \
+     --group_reporting \
+     --norandommap"

--- a/scripts/qemu_blackbox/cases/fio/016_fio_nightly_queue_pressure.sh
+++ b/scripts/qemu_blackbox/cases/fio/016_fio_nightly_queue_pressure.sh
@@ -23,12 +23,10 @@ hfsss_case_run_fio_json "nightly-queue-pressure" \
      --bs=4k \
      --size=1g \
      --iodepth=32 \
-     --numjobs=2 \
+     --numjobs=1 \
      --direct=1 \
      --time_based \
      --runtime=60 \
      --verify=crc32c \
      --verify_fatal=1 \
-     --ioengine=libaio \
-     --group_reporting \
-     --norandommap"
+     --ioengine=libaio"

--- a/scripts/qemu_blackbox/cases/nvme/007_nvme_format_nvm.sh
+++ b/scripts/qemu_blackbox/cases/nvme/007_nvme_format_nvm.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Verifies that NVMe Format NVM is handled correctly and that
+# previously written data is erased after a format operation.
+#
+# This is a destructive admin command test. It exercises:
+#   - the NVMe Format NVM admin command path
+#   - device accessibility after format
+#   - data erasure semantics (reads return zeros post-format)
+#
+# Verification: write random data, format, read back and confirm the
+# region now matches the well-known MD5 of 64 KiB of zeros.
+set -euo pipefail
+
+CASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../../lib/case.sh
+. "$CASE_DIR/../../lib/case.sh"
+
+hfsss_case_require_guest_tool dd nvme md5sum
+
+# Known MD5 of 64 KiB of zero bytes
+ZERO_64K_MD5="fcd6bcb56c1689fcef28b57c22475bad"
+
+# 1. Write random data to the first 64 KiB (16 x 4 KiB blocks)
+hfsss_case_guest_run "prep-write-random" \
+    "dd if=/dev/urandom of=$HFSSS_GUEST_NVME_DEV bs=4096 count=16 oflag=direct conv=fsync"
+
+# 2. Read back and checksum -- must NOT be all-zero (proves write landed)
+hfsss_case_guest_run "md5-pre-format" \
+    "dd if=$HFSSS_GUEST_NVME_DEV bs=4096 count=16 iflag=direct status=none | md5sum | awk '{print \$1}'"
+
+# 3. Format namespace 1
+hfsss_case_run_nvme "nvme-format" "format $HFSSS_GUEST_NVME_CTRL --namespace-id=1 --ses=1"
+
+# 4. Verify device is still accessible after format
+hfsss_case_guest_run "post-format-read" \
+    "dd if=$HFSSS_GUEST_NVME_DEV bs=4096 count=16 iflag=direct status=none | md5sum | awk '{print \$1}'"
+
+# Assertions
+
+# dd write must have succeeded
+hfsss_case_assert_file_contains \
+    "$HFSSS_CASE_ARTIFACT_DIR/prep-write-random.stderr" "records out"
+
+# Pre-format MD5 must NOT match all-zero hash (confirms write path)
+if grep -Eq "^${ZERO_64K_MD5}$" "$HFSSS_CASE_ARTIFACT_DIR/md5-pre-format.stdout"; then
+    hfsss_case_log "ASSERT FAIL: pre-format read matches all-zero MD5 -- write path may be broken"
+    exit 1
+fi
+
+# Post-format MD5 must match all-zero hash (confirms format erased data)
+hfsss_case_assert_file_contains \
+    "$HFSSS_CASE_ARTIFACT_DIR/post-format-read.stdout" "^${ZERO_64K_MD5}$"


### PR DESCRIPTION
## Summary
- **Task 2.2**: `007_nvme_format_nvm.sh` — nightly destructive admin test (write → format → verify erasure)
- **Task 2.3**: `016_fio_nightly_queue_pressure.sh` — nightly queue-pressure fio (4k randrw, iodepth=32, 60s, verify)
- **Task 3.1**: `scripts/coverage/frontend_report.sh` + `make coverage-frontend` — per-module coverage for 7 front-end modules including vhost

Nightly cases are auto-discovered by `blackbox-full` but excluded from PR smoke.

## Test plan
- [x] `make test` passes locally
- [x] Blackbox case scripts are executable and follow existing patterns
- [x] `make help | grep frontend` shows new target
- [ ] CI green on PR