### PR TITLE
fix: remove --norandommap from fio 015 verify test

### DIFF
--- a/scripts/qemu_blackbox/cases/fio/015_fio_high_iodepth_verify.sh
+++ b/scripts/qemu_blackbox/cases/fio/015_fio_high_iodepth_verify.sh
@@ -28,5 +28,4 @@ hfsss_case_run_fio_json "high-iodepth" \
      --direct=1 \
      --verify=crc32c \
      --verify_fatal=1 \
-     --ioengine=libaio \
-     --norandommap"
+     --ioengine=libaio"


### PR DESCRIPTION
## Summary
- Remove `--norandommap` from `015_fio_high_iodepth_verify.sh` to prevent false CRC32C verify failures
- `--norandommap` with `--verify` at iodepth=64 allows fio to overwrite blocks before verification completes, causing rand_seed mismatches
- Same class of bug previously fixed in test 016 during PR #64 review

## Test plan
- [x] Re-ran full stress suite (014 + 015 + 016): 3/3 PASS
- [x] 015 previously failed with ~30 verify errors, now passes cleanly