### PR TITLE
fix: address 4 Codex findings + CB-004/007 + YAML parser fix

### DIFF
--- a/src/common/hfsss_config.c
+++ b/src/common/hfsss_config.c
@@ -4,6 +4,7 @@
 #include "common/common.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 #include <ctype.h>
 #include <errno.h>
@@ -159,6 +160,10 @@ int hfsss_config_load(const char *path, struct hfsss_config *cfg,
 
     while (fgets(line, sizeof(line), f)) {
         lineno++;
+        /* Detect whether the line is indented BEFORE trimming, so we can
+         * tell section children (indented) from top-level keys (flush-left).
+         * A top-level non-blank line resets the current section. */
+        bool indented = (line[0] == ' ' || line[0] == '\t');
         char *p = trim(line);
         if (*p == '#' || *p == '\0') continue;
 
@@ -177,6 +182,13 @@ int hfsss_config_load(const char *path, struct hfsss_config *cfg,
         }
 
         unquote(val);
+
+        /* Top-level key (no indentation) closes any active section so that
+         * e.g. "log_level: 3" after a "persist:" block is applied at the
+         * root, not as "persist.log_level". */
+        if (!indented) {
+            section[0] = '\0';
+        }
 
         if (apply_kv(cfg, section, key, val) != 0) {
             HFSSS_LOG_WARN("CFG", "unknown key '%s.%s' at line %d (ignored)",

--- a/src/controller/latency_monitor.c
+++ b/src/controller/latency_monitor.c
@@ -1,4 +1,5 @@
 #include "controller/qos.h"
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -86,13 +87,18 @@ u64 lat_monitor_percentile(const struct ns_latency_monitor *mon,
     for (u32 i = 0; i < QOS_HIST_BUCKETS; i++) {
         cumulative += mon->buckets[i];
         if (cumulative >= target) {
-            /* Return upper bound of this bucket in microseconds */
+            /* Return upper bound of this bucket in microseconds.
+             * Clamp the shift: at i == QOS_HIST_BUCKETS - 1 (last bucket)
+             * a shift by QOS_HIST_BUCKETS would be UB on a 64-bit int. */
+            if (i + 1 >= QOS_HIST_BUCKETS) {
+                return UINT64_MAX;
+            }
             return (1ULL << (i + 1));
         }
     }
 
-    /* Should not reach here; return max bucket upper bound */
-    return (1ULL << QOS_HIST_BUCKETS);
+    /* Exhausted all buckets without reaching target: return saturated max */
+    return UINT64_MAX;
 }
 
 bool lat_monitor_check_sla(struct ns_latency_monitor *mon)

--- a/src/ftl/wear_level.c
+++ b/src/ftl/wear_level.c
@@ -47,6 +47,24 @@ int wear_level_set_static_threshold(struct wear_level_ctx *ctx, u32 threshold)
     return HFSSS_OK;
 }
 
+int wear_level_set_alert_threshold(struct wear_level_ctx *ctx,
+                                   u32 alert_threshold,
+                                   u32 critical_threshold)
+{
+    if (!ctx) {
+        return HFSSS_ERR_INVAL;
+    }
+    /* Sanity: thresholds are percentages (0..100), and critical must be
+     * >= alert for the alert hierarchy to make sense. */
+    if (alert_threshold > 100 || critical_threshold > 100 ||
+        critical_threshold < alert_threshold) {
+        return HFSSS_ERR_INVAL;
+    }
+    ctx->wear_alert_threshold = alert_threshold;
+    ctx->wear_critical_threshold = critical_threshold;
+    return HFSSS_OK;
+}
+
 bool wear_level_should_run_static(struct wear_level_ctx *ctx, u64 current_ts, u32 max_erase, u32 min_erase)
 {
     if (!ctx || !ctx->enabled || !ctx->static_enabled) {

--- a/src/media/media.c
+++ b/src/media/media.c
@@ -1,6 +1,10 @@
 #include "media/media.h"
+#include "sssim.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 /* Forward declarations */
 static void media_wait_until_available(struct media_ctx *ctx, enum op_type op,
@@ -936,28 +940,70 @@ int media_load(struct media_ctx *ctx, const char *filepath)
     return HFSSS_OK;
 }
 
-int media_create_checkpoint(struct media_ctx *ctx, const char *checkpoint_dir)
+/* Join a directory and filename into out buffer. Caller must ensure out_sz
+ * is large enough; returns HFSSS_ERR_INVAL on truncation. */
+static int build_ckpt_path(char *out, size_t out_sz, const char *dir,
+                           const char *filename)
 {
-    (void)checkpoint_dir; /* TODO: Implement directory-based checkpointing */
-    int ret = media_save(ctx, "checkpoint.bin");
-    if (ret == HFSSS_OK) {
-        media_mark_all_clean(ctx);
+    if (!out || !dir || !filename || out_sz == 0) {
+        return HFSSS_ERR_INVAL;
     }
-    return ret;
+    int n = snprintf(out, out_sz, "%s/%s", dir, filename);
+    if (n < 0 || (size_t)n >= out_sz) {
+        return HFSSS_ERR_INVAL;
+    }
+    return HFSSS_OK;
 }
 
-int media_create_incremental_checkpoint(struct media_ctx *ctx, const char *checkpoint_dir)
+int media_create_checkpoint(struct media_ctx *ctx, const char *checkpoint_dir)
 {
-    (void)checkpoint_dir; /* TODO: Implement directory-based checkpointing */
-    int ret = media_save_incremental(ctx, "checkpoint_inc.bin");
-    if (ret == HFSSS_OK) {
+    if (!ctx || !checkpoint_dir) {
+        return HFSSS_ERR_INVAL;
+    }
+    /* Ensure directory exists (idempotent) */
+    mkdir(checkpoint_dir, 0755);
+
+    char path[SSSIM_PATH_LEN];
+    int rc = build_ckpt_path(path, sizeof(path), checkpoint_dir,
+                             "checkpoint.bin");
+    if (rc != HFSSS_OK) return rc;
+
+    rc = media_save(ctx, path);
+    if (rc == HFSSS_OK) {
         media_mark_all_clean(ctx);
     }
-    return ret;
+    return rc;
+}
+
+int media_create_incremental_checkpoint(struct media_ctx *ctx,
+                                        const char *checkpoint_dir)
+{
+    if (!ctx || !checkpoint_dir) {
+        return HFSSS_ERR_INVAL;
+    }
+    mkdir(checkpoint_dir, 0755);
+
+    char path[SSSIM_PATH_LEN];
+    int rc = build_ckpt_path(path, sizeof(path), checkpoint_dir,
+                             "checkpoint_inc.bin");
+    if (rc != HFSSS_OK) return rc;
+
+    rc = media_save_incremental(ctx, path);
+    if (rc == HFSSS_OK) {
+        media_mark_all_clean(ctx);
+    }
+    return rc;
 }
 
 int media_restore_checkpoint(struct media_ctx *ctx, const char *checkpoint_dir)
 {
-    (void)checkpoint_dir; /* TODO: Implement directory-based checkpointing */
-    return media_load(ctx, "checkpoint.bin");
+    if (!ctx || !checkpoint_dir) {
+        return HFSSS_ERR_INVAL;
+    }
+    char path[SSSIM_PATH_LEN];
+    int rc = build_ckpt_path(path, sizeof(path), checkpoint_dir,
+                             "checkpoint.bin");
+    if (rc != HFSSS_OK) return rc;
+
+    return media_load(ctx, path);
 }

--- a/tests/systest_error_boundary.c
+++ b/tests/systest_error_boundary.c
@@ -8,6 +8,11 @@
 #include "pcie/nvme_uspace.h"
 #include "ftl/ftl.h"
 #include "common/common.h"
+#include "common/hfsss_config.h"
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
 
 /* --------------- Test Harness --------------- */
 
@@ -347,6 +352,84 @@ static void test_cb003_low_op_ratio(void) {
 }
 
 /* ================================================================
+ * CB-004: High OP ratio (50%) — minimal GC pressure
+ * ================================================================ */
+static void test_cb004_high_op_ratio(void) {
+    printf("\n=== CB-004: High OP ratio (50%%) ===\n");
+
+    struct nvme_uspace_dev dev;
+    struct nvme_uspace_config cfg;
+    memset(&dev, 0, sizeof(dev));
+
+    /* Custom setup with op_ratio = 50 */
+    nvme_uspace_config_default(&cfg);
+    cfg.sssim_cfg.channel_count = 2;
+    cfg.sssim_cfg.chips_per_channel = 1;
+    cfg.sssim_cfg.dies_per_chip = 1;
+    cfg.sssim_cfg.planes_per_die = 1;
+    cfg.sssim_cfg.blocks_per_plane = 64;
+    cfg.sssim_cfg.pages_per_block = 128;
+    cfg.sssim_cfg.page_size = 4096;
+    cfg.sssim_cfg.op_ratio = 50;
+    uint64_t raw = (uint64_t)2 * 1 * 1 * 1 * 64 * 128;
+    cfg.sssim_cfg.total_lbas = raw * (100 - 50) / 100;
+
+    int rc = nvme_uspace_dev_init(&dev, &cfg);
+    TEST_ASSERT(rc == HFSSS_OK, "CB-004: dev init with 50%% OP");
+    if (rc != HFSSS_OK) return;
+
+    rc = nvme_uspace_dev_start(&dev);
+    TEST_ASSERT(rc == HFSSS_OK, "CB-004: dev start");
+    if (rc != HFSSS_OK) { nvme_uspace_dev_cleanup(&dev); return; }
+
+    rc = nvme_uspace_create_io_cq(&dev, 1, 256, false);
+    TEST_ASSERT(rc == HFSSS_OK, "CB-004: create CQ");
+    rc = nvme_uspace_create_io_sq(&dev, 1, 256, 1, 0);
+    TEST_ASSERT(rc == HFSSS_OK, "CB-004: create SQ");
+
+    u64 total_lbas = cfg.sssim_cfg.total_lbas;
+    void *buf = malloc(LBA_SIZE);
+    TEST_ASSERT(buf != NULL, "CB-004: allocate buffer");
+    if (!buf) { teardown_dev(&dev); return; }
+
+    /* Fill 80% so writes always succeed (plenty of headroom) */
+    u64 fill_count = total_lbas * 80 / 100;
+    int written_ok = 0;
+    for (u64 lba = 0; lba < fill_count; lba++) {
+        fill_pattern(buf, (uint32_t)lba, 1);
+        rc = nvme_uspace_write(&dev, 1, lba, 1, buf);
+        if (rc == HFSSS_OK) written_ok++;
+    }
+    TEST_ASSERT(written_ok == (int)fill_count,
+                "CB-004: all 80%% writes succeed with 50%% OP");
+
+    /* Random overwrites should also always succeed (generous OP) */
+    uint32_t seed = 0xDEADBEEF;
+    int overwrite_ok = 0;
+    for (int i = 0; i < 3000; i++) {
+        seed = lcg(seed);
+        u64 lba = seed % fill_count;
+        fill_pattern(buf, (uint32_t)lba, 2);
+        rc = nvme_uspace_write(&dev, 1, lba, 1, buf);
+        if (rc == HFSSS_OK) overwrite_ok++;
+    }
+    TEST_ASSERT(overwrite_ok == 3000,
+                "CB-004: all overwrites succeed with 50%% OP");
+
+    /* With generous OP, GC pressure should be light. Read WAF. */
+    struct ftl_stats stats;
+    sssim_get_stats(&dev.sssim, &stats);
+    printf("  (gc_count=%llu, WAF=%.3f at 50%% OP)\n",
+           (unsigned long long)stats.gc_count, stats.waf);
+    /* WAF with 50% OP + 80% fill should be low (<5 is very generous).
+     * Mostly we just assert the sim produced a valid positive WAF. */
+    TEST_ASSERT(stats.waf >= 1.0, "CB-004: WAF is valid (>= 1.0)");
+
+    free(buf);
+    teardown_dev(&dev);
+}
+
+/* ================================================================
  * CB-005: NAND types (verify all init correctly)
  * ================================================================ */
 static void test_cb005_nand_types(void) {
@@ -472,6 +555,73 @@ static void test_cb006_edge_lba_values(void) {
 }
 
 /* ================================================================
+ * CB-007: Config file round-trip (YAML save/load)
+ * ================================================================ */
+static void test_cb007_config_round_trip(void) {
+    printf("\n=== CB-007: Config file round-trip ===\n");
+
+    char path[256];
+    snprintf(path, sizeof(path), "/tmp/systest_cb007_%d.yaml", (int)getpid());
+
+    /* Step 1: defaults + custom values */
+    struct hfsss_config cfg_a;
+    hfsss_config_defaults(&cfg_a);
+    cfg_a.nand.channel_count = 4;
+    cfg_a.nand.chips_per_channel = 2;
+    cfg_a.nand.blocks_per_plane = 256;
+    cfg_a.nand.op_ratio_pct = 20;
+    cfg_a.gc.threshold_pct = 15;
+    strncpy(cfg_a.gc.policy, "cost_benefit", sizeof(cfg_a.gc.policy) - 1);
+    cfg_a.log_level = 3;
+
+    int rc = hfsss_config_save(path, &cfg_a);
+    TEST_ASSERT(rc == 0, "CB-007: hfsss_config_save succeeds");
+    if (rc != 0) return;
+
+    /* Step 2: validate the file exists and is non-empty */
+    struct stat st;
+    rc = stat(path, &st);
+    TEST_ASSERT(rc == 0 && st.st_size > 0,
+                "CB-007: config file created and non-empty");
+
+    /* Step 3: load into fresh struct and compare */
+    struct hfsss_config cfg_b;
+    memset(&cfg_b, 0, sizeof(cfg_b));
+    char errbuf[256] = {0};
+    rc = hfsss_config_load(path, &cfg_b, errbuf, sizeof(errbuf));
+    TEST_ASSERT(rc == 0, "CB-007: hfsss_config_load succeeds");
+    if (rc != 0) {
+        printf("  (load error: %s)\n", errbuf);
+        unlink(path);
+        return;
+    }
+
+    /* Step 4: field-level equality checks */
+    TEST_ASSERT(cfg_b.nand.channel_count == cfg_a.nand.channel_count,
+                "CB-007: channel_count round-trips");
+    TEST_ASSERT(cfg_b.nand.chips_per_channel == cfg_a.nand.chips_per_channel,
+                "CB-007: chips_per_channel round-trips");
+    TEST_ASSERT(cfg_b.nand.blocks_per_plane == cfg_a.nand.blocks_per_plane,
+                "CB-007: blocks_per_plane round-trips");
+    TEST_ASSERT(cfg_b.nand.op_ratio_pct == cfg_a.nand.op_ratio_pct,
+                "CB-007: op_ratio_pct round-trips");
+    TEST_ASSERT(cfg_b.gc.threshold_pct == cfg_a.gc.threshold_pct,
+                "CB-007: gc.threshold_pct round-trips");
+    TEST_ASSERT(strcmp(cfg_b.gc.policy, cfg_a.gc.policy) == 0,
+                "CB-007: gc.policy string round-trips");
+    TEST_ASSERT(cfg_b.log_level == cfg_a.log_level,
+                "CB-007: log_level round-trips");
+
+    /* Step 5: validate both are well-formed */
+    rc = hfsss_config_validate(&cfg_a, errbuf, sizeof(errbuf));
+    TEST_ASSERT(rc == 0, "CB-007: original config validates");
+    rc = hfsss_config_validate(&cfg_b, errbuf, sizeof(errbuf));
+    TEST_ASSERT(rc == 0, "CB-007: reloaded config validates");
+
+    unlink(path);
+}
+
+/* ================================================================
  * Main
  * ================================================================ */
 int main(void) {
@@ -483,8 +633,10 @@ int main(void) {
     test_cb001_minimum_geometry();
     test_cb002_larger_geometry();
     test_cb003_low_op_ratio();
+    test_cb004_high_op_ratio();
     test_cb005_nand_types();
     test_cb006_edge_lba_values();
+    test_cb007_config_round_trip();
 
     printf("\n============================================\n");
     printf("  Results: %d/%d passed, %d failed\n", passed_tests, total_tests, failed_tests);

--- a/tests/systest_persistence.c
+++ b/tests/systest_persistence.c
@@ -15,6 +15,7 @@
 #include <sys/stat.h>
 #include "pcie/nvme_uspace.h"
 #include "ftl/ftl.h"
+#include "ftl/mapping.h"
 #include "ftl/superblock.h"
 #include "common/common.h"
 #include "common/fault_inject.h"
@@ -188,6 +189,18 @@ static void test_pr_001(void) {
     /* Flush to ensure all data reaches media */
     nvme_uspace_flush(&dev, 1);
 
+    /* Snapshot the L2P mapping so the reloaded device can restore it.
+     * This simulates "media save + FTL checkpoint" that the production
+     * recovery flow would perform atomically. */
+    union ppn *ppn_snapshot = calloc(write_count, sizeof(union ppn));
+    bool *ppn_valid = calloc(write_count, sizeof(bool));
+    for (uint64_t lba = 0; lba < write_count; lba++) {
+        if (mapping_l2p(&dev.sssim.ftl.mapping, lba,
+                        &ppn_snapshot[lba]) == HFSSS_OK) {
+            ppn_valid[lba] = true;
+        }
+    }
+
     int rc = media_save(&dev.sssim.media, media_path);
     TEST_ASSERT(rc == HFSSS_OK, "PR-001: media_save succeeds");
 
@@ -209,38 +222,32 @@ static void test_pr_001(void) {
     rc = media_load(&dev2.sssim.media, media_path);
     TEST_ASSERT(rc == HFSSS_OK, "PR-001: media_load succeeds");
 
-    /*
-     * After media_load the NAND image is restored, but the FTL L2P
-     * table of the fresh device has no mapping entries.  We read via
-     * the FTL layer which may return NOENT for LBAs it has not mapped
-     * yet.  To verify raw media persistence we bypass the FTL: write
-     * through the original FTL, save media, reload media, then re-read
-     * through an FTL that was checkpointed alongside the media.
-     *
-     * Since FTL checkpoint is not in scope of PR-001, we verify what
-     * we can: that media_save/media_load themselves succeed and that
-     * the round-trip returns HFSSS_OK without crashing.  A full L2P
-     * round-trip is covered by PR-003 and PR-004.
-     */
-    ok = true;
+    /* Restore the L2P mapping snapshot into dev2 so the read path can
+     * locate the LBAs.  This closes the full media + FTL round-trip. */
+    for (uint64_t lba = 0; lba < write_count; lba++) {
+        if (ppn_valid[lba]) {
+            mapping_direct_set(&dev2.sssim.ftl.mapping, lba,
+                               ppn_snapshot[lba]);
+        }
+    }
+
+    /* Now the real assertion: every persisted LBA must read back
+     * correctly through the NVMe -> FTL -> media path. */
     uint64_t verified = 0;
     for (uint64_t lba = 0; lba < write_count; lba++) {
         rc = nvme_uspace_read(&dev2, 1, lba, 1, rbuf);
         if (rc == HFSSS_OK && verify_pattern(rbuf, (uint32_t)lba, 1)) {
             verified++;
         }
-        /* NOENT is acceptable: fresh FTL has no L2P entries */
     }
-    /*
-     * If the FTL checkpoint was also restored (future integration), all
-     * 500 should verify.  For now, accept partial or full verification.
-     */
-    TEST_ASSERT(rc != HFSSS_ERR_IO,
-                "PR-001: read-back after media_load does not produce I/O error");
     printf("  (verified %llu of %llu LBAs through FTL)\n",
            (unsigned long long)verified,
            (unsigned long long)write_count);
+    TEST_ASSERT(verified == write_count,
+                "PR-001: all LBAs verify after media save/load + mapping restore");
 
+    free(ppn_snapshot);
+    free(ppn_valid);
     free(wbuf);
     free(rbuf);
     dev_teardown(&dev2);
@@ -413,6 +420,16 @@ static void test_pr_003(void) {
 
     nvme_uspace_flush(&dev, 1);
 
+    /* Snapshot L2P mapping for restore alongside the media checkpoint */
+    union ppn *ppn_snapshot = calloc(write_count, sizeof(union ppn));
+    bool *ppn_valid = calloc(write_count, sizeof(bool));
+    for (uint64_t lba = 0; lba < write_count; lba++) {
+        if (mapping_l2p(&dev.sssim.ftl.mapping, lba,
+                        &ppn_snapshot[lba]) == HFSSS_OK) {
+            ppn_valid[lba] = true;
+        }
+    }
+
     int rc = media_create_checkpoint(&dev.sssim.media, ckpt_dir);
     TEST_ASSERT(rc == HFSSS_OK, "PR-003: media_create_checkpoint succeeds");
 
@@ -434,12 +451,15 @@ static void test_pr_003(void) {
     rc = media_restore_checkpoint(&dev2.sssim.media, ckpt_dir);
     TEST_ASSERT(rc == HFSSS_OK, "PR-003: media_restore_checkpoint succeeds");
 
-    /*
-     * Similar caveat as PR-001: fresh FTL has no L2P table for the
-     * restored media.  We verify at the media layer level that the
-     * checkpoint round-trip completed without error.
-     */
-    ok = true;
+    /* Restore L2P mapping into dev2: full media + FTL checkpoint round-trip */
+    for (uint64_t lba = 0; lba < write_count; lba++) {
+        if (ppn_valid[lba]) {
+            mapping_direct_set(&dev2.sssim.ftl.mapping, lba,
+                               ppn_snapshot[lba]);
+        }
+    }
+
+    /* Real assertion: every LBA must read back with the original pattern */
     uint64_t verified = 0;
     for (uint64_t lba = 0; lba < write_count; lba++) {
         rc = nvme_uspace_read(&dev2, 1, lba, 1, rbuf);
@@ -447,12 +467,14 @@ static void test_pr_003(void) {
             verified++;
         }
     }
-    TEST_ASSERT(rc != HFSSS_ERR_IO,
-                "PR-003: reads after checkpoint restore produce no I/O error");
     printf("  (verified %llu of %llu LBAs through FTL)\n",
            (unsigned long long)verified,
            (unsigned long long)write_count);
+    TEST_ASSERT(verified == write_count,
+                "PR-003: all LBAs verify after media checkpoint round-trip");
 
+    free(ppn_snapshot);
+    free(ppn_valid);
     free(wbuf);
     free(rbuf);
     dev_teardown(&dev2);


### PR DESCRIPTION
## Summary

Fixes 4 real bugs flagged in a Codex review of current master, validated in an isolated worktree against commit `71318ca`.

| # | Bug | Where | Severity |
|---|-----|-------|----------|
| 1 | `lat_monitor_percentile()` hits \`1ULL << 64\` (undefined behavior) on the highest histogram bucket | `src/controller/latency_monitor.c:90,95` | Correctness (UB) |
| 2 | `media_create_checkpoint()` / `media_restore_checkpoint()` silently discard the caller-supplied \`checkpoint_dir\` and write a hardcoded \`checkpoint.bin\` in the cwd | `src/media/media.c:939,949,959` | API contract + cross-run contamination |
| 3 | `wear_level_set_alert_threshold()` declared in the public header but has no definition — callers hit an undefined-symbol link error | `include/ftl/wear_level.h:49` | Missing implementation |
| 4 | `systest_persistence` PR-001 / PR-003 print \`(verified 0 of 500 LBAs)\` and still pass because the assertion is only \`rc != HFSSS_ERR_IO\` | `tests/systest_persistence.c:234,456` | Test quality (false coverage) |

## Fixes

### 1. Latency histogram overflow
Clamp the shift to `QOS_HIST_BUCKETS - 1` and return `UINT64_MAX` for the top bucket and the no-target-hit fallthrough. Verified with a standalone repro that drops one sample into bucket 63 — now returns `UINT64_MAX` instead of `1`.

### 2. Checkpoint directory handling
Added `build_ckpt_path()` helper that joins the caller's directory with \`checkpoint.bin\` / \`checkpoint_inc.bin\`, `mkdir(0755)`s the directory when missing, and validates against path truncation. Confirmed with \`systest_persistence\` — no more \`checkpoint.bin\` left in the repo root after the run.

### 3. `wear_level_set_alert_threshold` implementation
Added the definition in `src/ftl/wear_level.c` with sanity checks:
- `alert_threshold <= 100`
- `critical_threshold <= 100`
- `critical_threshold >= alert_threshold` (keeps the alert hierarchy well-formed)

Verified with a standalone link repro — previously \`Undefined symbols\`, now links and runs.

### 4. PR-001 / PR-003 real round-trip assertion
The original design claimed a full save/restore round-trip but could never succeed because \`media_load()\` restores NAND bytes while the fresh FTL has an empty L2P table — so reads through \`nvme_uspace_read\` returned NOENT for every LBA. The assertion \`rc != HFSSS_ERR_IO\` was trivially true with 0 verified.

Fix: snapshot the L2P mapping before teardown via \`mapping_l2p()\`, then restore it into the reloaded device via \`mapping_direct_set()\` after \`media_load()\` / \`media_restore_checkpoint()\`. This closes the full media + FTL round-trip and the assertion now checks \`verified == write_count\`. Before: \`verified 0 of 500\`. After: \`verified 500 of 500\`.

## Test plan
- [x] Full clean build succeeds
- [x] systest_persistence: 39/39 PASS, verified 500/500 LBAs
- [x] systest_data_integrity: 50/50 PASS
- [x] systest_nvme_compliance: 70/70 PASS
- [x] systest_error_boundary: 536/536 PASS
- [x] systest_performance: 23/23 PASS
- [x] No checkpoint.bin left in cwd
- [x] Standalone repros confirm bugs 1 and 3
- [ ] CI validation