### PR TITLE
fix: resolve 4 concurrency deadlocks (Codex Round 3)

### DIFF
--- a/src/ftl/ftl_worker.c
+++ b/src/ftl/ftl_worker.c
@@ -11,7 +11,7 @@ extern void *wl_thread_main(void *arg);
 
 /* Global pointers set by ftl_mt_start() so worker threads can signal GC */
 pthread_mutex_t *ftl_mt_gc_mutex_ptr = NULL;
-pthread_cond_t  *ftl_mt_gc_cond_ptr  = NULL;
+pthread_cond_t *ftl_mt_gc_cond_ptr = NULL;
 
 static void *ftl_worker_main(void *arg)
 {
@@ -43,9 +43,9 @@ static void *ftl_worker_main(void *arg)
             u32 data_step = req.data_stride ? req.data_stride : page_size;
             u8 *ptr = req.data;
             for (u32 i = 0; i < req.count; i++) {
-                rc = ftl_read_page_mt(w->ftl, w->taa,
-                                      req.lba + (u64)i * lba_step, ptr);
-                if (rc != HFSSS_OK) break;
+                rc = ftl_read_page_mt(w->ftl, w->taa, req.lba + (u64)i * lba_step, ptr);
+                if (rc != HFSSS_OK)
+                    break;
                 ptr += data_step;
             }
             break;
@@ -56,9 +56,9 @@ static void *ftl_worker_main(void *arg)
             u32 data_step = req.data_stride ? req.data_stride : page_size;
             const u8 *ptr = req.data;
             for (u32 i = 0; i < req.count; i++) {
-                rc = ftl_write_page_mt(w->ftl, w->taa,
-                                       req.lba + (u64)i * lba_step, ptr);
-                if (rc != HFSSS_OK) break;
+                rc = ftl_write_page_mt(w->ftl, w->taa, req.lba + (u64)i * lba_step, ptr);
+                if (rc != HFSSS_OK)
+                    break;
                 ptr += data_step;
             }
             break;
@@ -66,9 +66,9 @@ static void *ftl_worker_main(void *arg)
         case IO_OP_TRIM: {
             u32 lba_step = req.lba_stride ? req.lba_stride : 1;
             for (u32 i = 0; i < req.count; i++) {
-                rc = ftl_trim_page_mt(w->ftl, w->taa,
-                                      req.lba + (u64)i * lba_step);
-                if (rc != HFSSS_OK) break;
+                rc = ftl_trim_page_mt(w->ftl, w->taa, req.lba + (u64)i * lba_step);
+                if (rc != HFSSS_OK)
+                    break;
             }
             break;
         }
@@ -85,7 +85,8 @@ static void *ftl_worker_main(void *arg)
         cpl.byte_len = req.byte_len;
         cpl.status = rc;
         w->ops_completed++;
-        if (rc != HFSSS_OK) w->ops_failed++;
+        if (rc != HFSSS_OK)
+            w->ops_failed++;
 
         while (!io_ring_push(&w->completion_ring, &cpl)) {
             sched_yield();
@@ -95,8 +96,7 @@ static void *ftl_worker_main(void *arg)
     return NULL;
 }
 
-int ftl_mt_init(struct ftl_mt_ctx *ctx, struct ftl_config *config,
-                struct hal_ctx *hal)
+int ftl_mt_init(struct ftl_mt_ctx *ctx, struct ftl_config *config, struct hal_ctx *hal)
 {
     int ret;
 
@@ -113,15 +113,10 @@ int ftl_mt_init(struct ftl_mt_ctx *ctx, struct ftl_config *config,
     }
 
     /* Initialize TAA with 256 shards */
-    u64 total_pages = (u64)config->channel_count *
-                      config->chips_per_channel *
-                      config->dies_per_chip *
-                      config->planes_per_die *
-                      config->blocks_per_plane *
-                      config->pages_per_block;
+    u64 total_pages = (u64)config->channel_count * config->chips_per_channel * config->dies_per_chip *
+                      config->planes_per_die * config->blocks_per_plane * config->pages_per_block;
 
-    ret = taa_init(&ctx->taa, config->total_lbas, total_pages,
-                   TAA_DEFAULT_SHARDS);
+    ret = taa_init(&ctx->taa, config->total_lbas, total_pages, TAA_DEFAULT_SHARDS);
     if (ret != HFSSS_OK) {
         ftl_cleanup(&ctx->ftl);
         return ret;
@@ -138,13 +133,13 @@ int ftl_mt_init(struct ftl_mt_ctx *ctx, struct ftl_config *config,
         w->ops_failed = 0;
         w->request_sync_initialized = false;
 
-        ret = io_ring_init(&w->request_ring, sizeof(struct io_request),
-                           IO_RING_DEFAULT_CAPACITY);
-        if (ret != HFSSS_OK) goto fail;
+        ret = io_ring_init(&w->request_ring, sizeof(struct io_request), IO_RING_DEFAULT_CAPACITY);
+        if (ret != HFSSS_OK)
+            goto fail;
 
-        ret = io_ring_init(&w->completion_ring, sizeof(struct io_completion),
-                           IO_RING_DEFAULT_CAPACITY);
-        if (ret != HFSSS_OK) goto fail;
+        ret = io_ring_init(&w->completion_ring, sizeof(struct io_completion), IO_RING_DEFAULT_CAPACITY);
+        if (ret != HFSSS_OK)
+            goto fail;
 
         ret = pthread_mutex_init(&w->request_lock, NULL);
         if (ret != 0) {
@@ -171,7 +166,8 @@ fail:
 
 void ftl_mt_cleanup(struct ftl_mt_ctx *ctx)
 {
-    if (!ctx) return;
+    if (!ctx)
+        return;
 
     ftl_mt_stop(ctx);
 
@@ -219,8 +215,7 @@ int ftl_mt_start(struct ftl_mt_ctx *ctx)
 
     for (int i = 0; i < FTL_NUM_WORKERS; i++) {
         ctx->workers[i].running = true;
-        int ret = pthread_create(&ctx->workers[i].thread, NULL,
-                                  ftl_worker_main, &ctx->workers[i]);
+        int ret = pthread_create(&ctx->workers[i].thread, NULL, ftl_worker_main, &ctx->workers[i]);
         if (ret != 0) {
             ctx->workers[i].running = false;
             rollback_started_workers(ctx, i);
@@ -242,7 +237,7 @@ int ftl_mt_start(struct ftl_mt_ctx *ctx)
         return HFSSS_ERR_INVAL;
     }
     ftl_mt_gc_mutex_ptr = &ctx->gc_mutex;
-    ftl_mt_gc_cond_ptr  = &ctx->gc_cond;
+    ftl_mt_gc_cond_ptr = &ctx->gc_cond;
 
     /* Start WL/Read Disturb background thread */
     ctx->wl_running = true;
@@ -256,7 +251,7 @@ int ftl_mt_start(struct ftl_mt_ctx *ctx)
         pthread_mutex_unlock(&ctx->gc_mutex);
         pthread_join(ctx->gc_thread, NULL);
         ftl_mt_gc_mutex_ptr = NULL;
-        ftl_mt_gc_cond_ptr  = NULL;
+        ftl_mt_gc_cond_ptr = NULL;
         pthread_cond_destroy(&ctx->gc_cond);
         pthread_mutex_destroy(&ctx->gc_mutex);
         rollback_started_workers(ctx, FTL_NUM_WORKERS);
@@ -268,7 +263,8 @@ int ftl_mt_start(struct ftl_mt_ctx *ctx)
 
 void ftl_mt_stop(struct ftl_mt_ctx *ctx)
 {
-    if (!ctx) return;
+    if (!ctx)
+        return;
 
     /* Stop GC thread */
     if (ctx->gc_running) {
@@ -276,7 +272,7 @@ void ftl_mt_stop(struct ftl_mt_ctx *ctx)
         pthread_cond_signal(&ctx->gc_cond);
         pthread_join(ctx->gc_thread, NULL);
         ftl_mt_gc_mutex_ptr = NULL;
-        ftl_mt_gc_cond_ptr  = NULL;
+        ftl_mt_gc_cond_ptr = NULL;
         pthread_mutex_destroy(&ctx->gc_mutex);
         pthread_cond_destroy(&ctx->gc_cond);
     }
@@ -307,7 +303,8 @@ void ftl_mt_stop(struct ftl_mt_ctx *ctx)
 
 bool ftl_mt_submit(struct ftl_mt_ctx *ctx, const struct io_request *req)
 {
-    if (!ctx || !req) return false;
+    if (!ctx || !req)
+        return false;
 
     /* Route by LBA to worker: worker_id = lba % NUM_WORKERS */
     u32 wid = (u32)(req->lba % FTL_NUM_WORKERS);
@@ -321,10 +318,10 @@ bool ftl_mt_submit(struct ftl_mt_ctx *ctx, const struct io_request *req)
     return true;
 }
 
-bool ftl_mt_poll_completion(struct ftl_mt_ctx *ctx,
-                            struct io_completion *out)
+bool ftl_mt_poll_completion(struct ftl_mt_ctx *ctx, struct io_completion *out)
 {
-    if (!ctx || !out) return false;
+    if (!ctx || !out)
+        return false;
 
     /* Round-robin poll all workers for completions */
     for (int i = 0; i < FTL_NUM_WORKERS; i++) {

--- a/src/ftl/ftl_worker.c
+++ b/src/ftl/ftl_worker.c
@@ -189,6 +189,28 @@ void ftl_mt_cleanup(struct ftl_mt_ctx *ctx)
     memset(ctx, 0, sizeof(*ctx));
 }
 
+/* Tear down already-started workers on partial-startup failure.
+ * Mirrors ftl_mt_stop(): push STOP, then signal request_cond under
+ * the lock before joining, so workers blocked in pthread_cond_wait()
+ * actually wake up and see the stop message. Without the signal the
+ * join will deadlock. */
+static void rollback_started_workers(struct ftl_mt_ctx *ctx, int count)
+{
+    for (int j = 0; j < count; j++) {
+        struct io_request stop;
+        memset(&stop, 0, sizeof(stop));
+        stop.opcode = IO_OP_STOP;
+        while (!io_ring_push(&ctx->workers[j].request_ring, &stop)) {
+            sched_yield();
+        }
+        pthread_mutex_lock(&ctx->workers[j].request_lock);
+        pthread_cond_signal(&ctx->workers[j].request_cond);
+        pthread_mutex_unlock(&ctx->workers[j].request_lock);
+        pthread_join(ctx->workers[j].thread, NULL);
+        ctx->workers[j].running = false;
+    }
+}
+
 int ftl_mt_start(struct ftl_mt_ctx *ctx)
 {
     if (!ctx || !ctx->initialized) {
@@ -200,14 +222,8 @@ int ftl_mt_start(struct ftl_mt_ctx *ctx)
         int ret = pthread_create(&ctx->workers[i].thread, NULL,
                                   ftl_worker_main, &ctx->workers[i]);
         if (ret != 0) {
-            /* Stop already-started workers */
-            for (int j = 0; j < i; j++) {
-                struct io_request stop;
-                memset(&stop, 0, sizeof(stop));
-                stop.opcode = IO_OP_STOP;
-                io_ring_push(&ctx->workers[j].request_ring, &stop);
-                pthread_join(ctx->workers[j].thread, NULL);
-            }
+            ctx->workers[i].running = false;
+            rollback_started_workers(ctx, i);
             return HFSSS_ERR_INVAL;
         }
     }
@@ -216,13 +232,36 @@ int ftl_mt_start(struct ftl_mt_ctx *ctx)
     pthread_mutex_init(&ctx->gc_mutex, NULL);
     pthread_cond_init(&ctx->gc_cond, NULL);
     ctx->gc_running = true;
-    pthread_create(&ctx->gc_thread, NULL, gc_thread_main, ctx);
+    int gc_rc = pthread_create(&ctx->gc_thread, NULL, gc_thread_main, ctx);
+    if (gc_rc != 0) {
+        /* GC thread failed to start: clean up cond/mutex, unwind workers */
+        ctx->gc_running = false;
+        pthread_cond_destroy(&ctx->gc_cond);
+        pthread_mutex_destroy(&ctx->gc_mutex);
+        rollback_started_workers(ctx, FTL_NUM_WORKERS);
+        return HFSSS_ERR_INVAL;
+    }
     ftl_mt_gc_mutex_ptr = &ctx->gc_mutex;
     ftl_mt_gc_cond_ptr  = &ctx->gc_cond;
 
     /* Start WL/Read Disturb background thread */
     ctx->wl_running = true;
-    pthread_create(&ctx->wl_thread, NULL, wl_thread_main, ctx);
+    int wl_rc = pthread_create(&ctx->wl_thread, NULL, wl_thread_main, ctx);
+    if (wl_rc != 0) {
+        /* WL failed: stop GC first (signal cond to unblock), then workers */
+        ctx->wl_running = false;
+        ctx->gc_running = false;
+        pthread_mutex_lock(&ctx->gc_mutex);
+        pthread_cond_signal(&ctx->gc_cond);
+        pthread_mutex_unlock(&ctx->gc_mutex);
+        pthread_join(ctx->gc_thread, NULL);
+        ftl_mt_gc_mutex_ptr = NULL;
+        ftl_mt_gc_cond_ptr  = NULL;
+        pthread_cond_destroy(&ctx->gc_cond);
+        pthread_mutex_destroy(&ctx->gc_mutex);
+        rollback_started_workers(ctx, FTL_NUM_WORKERS);
+        return HFSSS_ERR_INVAL;
+    }
 
     return HFSSS_OK;
 }

--- a/src/perf/perf_validation.c
+++ b/src/perf/perf_validation.c
@@ -14,6 +14,7 @@
 #include <inttypes.h>
 #include <math.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -311,19 +312,72 @@ int bench_run(const struct bench_cfg *cfg, struct bench_result *out) {
     /* Default op_count when neither duration nor op_count specified */
     uint64_t default_ops = 10000;
 
+    /* Distribute op_count across threads. If cfg->op_count is not
+     * evenly divisible by nt, the first (op_count % nt) workers each
+     * get one extra op so the total matches exactly. Previously the
+     * truncating division silently dropped up to (nt - 1) operations. */
+    uint64_t base_ops    = cfg->op_count ? (cfg->op_count / nt) : default_ops;
+    uint64_t extra_ops   = cfg->op_count ? (cfg->op_count % nt) : 0;
+
     for (uint32_t i = 0; i < nt; i++) {
         ws[i].cfg       = cfg;
-        ws[i].op_count  = cfg->op_count ? (cfg->op_count / nt) : default_ops;
+        ws[i].op_count  = base_ops + (i < extra_ops ? 1 : 0);
         ws[i].rng_state = 0xDEADBEEF12345678ULL ^ ((uint64_t)i * 0x9E3779B97F4A7C15ULL);
         if (cfg->duration_s > 0) ws[i].op_count = UINT64_MAX;
     }
 
-    for (uint32_t i = 0; i < nt; i++) {
-        pthread_create(&threads[i], NULL, bench_worker, &ws[i]);
+    /* Track which threads were actually created so failures can unwind
+     * the already-started ones instead of joining invalid thread ids. */
+    bool *started = (bool *)calloc(nt, sizeof(bool));
+    if (!started) {
+        free(threads);
+        free(ws);
+        return HFSSS_ERR_NOMEM;
     }
+
+    int create_rc = 0;
+    uint32_t created = 0;
     for (uint32_t i = 0; i < nt; i++) {
-        pthread_join(threads[i], NULL);
+        int prc = pthread_create(&threads[i], NULL, bench_worker, &ws[i]);
+        if (prc != 0) {
+            create_rc = prc;
+            break;
+        }
+        started[i] = true;
+        created++;
     }
+
+    if (create_rc != 0) {
+        /* Signal already-started workers to finish by zeroing their
+         * remaining op_count budget — the loop termination checks it
+         * on each iteration. Duration-based runs still exit when the
+         * deadline is reached; those cannot be shortened from outside
+         * without a shared stop flag, so we just join and surface the
+         * failure. */
+        for (uint32_t i = 0; i < created; i++) {
+            ws[i].op_count = 0;
+        }
+        for (uint32_t i = 0; i < nt; i++) {
+            if (started[i]) pthread_join(threads[i], NULL);
+        }
+        free(started);
+        free(threads);
+        free(ws);
+        return HFSSS_ERR_INVAL;
+    }
+
+    for (uint32_t i = 0; i < nt; i++) {
+        int jrc = pthread_join(threads[i], NULL);
+        if (jrc != 0) {
+            /* A failing join leaves the thread in an unknown state;
+             * bail out with an error instead of reporting success. */
+            free(started);
+            free(threads);
+            free(ws);
+            return HFSSS_ERR_IO;
+        }
+    }
+    free(started);
 
     /* Aggregate results */
     uint64_t total_read  = 0;

--- a/src/perf/perf_validation.c
+++ b/src/perf/perf_validation.c
@@ -136,7 +136,31 @@ struct worker_state {
     uint64_t                lat_hist[PERF_LAT_HIST_BUCKETS];
     uint64_t                elapsed_ns;
     uint64_t                rng_state;
+    /* Shared cancellation flag set by bench_run on the rollback path
+     * (e.g. when a later pthread_create() fails). Workers consult this
+     * inside the hot loop so they can be terminated promptly without
+     * waiting out the configured duration. The pointer is owned by
+     * bench_run; lifetime ends after pthread_join. */
+    volatile bool          *stop;
 };
+
+/* ------------------------------------------------------------------
+ * Test injection seam for pthread_create
+ *
+ * bench_run() launches workers via this indirection so unit tests can
+ * force pthread_create() failures and verify the rollback path is
+ * fast — independent of the host's actual thread limits. The setter is
+ * intentionally NOT in the public header; tests declare it extern.
+ * Pass NULL to restore the real implementation.
+ * ------------------------------------------------------------------ */
+typedef int (*perf_pthread_create_fn)(pthread_t *, const pthread_attr_t *,
+                                       void *(*)(void *), void *);
+
+static perf_pthread_create_fn g_pthread_create = pthread_create;
+
+void __perf_test_set_pthread_create(perf_pthread_create_fn fn) {
+    g_pthread_create = fn ? fn : pthread_create;
+}
 
 /*
  * Compute simulated per-operation latency in µs for a single IO.
@@ -243,6 +267,12 @@ static void *bench_worker(void *arg) {
 
     uint64_t ops = 0;
     while (ops < max_ops) {
+        /* Cooperative cancellation: bench_run() may flip this on the
+         * rollback path when a sibling pthread_create() fails. The
+         * old code zeroed ws->op_count here, but max_ops was already
+         * snapshotted into a local at startup, so the worker never
+         * noticed — and duration-based runs ran out the full clock. */
+        if (ws->stop && __atomic_load_n(ws->stop, __ATOMIC_ACQUIRE)) break;
         if (end_time && now_ns() >= end_time) break;
 
         bool is_read;
@@ -319,10 +349,16 @@ int bench_run(const struct bench_cfg *cfg, struct bench_result *out) {
     uint64_t base_ops    = cfg->op_count ? (cfg->op_count / nt) : default_ops;
     uint64_t extra_ops   = cfg->op_count ? (cfg->op_count % nt) : 0;
 
+    /* Shared cancellation flag for all workers in this run. Lifetime is
+     * the bench_run() stack frame, which extends past every pthread_join
+     * below, so the workers' pointers always reference live storage. */
+    volatile bool stop_flag = false;
+
     for (uint32_t i = 0; i < nt; i++) {
         ws[i].cfg       = cfg;
         ws[i].op_count  = base_ops + (i < extra_ops ? 1 : 0);
         ws[i].rng_state = 0xDEADBEEF12345678ULL ^ ((uint64_t)i * 0x9E3779B97F4A7C15ULL);
+        ws[i].stop      = &stop_flag;
         if (cfg->duration_s > 0) ws[i].op_count = UINT64_MAX;
     }
 
@@ -336,27 +372,21 @@ int bench_run(const struct bench_cfg *cfg, struct bench_result *out) {
     }
 
     int create_rc = 0;
-    uint32_t created = 0;
     for (uint32_t i = 0; i < nt; i++) {
-        int prc = pthread_create(&threads[i], NULL, bench_worker, &ws[i]);
+        int prc = g_pthread_create(&threads[i], NULL, bench_worker, &ws[i]);
         if (prc != 0) {
             create_rc = prc;
             break;
         }
         started[i] = true;
-        created++;
     }
 
     if (create_rc != 0) {
-        /* Signal already-started workers to finish by zeroing their
-         * remaining op_count budget — the loop termination checks it
-         * on each iteration. Duration-based runs still exit when the
-         * deadline is reached; those cannot be shortened from outside
-         * without a shared stop flag, so we just join and surface the
-         * failure. */
-        for (uint32_t i = 0; i < created; i++) {
-            ws[i].op_count = 0;
-        }
+        /* Raise the cancellation flag so already-started workers exit
+         * their hot loop on the next iteration instead of waiting out
+         * cfg->duration_s (or running through their op_count budget).
+         * Release pairs with the worker's acquire load. */
+        __atomic_store_n(&stop_flag, true, __ATOMIC_RELEASE);
         for (uint32_t i = 0; i < nt; i++) {
             if (started[i]) pthread_join(threads[i], NULL);
         }

--- a/src/perf/perf_validation.c
+++ b/src/perf/perf_validation.c
@@ -23,14 +23,14 @@
 /* ------------------------------------------------------------------
  * NAND timing reference constants (ONFI spec, µs)
  * ------------------------------------------------------------------ */
-#define NAND_TR_REF_US     25U      /* tR  – page read */
-#define NAND_TPROG_REF_US  200U     /* tPROG – page program */
-#define NAND_TERS_REF_US   1500U    /* tERS  – block erase */
+#define NAND_TR_REF_US 25U     /* tR  – page read */
+#define NAND_TPROG_REF_US 200U /* tPROG – page program */
+#define NAND_TERS_REF_US 1500U /* tERS  – block erase */
 
 /* Simulated timing model for NAND operations (µs, matches references) */
-#define NAND_TR_SIM_US     25U
-#define NAND_TPROG_SIM_US  200U
-#define NAND_TERS_SIM_US   1500U
+#define NAND_TR_SIM_US 25U
+#define NAND_TPROG_SIM_US 200U
+#define NAND_TERS_SIM_US 1500U
 
 /* ------------------------------------------------------------------
  * Simulated per-operation latency targets (µs)
@@ -38,21 +38,23 @@
  * ------------------------------------------------------------------ */
 
 /* Random 4 KB read: at QD=1 ~ 75 µs, at QD=32 pipeline hides latency */
-#define SIM_RAND_READ_LAT_QD1_US   75ULL
+#define SIM_RAND_READ_LAT_QD1_US 75ULL
 /* Random 4 KB write at QD=1 */
-#define SIM_RAND_WRITE_LAT_QD1_US  90ULL
+#define SIM_RAND_WRITE_LAT_QD1_US 90ULL
 /* Sequential read base latency (µs per 128 KB op) */
-#define SIM_SEQ_READ_LAT_US        20ULL
+#define SIM_SEQ_READ_LAT_US 20ULL
 /* Sequential write base latency */
-#define SIM_SEQ_WRITE_LAT_US       37ULL
+#define SIM_SEQ_WRITE_LAT_US 37ULL
 
 /* ------------------------------------------------------------------
  * Latency histogram helpers
  * 64 exponential buckets: bucket i covers [2^i µs, 2^(i+1) µs)
  * ------------------------------------------------------------------ */
 
-static int lat_bucket(uint64_t us) {
-    if (us == 0) return 0;
+static int lat_bucket(uint64_t us)
+{
+    if (us == 0)
+        return 0;
     int b = 0;
     uint64_t v = us;
     while (v > 1 && b < PERF_LAT_HIST_BUCKETS - 1) {
@@ -62,8 +64,10 @@ static int lat_bucket(uint64_t us) {
     return b;
 }
 
-static uint64_t hist_percentile(const uint64_t *hist, uint64_t total, double pct) {
-    if (total == 0) return 0;
+static uint64_t hist_percentile(const uint64_t *hist, uint64_t total, double pct)
+{
+    if (total == 0)
+        return 0;
     uint64_t target = (uint64_t)(total * pct / 100.0);
     uint64_t cum = 0;
     for (int i = 0; i < PERF_LAT_HIST_BUCKETS; i++) {
@@ -80,15 +84,16 @@ static uint64_t hist_percentile(const uint64_t *hist, uint64_t total, double pct
  * Zipfian random number generator
  * ------------------------------------------------------------------ */
 typedef struct {
-    double   theta;
+    double theta;
     uint64_t n;
-    double   zeta_n;
-    double   zeta_2;
-    double   alpha;
-    double   eta;
+    double zeta_n;
+    double zeta_2;
+    double alpha;
+    double eta;
 } zipf_gen_t;
 
-static double zeta(uint64_t n, double theta) {
+static double zeta(uint64_t n, double theta)
+{
     double sum = 0.0;
     for (uint64_t i = 1; i <= n && i <= 100000; i++) {
         sum += pow(1.0 / (double)i, theta);
@@ -96,30 +101,34 @@ static double zeta(uint64_t n, double theta) {
     return sum;
 }
 
-static void zipf_init(zipf_gen_t *z, uint64_t n, double theta) {
+static void zipf_init(zipf_gen_t *z, uint64_t n, double theta)
+{
     z->theta = theta;
     z->n = n;
     z->zeta_n = zeta(n, theta);
     z->zeta_2 = zeta(2, theta);
-    z->alpha  = 1.0 / (1.0 - theta);
-    z->eta    = (1.0 - pow(2.0 / (double)n, 1.0 - theta)) /
-                (1.0 - z->zeta_2 / z->zeta_n);
+    z->alpha = 1.0 / (1.0 - theta);
+    z->eta = (1.0 - pow(2.0 / (double)n, 1.0 - theta)) / (1.0 - z->zeta_2 / z->zeta_n);
 }
 
-static uint64_t zipf_next(zipf_gen_t *z, uint64_t *state) {
+static uint64_t zipf_next(zipf_gen_t *z, uint64_t *state)
+{
     /* Simple LCG for fast random numbers inside the generator */
     *state = *state * 6364136223846793005ULL + 1442695040888963407ULL;
     double u = (double)(*state >> 11) / (double)(1ULL << 53);
     double uz = u * z->zeta_n;
-    if (uz < 1.0) return 0;
-    if (uz < 1.0 + pow(0.5, z->theta)) return 1;
+    if (uz < 1.0)
+        return 0;
+    if (uz < 1.0 + pow(0.5, z->theta))
+        return 1;
     return (uint64_t)((double)z->n * pow(z->eta * u - z->eta + 1.0, z->alpha));
 }
 
 /* ------------------------------------------------------------------
  * Monotonic clock helper
  * ------------------------------------------------------------------ */
-static uint64_t now_ns(void) {
+static uint64_t now_ns(void)
+{
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
@@ -130,18 +139,18 @@ static uint64_t now_ns(void) {
  * ------------------------------------------------------------------ */
 struct worker_state {
     const struct bench_cfg *cfg;
-    uint64_t                op_count;
-    uint64_t                read_ops;
-    uint64_t                write_ops;
-    uint64_t                lat_hist[PERF_LAT_HIST_BUCKETS];
-    uint64_t                elapsed_ns;
-    uint64_t                rng_state;
+    uint64_t op_count;
+    uint64_t read_ops;
+    uint64_t write_ops;
+    uint64_t lat_hist[PERF_LAT_HIST_BUCKETS];
+    uint64_t elapsed_ns;
+    uint64_t rng_state;
     /* Shared cancellation flag set by bench_run on the rollback path
      * (e.g. when a later pthread_create() fails). Workers consult this
      * inside the hot loop so they can be terminated promptly without
      * waiting out the configured duration. The pointer is owned by
      * bench_run; lifetime ends after pthread_join. */
-    volatile bool          *stop;
+    volatile bool *stop;
 };
 
 /* ------------------------------------------------------------------
@@ -153,12 +162,12 @@ struct worker_state {
  * intentionally NOT in the public header; tests declare it extern.
  * Pass NULL to restore the real implementation.
  * ------------------------------------------------------------------ */
-typedef int (*perf_pthread_create_fn)(pthread_t *, const pthread_attr_t *,
-                                       void *(*)(void *), void *);
+typedef int (*perf_pthread_create_fn)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
 
 static perf_pthread_create_fn g_pthread_create = pthread_create;
 
-void __perf_test_set_pthread_create(perf_pthread_create_fn fn) {
+void __perf_test_set_pthread_create(perf_pthread_create_fn fn)
+{
     g_pthread_create = fn ? fn : pthread_create;
 }
 
@@ -167,15 +176,14 @@ void __perf_test_set_pthread_create(perf_pthread_create_fn fn) {
  * Models pipelining at higher queue depths: effective latency per op
  * is reduced by approximately sqrt(QD) for random workloads.
  */
-static uint64_t sim_op_latency_us(const struct bench_cfg *cfg, bool is_read) {
+static uint64_t sim_op_latency_us(const struct bench_cfg *cfg, bool is_read)
+{
     uint64_t base;
     uint32_t qd = cfg->queue_depth ? cfg->queue_depth : 1;
 
-    if (cfg->workload == BENCH_SEQ_READ ||
-        (cfg->workload == BENCH_MIXED && is_read)) {
+    if (cfg->workload == BENCH_SEQ_READ || (cfg->workload == BENCH_MIXED && is_read)) {
         base = SIM_SEQ_READ_LAT_US;
-    } else if (cfg->workload == BENCH_SEQ_WRITE ||
-               (cfg->workload == BENCH_MIXED && !is_read)) {
+    } else if (cfg->workload == BENCH_SEQ_WRITE || (cfg->workload == BENCH_MIXED && !is_read)) {
         base = SIM_SEQ_WRITE_LAT_US;
     } else if (is_read) {
         /* Random read: QD=1 baseline, pipeline reduces effective latency */
@@ -188,7 +196,8 @@ static uint64_t sim_op_latency_us(const struct bench_cfg *cfg, bool is_read) {
     if (qd > 1) {
         double factor = 1.0 / sqrt((double)qd);
         base = (uint64_t)(base * factor);
-        if (base == 0) base = 1;
+        if (base == 0)
+            base = 1;
     }
     return base;
 }
@@ -197,21 +206,20 @@ static uint64_t sim_op_latency_us(const struct bench_cfg *cfg, bool is_read) {
  * Simulate a single IO operation: perform lightweight memory work to
  * model the data path and return the simulated latency in µs.
  */
-static uint64_t sim_single_op(const struct bench_cfg *cfg, bool is_read,
-                               uint64_t *rng_state, volatile uint8_t *scratch,
-                               size_t scratch_sz) {
+static uint64_t sim_single_op(const struct bench_cfg *cfg, bool is_read, uint64_t *rng_state, volatile uint8_t *scratch,
+                              size_t scratch_sz)
+{
     /* LCG for address generation */
     *rng_state = *rng_state * 6364136223846793005ULL + 1442695040888963407ULL;
 
     uint64_t blk_sz = cfg->block_size ? cfg->block_size : 4096;
-    uint64_t cap    = cfg->capacity_bytes ? cfg->capacity_bytes
-                                          : (256ULL * 1024 * 1024);
+    uint64_t cap = cfg->capacity_bytes ? cfg->capacity_bytes : (256ULL * 1024 * 1024);
     uint64_t max_blk = cap / blk_sz;
-    uint64_t addr    = (*rng_state >> 11) % (max_blk ? max_blk : 1);
+    uint64_t addr = (*rng_state >> 11) % (max_blk ? max_blk : 1);
 
     /* Memory touch to simulate data path */
     size_t offset = (size_t)((addr * blk_sz) % scratch_sz);
-    size_t touch  = (size_t)(blk_sz < 64 ? blk_sz : 64);
+    size_t touch = (size_t)(blk_sz < 64 ? blk_sz : 64);
     if (is_read) {
         volatile uint8_t acc = 0;
         for (size_t i = 0; i < touch; i++) {
@@ -230,7 +238,8 @@ static uint64_t sim_single_op(const struct bench_cfg *cfg, bool is_read,
 /* ------------------------------------------------------------------
  * Single-thread benchmark worker
  * ------------------------------------------------------------------ */
-static void *bench_worker(void *arg) {
+static void *bench_worker(void *arg)
+{
     struct worker_state *ws = (struct worker_state *)arg;
     const struct bench_cfg *cfg = ws->cfg;
 
@@ -250,17 +259,18 @@ static void *bench_worker(void *arg) {
     }
 
     uint64_t max_ops = ws->op_count;
-    if (cfg->duration_s > 0) max_ops = UINT64_MAX;
+    if (cfg->duration_s > 0)
+        max_ops = UINT64_MAX;
 
     /* Zipfian generator setup */
     zipf_gen_t zgen;
     bool use_zipf = (cfg->workload == BENCH_ZIPFIAN);
     if (use_zipf) {
-        uint64_t cap = cfg->capacity_bytes ? cfg->capacity_bytes
-                                           : (256ULL * 1024 * 1024);
+        uint64_t cap = cfg->capacity_bytes ? cfg->capacity_bytes : (256ULL * 1024 * 1024);
         uint64_t blk_sz = cfg->block_size ? cfg->block_size : 4096;
         uint64_t n = cap / blk_sz;
-        if (n < 2) n = 2;
+        if (n < 2)
+            n = 2;
         double theta = cfg->zipf_theta > 0.0 ? cfg->zipf_theta : 0.9;
         zipf_init(&zgen, n, theta);
     }
@@ -272,8 +282,10 @@ static void *bench_worker(void *arg) {
          * old code zeroed ws->op_count here, but max_ops was already
          * snapshotted into a local at startup, so the worker never
          * noticed — and duration-based runs ran out the full clock. */
-        if (ws->stop && __atomic_load_n(ws->stop, __ATOMIC_ACQUIRE)) break;
-        if (end_time && now_ns() >= end_time) break;
+        if (ws->stop && __atomic_load_n(ws->stop, __ATOMIC_ACQUIRE))
+            break;
+        if (end_time && now_ns() >= end_time)
+            break;
 
         bool is_read;
         switch (cfg->workload) {
@@ -288,8 +300,7 @@ static void *bench_worker(void *arg) {
         case BENCH_MIXED:
         case BENCH_ZIPFIAN: {
             double rw = cfg->rw_ratio > 0.0 ? cfg->rw_ratio : 0.7;
-            ws->rng_state = ws->rng_state * 6364136223846793005ULL +
-                            1442695040888963407ULL;
+            ws->rng_state = ws->rng_state * 6364136223846793005ULL + 1442695040888963407ULL;
             double r = (double)(ws->rng_state >> 11) / (double)(1ULL << 53);
             is_read = (r < rw);
             break;
@@ -304,19 +315,19 @@ static void *bench_worker(void *arg) {
             (void)zipf_next(&zgen, &ws->rng_state);
         }
 
-        uint64_t lat_us = sim_single_op(cfg, is_read,
-                                        &ws->rng_state,
-                                        scratch, scratch_sz);
+        uint64_t lat_us = sim_single_op(cfg, is_read, &ws->rng_state, scratch, scratch_sz);
 
         ws->lat_hist[lat_bucket(lat_us)]++;
-        if (is_read) ws->read_ops++;
-        else         ws->write_ops++;
+        if (is_read)
+            ws->read_ops++;
+        else
+            ws->write_ops++;
         ops++;
     }
 
     uint64_t elapsed = now_ns() - start;
     ws->elapsed_ns = elapsed ? elapsed : 1;
-    ws->op_count   = ops;
+    ws->op_count = ops;
 
     free((void *)scratch);
     return NULL;
@@ -325,19 +336,26 @@ static void *bench_worker(void *arg) {
 /* ------------------------------------------------------------------
  * bench_run – public API
  * ------------------------------------------------------------------ */
-int bench_run(const struct bench_cfg *cfg, struct bench_result *out) {
-    if (!cfg || !out) return HFSSS_ERR_INVAL;
+int bench_run(const struct bench_cfg *cfg, struct bench_result *out)
+{
+    if (!cfg || !out)
+        return HFSSS_ERR_INVAL;
 
     memset(out, 0, sizeof(*out));
 
     uint32_t nt = cfg->num_threads ? cfg->num_threads : 1;
-    if (nt > 64) nt = 64;
+    if (nt > 64)
+        nt = 64;
 
     struct worker_state *ws = (struct worker_state *)calloc(nt, sizeof(*ws));
-    if (!ws) return HFSSS_ERR_NOMEM;
+    if (!ws)
+        return HFSSS_ERR_NOMEM;
 
     pthread_t *threads = (pthread_t *)calloc(nt, sizeof(pthread_t));
-    if (!threads) { free(ws); return HFSSS_ERR_NOMEM; }
+    if (!threads) {
+        free(ws);
+        return HFSSS_ERR_NOMEM;
+    }
 
     /* Default op_count when neither duration nor op_count specified */
     uint64_t default_ops = 10000;
@@ -346,8 +364,8 @@ int bench_run(const struct bench_cfg *cfg, struct bench_result *out) {
      * evenly divisible by nt, the first (op_count % nt) workers each
      * get one extra op so the total matches exactly. Previously the
      * truncating division silently dropped up to (nt - 1) operations. */
-    uint64_t base_ops    = cfg->op_count ? (cfg->op_count / nt) : default_ops;
-    uint64_t extra_ops   = cfg->op_count ? (cfg->op_count % nt) : 0;
+    uint64_t base_ops = cfg->op_count ? (cfg->op_count / nt) : default_ops;
+    uint64_t extra_ops = cfg->op_count ? (cfg->op_count % nt) : 0;
 
     /* Shared cancellation flag for all workers in this run. Lifetime is
      * the bench_run() stack frame, which extends past every pthread_join
@@ -355,11 +373,12 @@ int bench_run(const struct bench_cfg *cfg, struct bench_result *out) {
     volatile bool stop_flag = false;
 
     for (uint32_t i = 0; i < nt; i++) {
-        ws[i].cfg       = cfg;
-        ws[i].op_count  = base_ops + (i < extra_ops ? 1 : 0);
+        ws[i].cfg = cfg;
+        ws[i].op_count = base_ops + (i < extra_ops ? 1 : 0);
         ws[i].rng_state = 0xDEADBEEF12345678ULL ^ ((uint64_t)i * 0x9E3779B97F4A7C15ULL);
-        ws[i].stop      = &stop_flag;
-        if (cfg->duration_s > 0) ws[i].op_count = UINT64_MAX;
+        ws[i].stop = &stop_flag;
+        if (cfg->duration_s > 0)
+            ws[i].op_count = UINT64_MAX;
     }
 
     /* Track which threads were actually created so failures can unwind
@@ -388,7 +407,8 @@ int bench_run(const struct bench_cfg *cfg, struct bench_result *out) {
          * Release pairs with the worker's acquire load. */
         __atomic_store_n(&stop_flag, true, __ATOMIC_RELEASE);
         for (uint32_t i = 0; i < nt; i++) {
-            if (started[i]) pthread_join(threads[i], NULL);
+            if (started[i])
+                pthread_join(threads[i], NULL);
         }
         free(started);
         free(threads);
@@ -410,47 +430,49 @@ int bench_run(const struct bench_cfg *cfg, struct bench_result *out) {
     free(started);
 
     /* Aggregate results */
-    uint64_t total_read  = 0;
+    uint64_t total_read = 0;
     uint64_t total_write = 0;
-    uint64_t total_ops   = 0;
+    uint64_t total_ops = 0;
     uint64_t max_elapsed = 0;
     uint64_t combined_hist[PERF_LAT_HIST_BUCKETS] = {0};
 
     for (uint32_t i = 0; i < nt; i++) {
-        total_read  += ws[i].read_ops;
+        total_read += ws[i].read_ops;
         total_write += ws[i].write_ops;
-        total_ops   += ws[i].op_count;
-        if (ws[i].elapsed_ns > max_elapsed) max_elapsed = ws[i].elapsed_ns;
+        total_ops += ws[i].op_count;
+        if (ws[i].elapsed_ns > max_elapsed)
+            max_elapsed = ws[i].elapsed_ns;
         for (int b = 0; b < PERF_LAT_HIST_BUCKETS; b++) {
             combined_hist[b] += ws[i].lat_hist[b];
         }
     }
 
     double elapsed_s = (double)max_elapsed / 1e9;
-    if (elapsed_s <= 0.0) elapsed_s = 1e-9;
+    if (elapsed_s <= 0.0)
+        elapsed_s = 1e-9;
 
     uint64_t block_sz = cfg->block_size ? cfg->block_size : 4096;
 
-    out->total_ops    = total_ops;
-    out->elapsed_s    = elapsed_s;
-    out->read_iops    = (double)total_read  / elapsed_s;
-    out->write_iops   = (double)total_write / elapsed_s;
-    out->read_bw_mbps = out->read_iops  * (double)block_sz / (1024.0 * 1024.0);
-    out->write_bw_mbps= out->write_iops * (double)block_sz / (1024.0 * 1024.0);
-    out->waf          = 1.0; /* simplified WAF for simulator */
+    out->total_ops = total_ops;
+    out->elapsed_s = elapsed_s;
+    out->read_iops = (double)total_read / elapsed_s;
+    out->write_iops = (double)total_write / elapsed_s;
+    out->read_bw_mbps = out->read_iops * (double)block_sz / (1024.0 * 1024.0);
+    out->write_bw_mbps = out->write_iops * (double)block_sz / (1024.0 * 1024.0);
+    out->waf = 1.0; /* simplified WAF for simulator */
 
     memcpy(out->lat_hist, combined_hist, sizeof(combined_hist));
 
     uint64_t total_lat_ops = total_read + total_write;
-    out->lat_p50_us  = hist_percentile(combined_hist, total_lat_ops, 50.0);
-    out->lat_p99_us  = hist_percentile(combined_hist, total_lat_ops, 99.0);
+    out->lat_p50_us = hist_percentile(combined_hist, total_lat_ops, 50.0);
+    out->lat_p99_us = hist_percentile(combined_hist, total_lat_ops, 99.0);
     out->lat_p999_us = hist_percentile(combined_hist, total_lat_ops, 99.9);
 
-    out->cpu_util_pct       = 0.0;
+    out->cpu_util_pct = 0.0;
     out->parallel_efficiency = 0.0;
     if (nt > 1) {
         /* Measure single-thread baseline for efficiency */
-        out->parallel_efficiency = 1.0 / (double)nt;  /* conservative lower bound */
+        out->parallel_efficiency = 1.0 / (double)nt; /* conservative lower bound */
     }
 
     free(ws);
@@ -461,18 +483,18 @@ int bench_run(const struct bench_cfg *cfg, struct bench_result *out) {
 /* ------------------------------------------------------------------
  * bench_result_print
  * ------------------------------------------------------------------ */
-void bench_result_print(const struct bench_result *r, const struct bench_cfg *cfg) {
-    if (!r) return;
+void bench_result_print(const struct bench_result *r, const struct bench_cfg *cfg)
+{
+    if (!r)
+        return;
 
-    static const char *wl_names[] = {
-        "SEQ_READ", "SEQ_WRITE", "RAND_READ", "RAND_WRITE", "MIXED", "ZIPFIAN"
-    };
+    static const char *wl_names[] = {"SEQ_READ", "SEQ_WRITE", "RAND_READ", "RAND_WRITE", "MIXED", "ZIPFIAN"};
     const char *wl = "UNKNOWN";
-    if (cfg && (int)cfg->workload < (int)(sizeof(wl_names)/sizeof(wl_names[0])))
+    if (cfg && (int)cfg->workload < (int)(sizeof(wl_names) / sizeof(wl_names[0])))
         wl = wl_names[cfg->workload];
 
     uint32_t qd = cfg ? cfg->queue_depth : 0;
-    uint32_t bs = cfg ? cfg->block_size  : 0;
+    uint32_t bs = cfg ? cfg->block_size : 0;
 
     printf("=== Benchmark Result ===\n");
     printf("  Workload    : %s\n", wl);
@@ -493,9 +515,10 @@ void bench_result_print(const struct bench_result *r, const struct bench_cfg *cf
  * NAND timing accuracy (REQ-121)
  * Measures simulated tR/tPROG/tERS against ONFI reference values.
  * ------------------------------------------------------------------ */
-double nand_timing_measure_error(void) {
-    const uint64_t refs[3]  = { NAND_TR_REF_US,  NAND_TPROG_REF_US,  NAND_TERS_REF_US  };
-    const uint64_t sims[3]  = { NAND_TR_SIM_US,  NAND_TPROG_SIM_US,  NAND_TERS_SIM_US  };
+double nand_timing_measure_error(void)
+{
+    const uint64_t refs[3] = {NAND_TR_REF_US, NAND_TPROG_REF_US, NAND_TERS_REF_US};
+    const uint64_t sims[3] = {NAND_TR_SIM_US, NAND_TPROG_SIM_US, NAND_TERS_SIM_US};
 
     double max_err = 0.0;
     int n_samples = 1000;
@@ -512,9 +535,11 @@ double nand_timing_measure_error(void) {
             double jitter_pct = ((double)(int64_t)(rng >> 33) / (double)(1ULL << 30)) * 0.01;
             double measured = (double)sims[op] * (1.0 + jitter_pct);
             double err = fabs(measured - (double)refs[op]) / (double)refs[op] * 100.0;
-            if (err > sum_err) sum_err = err;
+            if (err > sum_err)
+                sum_err = err;
         }
-        if (sum_err > max_err) max_err = sum_err;
+        if (sum_err > max_err)
+            max_err = sum_err;
     }
     return max_err;
 }
@@ -528,11 +553,14 @@ double nand_timing_measure_error(void) {
  * are inherently sequential.  Actual I/O-path scalability is
  * validated externally via QEMU + NBD + fio (numjobs=32, iodepth=128).
  * ------------------------------------------------------------------ */
-#define SIM_SERIAL_FRACTION  0.02  /* 2% serial — 16ch pipelined controller */
+#define SIM_SERIAL_FRACTION 0.02 /* 2% serial — 16ch pipelined controller */
 
-double perf_scalability_efficiency(uint32_t num_threads) {
-    if (num_threads == 0) return 0.0;
-    if (num_threads == 1) return 1.0;
+double perf_scalability_efficiency(uint32_t num_threads)
+{
+    if (num_threads == 0)
+        return 0.0;
+    if (num_threads == 1)
+        return 1.0;
 
     /*
      * Amdahl's law: speedup(N) = 1 / (s + (1-s)/N)
@@ -547,124 +575,109 @@ double perf_scalability_efficiency(uint32_t num_threads) {
 /* ------------------------------------------------------------------
  * Requirement validation helpers
  * ------------------------------------------------------------------ */
-static void add_result(struct perf_validation_report *rpt,
-                       const char *req_id, const char *desc,
-                       double measured, double target, const char *unit,
-                       bool pass_if_ge) {
-    if (rpt->count >= 32) return;
+static void add_result(struct perf_validation_report *rpt, const char *req_id, const char *desc, double measured,
+                       double target, const char *unit, bool pass_if_ge)
+{
+    if (rpt->count >= 32)
+        return;
     struct perf_req_result *r = &rpt->results[rpt->count++];
-    r->req_id      = req_id;
+    r->req_id = req_id;
     r->description = desc;
-    r->measured    = measured;
-    r->target      = target;
-    r->unit        = unit;
-    r->passed      = pass_if_ge ? (measured >= target) : (measured <= target);
-    if (r->passed) rpt->passed++;
-    else           rpt->failed++;
+    r->measured = measured;
+    r->target = target;
+    r->unit = unit;
+    r->passed = pass_if_ge ? (measured >= target) : (measured <= target);
+    if (r->passed)
+        rpt->passed++;
+    else
+        rpt->failed++;
 }
 
 /*
  * Run a benchmark and return IOPS (read+write combined) for the given config.
  * Returns a bench_result by output parameter.
  */
-static double run_iops(enum bench_workload wl, uint32_t bs, uint32_t qd,
-                       double rw_ratio, struct bench_result *out) {
+static double run_iops(enum bench_workload wl, uint32_t bs, uint32_t qd, double rw_ratio, struct bench_result *out)
+{
     struct bench_cfg cfg = {
-        .workload       = wl,
-        .block_size     = bs,
-        .queue_depth    = qd,
-        .duration_s     = 0,
-        .op_count       = 20000,
-        .num_threads    = 1,
-        .rw_ratio       = rw_ratio,
-        .zipf_theta     = 0.9,
+        .workload = wl,
+        .block_size = bs,
+        .queue_depth = qd,
+        .duration_s = 0,
+        .op_count = 20000,
+        .num_threads = 1,
+        .rw_ratio = rw_ratio,
+        .zipf_theta = 0.9,
         .capacity_bytes = 256ULL * 1024 * 1024,
     };
     memset(out, 0, sizeof(*out));
-    if (bench_run(&cfg, out) != HFSSS_OK) return 0.0;
+    if (bench_run(&cfg, out) != HFSSS_OK)
+        return 0.0;
     return out->read_iops + out->write_iops;
 }
 
 /* ------------------------------------------------------------------
  * perf_validation_run_all – public API
  * ------------------------------------------------------------------ */
-int perf_validation_run_all(struct perf_validation_report *report) {
-    if (!report) return HFSSS_ERR_INVAL;
+int perf_validation_run_all(struct perf_validation_report *report)
+{
+    if (!report)
+        return HFSSS_ERR_INVAL;
     memset(report, 0, sizeof(*report));
 
     struct bench_result res;
 
     /* REQ-116: Random read IOPS at QD=32, 4KB: 600K–1M */
     run_iops(BENCH_RAND_READ, 4096, 32, 0.0, &res);
-    add_result(report, "REQ-116",
-               "Random read IOPS (4KB, QD=32) >= 600K",
-               res.read_iops, 600000.0, "IOPS", true);
+    add_result(report, "REQ-116", "Random read IOPS (4KB, QD=32) >= 600K", res.read_iops, 600000.0, "IOPS", true);
 
     /* REQ-117: Random write IOPS at QD=32, 4KB: 150K–300K */
     run_iops(BENCH_RAND_WRITE, 4096, 32, 0.0, &res);
-    add_result(report, "REQ-117",
-               "Random write IOPS (4KB, QD=32) >= 150K",
-               res.write_iops, 150000.0, "IOPS", true);
+    add_result(report, "REQ-117", "Random write IOPS (4KB, QD=32) >= 150K", res.write_iops, 150000.0, "IOPS", true);
 
     /* REQ-118: Mixed R/W IOPS >= 250K at QD=32, 70/30 */
     double mixed_iops = run_iops(BENCH_MIXED, 4096, 32, 0.7, &res);
-    add_result(report, "REQ-118",
-               "Mixed R/W IOPS (70/30, QD=32) >= 250K",
-               mixed_iops, 250000.0, "IOPS", true);
+    add_result(report, "REQ-118", "Mixed R/W IOPS (70/30, QD=32) >= 250K", mixed_iops, 250000.0, "IOPS", true);
 
     /* REQ-119: Sequential read bandwidth at 128KB >= 6500 MB/s */
     run_iops(BENCH_SEQ_READ, 131072, 32, 0.0, &res);
-    add_result(report, "REQ-119-RD",
-               "Sequential read BW (128KB) >= 6500 MB/s",
-               res.read_bw_mbps, 6500.0, "MB/s", true);
+    add_result(report, "REQ-119-RD", "Sequential read BW (128KB) >= 6500 MB/s", res.read_bw_mbps, 6500.0, "MB/s", true);
 
     /* REQ-119: Sequential write bandwidth at 128KB >= 3500 MB/s */
     run_iops(BENCH_SEQ_WRITE, 131072, 32, 0.0, &res);
-    add_result(report, "REQ-119-WR",
-               "Sequential write BW (128KB) >= 3500 MB/s",
-               res.write_bw_mbps, 3500.0, "MB/s", true);
+    add_result(report, "REQ-119-WR", "Sequential write BW (128KB) >= 3500 MB/s", res.write_bw_mbps, 3500.0, "MB/s",
+               true);
 
     /* REQ-120: Latency at QD=1: P50 ≤ 100µs */
     {
         struct bench_cfg cfg = {
-            .workload       = BENCH_RAND_READ,
-            .block_size     = 4096,
-            .queue_depth    = 1,
-            .duration_s     = 0,
-            .op_count       = 10000,
-            .num_threads    = 1,
+            .workload = BENCH_RAND_READ,
+            .block_size = 4096,
+            .queue_depth = 1,
+            .duration_s = 0,
+            .op_count = 10000,
+            .num_threads = 1,
             .capacity_bytes = 256ULL * 1024 * 1024,
         };
         memset(&res, 0, sizeof(res));
         bench_run(&cfg, &res);
-        add_result(report, "REQ-120-P50",
-                   "P50 latency (QD=1) <= 100µs",
-                   (double)res.lat_p50_us, 100.0, "µs", false);
-        add_result(report, "REQ-120-P99",
-                   "P99 latency (QD=1) <= 150µs",
-                   (double)res.lat_p99_us, 150.0, "µs", false);
-        add_result(report, "REQ-120-P999",
-                   "P99.9 latency (QD=1) <= 500µs",
-                   (double)res.lat_p999_us, 500.0, "µs", false);
+        add_result(report, "REQ-120-P50", "P50 latency (QD=1) <= 100µs", (double)res.lat_p50_us, 100.0, "µs", false);
+        add_result(report, "REQ-120-P99", "P99 latency (QD=1) <= 150µs", (double)res.lat_p99_us, 150.0, "µs", false);
+        add_result(report, "REQ-120-P999", "P99.9 latency (QD=1) <= 500µs", (double)res.lat_p999_us, 500.0, "µs",
+                   false);
     }
 
     /* REQ-121: NAND timing accuracy < 5% */
     double timing_err = nand_timing_measure_error();
     report->nand_timing_error_pct = timing_err;
-    add_result(report, "REQ-121",
-               "NAND timing error < 5%",
-               timing_err, 5.0, "%", false);
+    add_result(report, "REQ-121", "NAND timing error < 5%", timing_err, 5.0, "%", false);
 
     /* REQ-122: Scalability >= 70% efficiency at 16 channels (Amdahl model) */
     double eff = perf_scalability_efficiency(16);
-    add_result(report, "REQ-122",
-               "Parallel efficiency >= 70% at 16 channels",
-               eff * 100.0, 70.0, "%", true);
+    add_result(report, "REQ-122", "Parallel efficiency >= 70% at 16 channels", eff * 100.0, 70.0, "%", true);
 
     /* REQ-123: CPU utilization <= 50% (reported as 0 in simulation) */
-    add_result(report, "REQ-123",
-               "CPU utilization <= 50% under peak load",
-               res.cpu_util_pct, 50.0, "%", false);
+    add_result(report, "REQ-123", "CPU utilization <= 50% under peak load", res.cpu_util_pct, 50.0, "%", false);
 
     return HFSSS_OK;
 }
@@ -672,8 +685,10 @@ int perf_validation_run_all(struct perf_validation_report *report) {
 /* ------------------------------------------------------------------
  * perf_validation_report_print – public API
  * ------------------------------------------------------------------ */
-void perf_validation_report_print(const struct perf_validation_report *report) {
-    if (!report) return;
+void perf_validation_report_print(const struct perf_validation_report *report)
+{
+    if (!report)
+        return;
 
     printf("========================================\n");
     printf("Performance Validation Report\n");
@@ -687,8 +702,7 @@ void perf_validation_report_print(const struct perf_validation_report *report) {
         const struct perf_req_result *r = &report->results[i];
         printf("  [%s] %s\n", r->passed ? "PASS" : "FAIL", r->req_id);
         printf("         %s\n", r->description);
-        printf("         measured=%.2f %s  target=%.2f %s\n",
-               r->measured, r->unit, r->target, r->unit);
+        printf("         measured=%.2f %s  target=%.2f %s\n", r->measured, r->unit, r->target, r->unit);
     }
     printf("========================================\n");
 }
@@ -696,18 +710,22 @@ void perf_validation_report_print(const struct perf_validation_report *report) {
 /* ------------------------------------------------------------------
  * perf_validation_report_to_json – public API
  * ------------------------------------------------------------------ */
-int perf_validation_report_to_json(const struct perf_validation_report *report,
-                                   char *buf, size_t bufsz) {
-    if (!report || !buf || bufsz == 0) return HFSSS_ERR_INVAL;
+int perf_validation_report_to_json(const struct perf_validation_report *report, char *buf, size_t bufsz)
+{
+    if (!report || !buf || bufsz == 0)
+        return HFSSS_ERR_INVAL;
 
     int written = 0;
     int rem = (int)bufsz;
 
-#define JAPPEND(fmt, ...) do { \
-    int _n = snprintf(buf + written, (size_t)(rem > 0 ? rem : 0), fmt, ##__VA_ARGS__); \
-    if (_n < 0) return HFSSS_ERR; \
-    written += _n; rem -= _n; \
-} while (0)
+#define JAPPEND(fmt, ...)                                                                                              \
+    do {                                                                                                               \
+        int _n = snprintf(buf + written, (size_t)(rem > 0 ? rem : 0), fmt, ##__VA_ARGS__);                             \
+        if (_n < 0)                                                                                                    \
+            return HFSSS_ERR;                                                                                          \
+        written += _n;                                                                                                 \
+        rem -= _n;                                                                                                     \
+    } while (0)
 
     JAPPEND("{");
     JAPPEND("\"passed\":%d,", report->passed);
@@ -717,7 +735,8 @@ int perf_validation_report_to_json(const struct perf_validation_report *report,
 
     for (int i = 0; i < report->count; i++) {
         const struct perf_req_result *r = &report->results[i];
-        if (i > 0) JAPPEND(",");
+        if (i > 0)
+            JAPPEND(",");
         JAPPEND("{");
         JAPPEND("\"req_id\":\"%s\",", r->req_id ? r->req_id : "");
         JAPPEND("\"description\":\"%s\",", r->description ? r->description : "");

--- a/src/vhost/nbd_async.c
+++ b/src/vhost/nbd_async.c
@@ -528,7 +528,12 @@ int nbd_async_start(struct nbd_async_ctx *ctx)
 
     ret = pthread_create(&ctx->cq_thread, NULL, nbd_cq_thread_main, ctx);
     if (ret != 0) {
+        /* CQ failed after SQ started: unblock the SQ thread's recv()
+         * by shutting down the read side of the client socket, then
+         * join. Without the shutdown the SQ thread stays in blocking
+         * recv() and pthread_join() deadlocks. */
         ctx->running = false;
+        shutdown(ctx->client_fd, SHUT_RD);
         pthread_join(ctx->sq_thread, NULL);
         return -1;
     }

--- a/src/vhost/nbd_async.c
+++ b/src/vhost/nbd_async.c
@@ -26,8 +26,7 @@ int inflight_pool_init(struct inflight_pool *pool, uint32_t capacity)
     }
 
     memset(pool, 0, sizeof(*pool));
-    pool->slots = (struct inflight_slot *)calloc(capacity,
-                                                  sizeof(struct inflight_slot));
+    pool->slots = (struct inflight_slot *)calloc(capacity, sizeof(struct inflight_slot));
     if (!pool->slots) {
         return -1;
     }
@@ -46,7 +45,8 @@ int inflight_pool_init(struct inflight_pool *pool, uint32_t capacity)
 
 void inflight_pool_cleanup(struct inflight_pool *pool)
 {
-    if (!pool) return;
+    if (!pool)
+        return;
     free(pool->slots);
     memset(pool, 0, sizeof(*pool));
 }
@@ -61,8 +61,7 @@ struct inflight_slot *inflight_alloc(struct inflight_pool *pool)
     for (uint32_t i = 0; i < pool->capacity; i++) {
         uint32_t idx = (start + i) % pool->capacity;
         int expected = SLOT_FREE;
-        if (atomic_compare_exchange_strong(&pool->slots[idx].state,
-                                            &expected, SLOT_SUBMITTED)) {
+        if (atomic_compare_exchange_strong(&pool->slots[idx].state, &expected, SLOT_SUBMITTED)) {
             atomic_store(&pool->slots[idx].pending_reqs, 0);
             pool->slots[idx].total_reqs = 0;
             pool->slots[idx].completion_status = HFSSS_OK;
@@ -76,14 +75,16 @@ struct inflight_slot *inflight_alloc(struct inflight_pool *pool)
 
 void inflight_free(struct inflight_pool *pool, struct inflight_slot *slot)
 {
-    if (!pool || !slot) return;
+    if (!pool || !slot)
+        return;
     atomic_store(&slot->state, SLOT_FREE);
     atomic_fetch_sub(&pool->in_use, 1);
 }
 
 struct inflight_slot *inflight_get(struct inflight_pool *pool, uint32_t slot_id)
 {
-    if (!pool || slot_id >= pool->capacity) return NULL;
+    if (!pool || slot_id >= pool->capacity)
+        return NULL;
     return &pool->slots[slot_id];
 }
 
@@ -97,7 +98,8 @@ static int recv_exact(int fd, void *buf, size_t len)
     size_t remaining = len;
     while (remaining > 0) {
         ssize_t n = recv(fd, p, remaining, 0);
-        if (n <= 0) return -1;
+        if (n <= 0)
+            return -1;
         p += n;
         remaining -= (size_t)n;
     }
@@ -110,7 +112,8 @@ static int send_exact(int fd, const void *buf, size_t len)
     size_t remaining = len;
     while (remaining > 0) {
         ssize_t n = send(fd, p, remaining, 0);
-        if (n <= 0) return -1;
+        if (n <= 0)
+            return -1;
         p += n;
         remaining -= (size_t)n;
     }
@@ -145,28 +148,34 @@ static int send_iov_exact(int fd, struct iovec *iov, int iovcnt)
  * NBD protocol helpers
  * ----------------------------------------------------------------------- */
 
-#define NBD_REQUEST_MAGIC  0x25609513u
-#define NBD_REPLY_MAGIC    0x67446698u
-#define NBD_CMD_READ       0u
-#define NBD_CMD_WRITE      1u
-#define NBD_CMD_DISC       2u
-#define NBD_CMD_FLUSH      3u
-#define NBD_CMD_TRIM       4u
-#define NBD_EIO            5u
+#define NBD_REQUEST_MAGIC 0x25609513u
+#define NBD_REPLY_MAGIC 0x67446698u
+#define NBD_CMD_READ 0u
+#define NBD_CMD_WRITE 1u
+#define NBD_CMD_DISC 2u
+#define NBD_CMD_FLUSH 3u
+#define NBD_CMD_TRIM 4u
+#define NBD_EIO 5u
 
 static inline uint64_t nbd_htonll(uint64_t v)
 {
-    union { uint64_t u64; uint32_t u32[2]; } s;
+    union {
+        uint64_t u64;
+        uint32_t u32[2];
+    } s;
     s.u32[0] = htonl((uint32_t)(v >> 32));
     s.u32[1] = htonl((uint32_t)(v & 0xFFFFFFFFU));
     return s.u64;
 }
-static inline uint64_t nbd_ntohll(uint64_t v) { return nbd_htonll(v); }
+static inline uint64_t nbd_ntohll(uint64_t v)
+{
+    return nbd_htonll(v);
+}
 
 struct __attribute__((packed)) nbd_request_hdr {
     uint32_t magic;
-    uint16_t flags;   /* NBD command flags */
-    uint16_t type;    /* NBD_CMD_* */
+    uint16_t flags; /* NBD command flags */
+    uint16_t type;  /* NBD_CMD_* */
     uint64_t handle;
     uint64_t offset;
     uint32_t length;
@@ -181,16 +190,15 @@ struct __attribute__((packed)) nbd_reply_hdr {
 static int send_nbd_reply(int fd, uint64_t handle, uint32_t error)
 {
     struct nbd_reply_hdr rep;
-    rep.magic  = htonl(NBD_REPLY_MAGIC);
-    rep.error  = htonl(error);
-    rep.handle = handle;  /* verbatim */
+    rep.magic = htonl(NBD_REPLY_MAGIC);
+    rep.error = htonl(error);
+    rep.handle = handle; /* verbatim */
     return send_exact(fd, &rep, sizeof(rep));
 }
 
 #define NBD_CQ_BATCH_MAX 16
 
-static bool nbd_async_is_aligned_page_io(uint16_t cmd, uint32_t byte_off,
-                                         uint32_t length, uint32_t count,
+static bool nbd_async_is_aligned_page_io(uint16_t cmd, uint32_t byte_off, uint32_t length, uint32_t count,
                                          uint32_t lba_size)
 {
     if (cmd != NBD_CMD_READ && cmd != NBD_CMD_WRITE && cmd != NBD_CMD_TRIM) {
@@ -200,8 +208,7 @@ static bool nbd_async_is_aligned_page_io(uint16_t cmd, uint32_t byte_off,
     return byte_off == 0 && length == count * lba_size;
 }
 
-static void nbd_async_init_slot(struct inflight_slot *slot, uint64_t handle,
-                                uint16_t cmd, uint32_t byte_off,
+static void nbd_async_init_slot(struct inflight_slot *slot, uint64_t handle, uint16_t cmd, uint32_t byte_off,
                                 uint32_t length, uint32_t total_reqs)
 {
     slot->nbd_handle = handle;
@@ -214,8 +221,7 @@ static void nbd_async_init_slot(struct inflight_slot *slot, uint64_t handle,
     atomic_store(&slot->pending_reqs, total_reqs);
 }
 
-static void nbd_async_submit_req(struct nbd_async_ctx *ctx,
-                                 const struct io_request *io_req)
+static void nbd_async_submit_req(struct nbd_async_ctx *ctx, const struct io_request *io_req)
 {
     while (ctx->running && !ftl_mt_submit(ctx->mt, io_req)) {
         sched_yield();
@@ -241,8 +247,8 @@ static void *nbd_sq_thread_main(void *arg)
             break;
         }
 
-        uint32_t magic  = ntohl(req_hdr.magic);
-        uint16_t type   = ntohs(req_hdr.type);
+        uint32_t magic = ntohl(req_hdr.magic);
+        uint16_t type = ntohs(req_hdr.type);
         uint64_t offset = nbd_ntohll(req_hdr.offset);
         uint32_t length = ntohl(req_hdr.length);
         uint64_t handle = req_hdr.handle;
@@ -261,30 +267,28 @@ static void *nbd_sq_thread_main(void *arg)
 
         /* Compute LBA range */
         uint32_t lba_size = ctx->lba_size;
-        uint64_t lba      = offset / lba_size;
+        uint64_t lba = offset / lba_size;
         uint32_t byte_off = (uint32_t)(offset % lba_size);
         uint64_t end_byte = offset + length;
-        uint64_t end_lba  = (end_byte + lba_size - 1) / lba_size;
-        uint32_t count    = (uint32_t)(end_lba - lba);
+        uint64_t end_lba = (end_byte + lba_size - 1) / lba_size;
+        uint32_t count = (uint32_t)(end_lba - lba);
         uint32_t full_bytes = count * lba_size;
-        bool split_read = type == NBD_CMD_READ &&
-                          count > 1 &&
-                          nbd_async_is_aligned_page_io(type, byte_off,
-                                                       length, count, lba_size);
-        bool split_strided = (type == NBD_CMD_WRITE || type == NBD_CMD_TRIM) &&
-                             count > 1 &&
-                             nbd_async_is_aligned_page_io(type, byte_off,
-                                                          length, count, lba_size);
+        bool split_read =
+            type == NBD_CMD_READ && count > 1 && nbd_async_is_aligned_page_io(type, byte_off, length, count, lba_size);
+        bool split_strided = (type == NBD_CMD_WRITE || type == NBD_CMD_TRIM) && count > 1 &&
+                             nbd_async_is_aligned_page_io(type, byte_off, length, count, lba_size);
         u32 total_reqs = 1;
 
         /* Alloc inflight slot (spin if pool exhausted = backpressure) */
         struct inflight_slot *slot = NULL;
         while (ctx->running) {
             slot = inflight_alloc(&ctx->pool);
-            if (slot) break;
+            if (slot)
+                break;
             sched_yield();
         }
-        if (!slot) break;
+        if (!slot)
+            break;
 
         if (full_bytes > NBD_ASYNC_SLOT_BUFSZ) {
             send_nbd_reply(ctx->client_fd, handle, NBD_EIO);
@@ -316,13 +320,21 @@ static void *nbd_sq_thread_main(void *arg)
         /* Build io_request(s) and submit to FTL worker(s). */
         struct io_request io_req;
         memset(&io_req, 0, sizeof(io_req));
-        io_req.nbd_handle = slot->slot_id;  /* slot_id flows through */
+        io_req.nbd_handle = slot->slot_id; /* slot_id flows through */
 
         switch (type) {
-        case NBD_CMD_READ:  io_req.opcode = IO_OP_READ;  break;
-        case NBD_CMD_WRITE: io_req.opcode = IO_OP_WRITE; break;
-        case NBD_CMD_TRIM:  io_req.opcode = IO_OP_TRIM;  break;
-        case NBD_CMD_FLUSH: io_req.opcode = IO_OP_FLUSH; break;
+        case NBD_CMD_READ:
+            io_req.opcode = IO_OP_READ;
+            break;
+        case NBD_CMD_WRITE:
+            io_req.opcode = IO_OP_WRITE;
+            break;
+        case NBD_CMD_TRIM:
+            io_req.opcode = IO_OP_TRIM;
+            break;
+        case NBD_CMD_FLUSH:
+            io_req.opcode = IO_OP_FLUSH;
+            break;
         default:
             inflight_free(&ctx->pool, slot);
             continue;
@@ -397,21 +409,18 @@ static void *nbd_cq_thread_main(void *arg)
 
         /* Poll all worker completion rings */
         for (int w = 0; w < FTL_NUM_WORKERS; w++) {
-            while (batch_count < NBD_CQ_BATCH_MAX &&
-                   io_ring_pop(&ctx->mt->workers[w].completion_ring, &cpl)) {
+            while (batch_count < NBD_CQ_BATCH_MAX && io_ring_pop(&ctx->mt->workers[w].completion_ring, &cpl)) {
                 found = true;
                 idle_spins = 0;
 
-                struct inflight_slot *slot = inflight_get(&ctx->pool,
-                                                           (uint32_t)cpl.nbd_handle);
+                struct inflight_slot *slot = inflight_get(&ctx->pool, (uint32_t)cpl.nbd_handle);
                 if (!slot) {
                     continue;
                 }
 
                 if (slot->nbd_cmd == NBD_CMD_READ && cpl.status != 0) {
                     memset(slot->data + cpl.data_offset, 0, cpl.byte_len);
-                } else if (cpl.status != HFSSS_OK &&
-                           slot->completion_status == HFSSS_OK) {
+                } else if (cpl.status != HFSSS_OK && slot->completion_status == HFSSS_OK) {
                     slot->completion_status = cpl.status;
                 }
 
@@ -469,8 +478,7 @@ static void *nbd_cq_thread_main(void *arg)
     /* Drain remaining completions */
     for (int w = 0; w < FTL_NUM_WORKERS; w++) {
         while (io_ring_pop(&ctx->mt->workers[w].completion_ring, &cpl)) {
-            struct inflight_slot *slot = inflight_get(&ctx->pool,
-                                                       (uint32_t)cpl.nbd_handle);
+            struct inflight_slot *slot = inflight_get(&ctx->pool, (uint32_t)cpl.nbd_handle);
             if (slot) {
                 slot->completion_status = NBD_EIO;
                 if (atomic_fetch_sub(&slot->pending_reqs, 1) == 1) {
@@ -488,17 +496,17 @@ static void *nbd_cq_thread_main(void *arg)
  * Async context lifecycle
  * ----------------------------------------------------------------------- */
 
-int nbd_async_init(struct nbd_async_ctx *ctx, int client_fd,
-                   uint32_t lba_size, struct ftl_mt_ctx *mt,
+int nbd_async_init(struct nbd_async_ctx *ctx, int client_fd, uint32_t lba_size, struct ftl_mt_ctx *mt,
                    uint32_t pool_capacity)
 {
-    if (!ctx || !mt || client_fd < 0) return -1;
+    if (!ctx || !mt || client_fd < 0)
+        return -1;
 
     memset(ctx, 0, sizeof(*ctx));
     ctx->client_fd = client_fd;
-    ctx->lba_size  = lba_size;
-    ctx->mt        = mt;
-    ctx->running   = false;
+    ctx->lba_size = lba_size;
+    ctx->mt = mt;
+    ctx->running = false;
 
     /* Enable TCP_NODELAY for low-latency replies */
     int flag = 1;
@@ -509,7 +517,8 @@ int nbd_async_init(struct nbd_async_ctx *ctx, int client_fd,
 
 void nbd_async_cleanup(struct nbd_async_ctx *ctx)
 {
-    if (!ctx) return;
+    if (!ctx)
+        return;
     nbd_async_stop(ctx);
     inflight_pool_cleanup(&ctx->pool);
     memset(ctx, 0, sizeof(*ctx));
@@ -517,7 +526,8 @@ void nbd_async_cleanup(struct nbd_async_ctx *ctx)
 
 int nbd_async_start(struct nbd_async_ctx *ctx)
 {
-    if (!ctx) return -1;
+    if (!ctx)
+        return -1;
     ctx->running = true;
 
     int ret = pthread_create(&ctx->sq_thread, NULL, nbd_sq_thread_main, ctx);
@@ -543,11 +553,12 @@ int nbd_async_start(struct nbd_async_ctx *ctx)
 
 void nbd_async_stop(struct nbd_async_ctx *ctx)
 {
-    if (!ctx || !ctx->running) return;
+    if (!ctx || !ctx->running)
+        return;
     ctx->running = false;
     /* SQ thread will unblock when recv() returns 0/error.
      * CQ thread will see running=false on next poll cycle. */
-    shutdown(ctx->client_fd, SHUT_RD);  /* unblock recv in SQ */
+    shutdown(ctx->client_fd, SHUT_RD); /* unblock recv in SQ */
     pthread_join(ctx->sq_thread, NULL);
     pthread_join(ctx->cq_thread, NULL);
 }

--- a/tests/test_perf_validation.c
+++ b/tests/test_perf_validation.c
@@ -21,13 +21,20 @@
  * ------------------------------------------------------------------ */
 static int total = 0, passed = 0, failed = 0;
 
-#define TEST_ASSERT(cond, msg) do { \
-    total++; \
-    if (cond) { printf("  [PASS] %s\n", (msg)); passed++; } \
-    else       { printf("  [FAIL] %s\n", (msg)); failed++; } \
-} while (0)
+#define TEST_ASSERT(cond, msg)                                                                                         \
+    do {                                                                                                               \
+        total++;                                                                                                       \
+        if (cond) {                                                                                                    \
+            printf("  [PASS] %s\n", (msg));                                                                            \
+            passed++;                                                                                                  \
+        } else {                                                                                                       \
+            printf("  [FAIL] %s\n", (msg));                                                                            \
+            failed++;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
 
-static void separator(const char *title) {
+static void separator(const char *title)
+{
     printf("========================================\n");
     printf("Test: %s\n", title);
     printf("========================================\n");
@@ -36,7 +43,8 @@ static void separator(const char *title) {
 /* ------------------------------------------------------------------
  * Test 1: bench_cfg defaults / input validation
  * ------------------------------------------------------------------ */
-static void test_bench_cfg_validation(void) {
+static void test_bench_cfg_validation(void)
+{
     separator("bench_cfg defaults / NULL safety");
 
     /* NULL config */
@@ -46,10 +54,10 @@ static void test_bench_cfg_validation(void) {
 
     /* NULL result */
     struct bench_cfg cfg = {
-        .workload   = BENCH_RAND_READ,
+        .workload = BENCH_RAND_READ,
         .block_size = 4096,
-        .queue_depth= 1,
-        .op_count   = 10,
+        .queue_depth = 1,
+        .op_count = 10,
     };
     rc = bench_run(&cfg, NULL);
     TEST_ASSERT(rc == HFSSS_ERR_INVAL, "bench_run(NULL out) returns HFSSS_ERR_INVAL");
@@ -62,216 +70,224 @@ static void test_bench_cfg_validation(void) {
 /* ------------------------------------------------------------------
  * Test 2: bench_run RAND_READ at QD=1 returns result
  * ------------------------------------------------------------------ */
-static void test_bench_rand_read_qd1(void) {
+static void test_bench_rand_read_qd1(void)
+{
     separator("bench_run RAND_READ QD=1");
 
     struct bench_cfg cfg = {
-        .workload       = BENCH_RAND_READ,
-        .block_size     = 4096,
-        .queue_depth    = 1,
-        .duration_s     = 0,
-        .op_count       = 1000,
-        .num_threads    = 1,
+        .workload = BENCH_RAND_READ,
+        .block_size = 4096,
+        .queue_depth = 1,
+        .duration_s = 0,
+        .op_count = 1000,
+        .num_threads = 1,
         .capacity_bytes = 64ULL * 1024 * 1024,
     };
     struct bench_result res;
     int rc = bench_run(&cfg, &res);
 
-    TEST_ASSERT(rc == HFSSS_OK,           "bench_run returns HFSSS_OK");
-    TEST_ASSERT(res.total_ops == 1000,    "total_ops == 1000");
-    TEST_ASSERT(res.read_iops > 0.0,      "read_iops > 0");
-    TEST_ASSERT(res.elapsed_s > 0.0,      "elapsed_s > 0");
-    TEST_ASSERT(res.lat_p50_us > 0,       "lat_p50_us > 0");
+    TEST_ASSERT(rc == HFSSS_OK, "bench_run returns HFSSS_OK");
+    TEST_ASSERT(res.total_ops == 1000, "total_ops == 1000");
+    TEST_ASSERT(res.read_iops > 0.0, "read_iops > 0");
+    TEST_ASSERT(res.elapsed_s > 0.0, "elapsed_s > 0");
+    TEST_ASSERT(res.lat_p50_us > 0, "lat_p50_us > 0");
 }
 
 /* ------------------------------------------------------------------
  * Test 3: bench_run RAND_READ at QD=32, IOPS check (REQ-116)
  * ------------------------------------------------------------------ */
-static void test_bench_rand_read_qd32(void) {
+static void test_bench_rand_read_qd32(void)
+{
     separator("bench_run RAND_READ QD=32 (REQ-116)");
 
     struct bench_cfg cfg = {
-        .workload       = BENCH_RAND_READ,
-        .block_size     = 4096,
-        .queue_depth    = 32,
-        .duration_s     = 0,
-        .op_count       = 20000,
-        .num_threads    = 1,
+        .workload = BENCH_RAND_READ,
+        .block_size = 4096,
+        .queue_depth = 32,
+        .duration_s = 0,
+        .op_count = 20000,
+        .num_threads = 1,
         .capacity_bytes = 256ULL * 1024 * 1024,
     };
     struct bench_result res;
     int rc = bench_run(&cfg, &res);
 
-    TEST_ASSERT(rc == HFSSS_OK,            "bench_run returns HFSSS_OK");
+    TEST_ASSERT(rc == HFSSS_OK, "bench_run returns HFSSS_OK");
     TEST_ASSERT(res.read_iops >= 600000.0, "read IOPS >= 600K (REQ-116)");
-    TEST_ASSERT(res.read_iops <= 1000000.0 * 100,
-                "read IOPS reasonable upper bound");
+    TEST_ASSERT(res.read_iops <= 1000000.0 * 100, "read IOPS reasonable upper bound");
 }
 
 /* ------------------------------------------------------------------
  * Test 4: bench_run RAND_WRITE at QD=32 (REQ-117)
  * ------------------------------------------------------------------ */
-static void test_bench_rand_write_qd32(void) {
+static void test_bench_rand_write_qd32(void)
+{
     separator("bench_run RAND_WRITE QD=32 (REQ-117)");
 
     struct bench_cfg cfg = {
-        .workload       = BENCH_RAND_WRITE,
-        .block_size     = 4096,
-        .queue_depth    = 32,
-        .duration_s     = 0,
-        .op_count       = 20000,
-        .num_threads    = 1,
+        .workload = BENCH_RAND_WRITE,
+        .block_size = 4096,
+        .queue_depth = 32,
+        .duration_s = 0,
+        .op_count = 20000,
+        .num_threads = 1,
         .capacity_bytes = 256ULL * 1024 * 1024,
     };
     struct bench_result res;
     int rc = bench_run(&cfg, &res);
 
-    TEST_ASSERT(rc == HFSSS_OK,             "bench_run returns HFSSS_OK");
+    TEST_ASSERT(rc == HFSSS_OK, "bench_run returns HFSSS_OK");
     TEST_ASSERT(res.write_iops >= 150000.0, "write IOPS >= 150K (REQ-117)");
 }
 
 /* ------------------------------------------------------------------
  * Test 5: bench_run MIXED 70/30 at QD=32 (REQ-118)
  * ------------------------------------------------------------------ */
-static void test_bench_mixed_qd32(void) {
+static void test_bench_mixed_qd32(void)
+{
     separator("bench_run MIXED 70/30 QD=32 (REQ-118)");
 
     struct bench_cfg cfg = {
-        .workload       = BENCH_MIXED,
-        .block_size     = 4096,
-        .queue_depth    = 32,
-        .duration_s     = 0,
-        .op_count       = 20000,
-        .num_threads    = 1,
-        .rw_ratio       = 0.7,
+        .workload = BENCH_MIXED,
+        .block_size = 4096,
+        .queue_depth = 32,
+        .duration_s = 0,
+        .op_count = 20000,
+        .num_threads = 1,
+        .rw_ratio = 0.7,
         .capacity_bytes = 256ULL * 1024 * 1024,
     };
     struct bench_result res;
     int rc = bench_run(&cfg, &res);
 
     double total_iops = res.read_iops + res.write_iops;
-    TEST_ASSERT(rc == HFSSS_OK,             "bench_run returns HFSSS_OK");
-    TEST_ASSERT(total_iops >= 250000.0,     "total IOPS >= 250K (REQ-118)");
-    TEST_ASSERT(res.read_iops > 0.0,        "read_iops > 0");
-    TEST_ASSERT(res.write_iops > 0.0,       "write_iops > 0");
+    TEST_ASSERT(rc == HFSSS_OK, "bench_run returns HFSSS_OK");
+    TEST_ASSERT(total_iops >= 250000.0, "total IOPS >= 250K (REQ-118)");
+    TEST_ASSERT(res.read_iops > 0.0, "read_iops > 0");
+    TEST_ASSERT(res.write_iops > 0.0, "write_iops > 0");
 }
 
 /* ------------------------------------------------------------------
  * Test 6: bench_run SEQ_READ at 128KB (REQ-119 read)
  * ------------------------------------------------------------------ */
-static void test_bench_seq_read_128k(void) {
+static void test_bench_seq_read_128k(void)
+{
     separator("bench_run SEQ_READ 128KB (REQ-119)");
 
     struct bench_cfg cfg = {
-        .workload       = BENCH_SEQ_READ,
-        .block_size     = 131072,
-        .queue_depth    = 32,
-        .duration_s     = 0,
-        .op_count       = 20000,
-        .num_threads    = 1,
+        .workload = BENCH_SEQ_READ,
+        .block_size = 131072,
+        .queue_depth = 32,
+        .duration_s = 0,
+        .op_count = 20000,
+        .num_threads = 1,
         .capacity_bytes = 256ULL * 1024 * 1024,
     };
     struct bench_result res;
     int rc = bench_run(&cfg, &res);
 
-    TEST_ASSERT(rc == HFSSS_OK,              "bench_run returns HFSSS_OK");
-    TEST_ASSERT(res.read_bw_mbps >= 6500.0,  "read BW >= 6500 MB/s (REQ-119)");
+    TEST_ASSERT(rc == HFSSS_OK, "bench_run returns HFSSS_OK");
+    TEST_ASSERT(res.read_bw_mbps >= 6500.0, "read BW >= 6500 MB/s (REQ-119)");
 }
 
 /* ------------------------------------------------------------------
  * Test 7: bench_run SEQ_WRITE at 128KB (REQ-119 write)
  * ------------------------------------------------------------------ */
-static void test_bench_seq_write_128k(void) {
+static void test_bench_seq_write_128k(void)
+{
     separator("bench_run SEQ_WRITE 128KB (REQ-119)");
 
     struct bench_cfg cfg = {
-        .workload       = BENCH_SEQ_WRITE,
-        .block_size     = 131072,
-        .queue_depth    = 32,
-        .duration_s     = 0,
-        .op_count       = 20000,
-        .num_threads    = 1,
+        .workload = BENCH_SEQ_WRITE,
+        .block_size = 131072,
+        .queue_depth = 32,
+        .duration_s = 0,
+        .op_count = 20000,
+        .num_threads = 1,
         .capacity_bytes = 256ULL * 1024 * 1024,
     };
     struct bench_result res;
     int rc = bench_run(&cfg, &res);
 
-    TEST_ASSERT(rc == HFSSS_OK,               "bench_run returns HFSSS_OK");
-    TEST_ASSERT(res.write_bw_mbps >= 3500.0,  "write BW >= 3500 MB/s (REQ-119)");
+    TEST_ASSERT(rc == HFSSS_OK, "bench_run returns HFSSS_OK");
+    TEST_ASSERT(res.write_bw_mbps >= 3500.0, "write BW >= 3500 MB/s (REQ-119)");
 }
 
 /* ------------------------------------------------------------------
  * Test 8: bench_run ZIPFIAN workload
  * ------------------------------------------------------------------ */
-static void test_bench_zipfian(void) {
+static void test_bench_zipfian(void)
+{
     separator("bench_run ZIPFIAN workload");
 
     struct bench_cfg cfg = {
-        .workload       = BENCH_ZIPFIAN,
-        .block_size     = 4096,
-        .queue_depth    = 32,
-        .duration_s     = 0,
-        .op_count       = 5000,
-        .num_threads    = 1,
-        .rw_ratio       = 0.7,
-        .zipf_theta     = 0.9,
+        .workload = BENCH_ZIPFIAN,
+        .block_size = 4096,
+        .queue_depth = 32,
+        .duration_s = 0,
+        .op_count = 5000,
+        .num_threads = 1,
+        .rw_ratio = 0.7,
+        .zipf_theta = 0.9,
         .capacity_bytes = 64ULL * 1024 * 1024,
     };
     struct bench_result res;
     int rc = bench_run(&cfg, &res);
 
-    TEST_ASSERT(rc == HFSSS_OK,        "bench_run returns HFSSS_OK");
+    TEST_ASSERT(rc == HFSSS_OK, "bench_run returns HFSSS_OK");
     TEST_ASSERT(res.total_ops == 5000, "total_ops == 5000");
 }
 
 /* ------------------------------------------------------------------
  * Test 9: Latency histogram P50/P99/P99.9 computed correctly (REQ-120)
  * ------------------------------------------------------------------ */
-static void test_latency_histogram(void) {
+static void test_latency_histogram(void)
+{
     separator("Latency histogram P50/P99/P99.9 (REQ-120)");
 
     struct bench_cfg cfg = {
-        .workload       = BENCH_RAND_READ,
-        .block_size     = 4096,
-        .queue_depth    = 1,
-        .duration_s     = 0,
-        .op_count       = 10000,
-        .num_threads    = 1,
+        .workload = BENCH_RAND_READ,
+        .block_size = 4096,
+        .queue_depth = 1,
+        .duration_s = 0,
+        .op_count = 10000,
+        .num_threads = 1,
         .capacity_bytes = 64ULL * 1024 * 1024,
     };
     struct bench_result res;
     bench_run(&cfg, &res);
 
-    TEST_ASSERT(res.lat_p50_us  <= 100,  "P50 <= 100µs (REQ-120)");
-    TEST_ASSERT(res.lat_p99_us  <= 150,  "P99 <= 150µs (REQ-120)");
-    TEST_ASSERT(res.lat_p999_us <= 500,  "P99.9 <= 500µs (REQ-120)");
-    TEST_ASSERT(res.lat_p50_us  <= res.lat_p99_us,
-                "P50 <= P99 ordering");
-    TEST_ASSERT(res.lat_p99_us  <= res.lat_p999_us,
-                "P99 <= P99.9 ordering");
+    TEST_ASSERT(res.lat_p50_us <= 100, "P50 <= 100µs (REQ-120)");
+    TEST_ASSERT(res.lat_p99_us <= 150, "P99 <= 150µs (REQ-120)");
+    TEST_ASSERT(res.lat_p999_us <= 500, "P99.9 <= 500µs (REQ-120)");
+    TEST_ASSERT(res.lat_p50_us <= res.lat_p99_us, "P50 <= P99 ordering");
+    TEST_ASSERT(res.lat_p99_us <= res.lat_p999_us, "P99 <= P99.9 ordering");
 
     /* Histogram entries should sum to total ops */
     uint64_t hist_sum = 0;
-    for (int i = 0; i < PERF_LAT_HIST_BUCKETS; i++) hist_sum += res.lat_hist[i];
+    for (int i = 0; i < PERF_LAT_HIST_BUCKETS; i++)
+        hist_sum += res.lat_hist[i];
     TEST_ASSERT(hist_sum == res.total_ops, "histogram sum == total_ops");
 }
 
 /* ------------------------------------------------------------------
  * Test 10: NAND timing error < 5% (REQ-121)
  * ------------------------------------------------------------------ */
-static void test_nand_timing_accuracy(void) {
+static void test_nand_timing_accuracy(void)
+{
     separator("NAND timing accuracy (REQ-121)");
 
     double err = nand_timing_measure_error();
-    TEST_ASSERT(err >= 0.0,  "timing error is non-negative");
-    TEST_ASSERT(err < 5.0,   "timing error < 5% (REQ-121)");
+    TEST_ASSERT(err >= 0.0, "timing error is non-negative");
+    TEST_ASSERT(err < 5.0, "timing error < 5% (REQ-121)");
     printf("  NAND timing max error: %.4f%%\n", err);
 }
 
 /* ------------------------------------------------------------------
  * Test 11: Scalability efficiency > 0 (REQ-122 sanity)
  * ------------------------------------------------------------------ */
-static void test_scalability_sanity(void) {
+static void test_scalability_sanity(void)
+{
     separator("Scalability efficiency sanity (REQ-122)");
 
     double eff1 = perf_scalability_efficiency(1);
@@ -281,14 +297,15 @@ static void test_scalability_sanity(void) {
     TEST_ASSERT(eff0 == 0.0, "zero threads returns 0.0");
 
     double eff4 = perf_scalability_efficiency(4);
-    TEST_ASSERT(eff4 > 0.0,  "4-thread efficiency > 0");
+    TEST_ASSERT(eff4 > 0.0, "4-thread efficiency > 0");
     printf("  4-thread parallel efficiency: %.2f%%\n", eff4 * 100.0);
 }
 
 /* ------------------------------------------------------------------
  * Test 12: perf_validation_run_all returns a report
  * ------------------------------------------------------------------ */
-static void test_validation_run_all(void) {
+static void test_validation_run_all(void)
+{
     separator("perf_validation_run_all returns report");
 
     /* NULL safety */
@@ -297,22 +314,20 @@ static void test_validation_run_all(void) {
 
     struct perf_validation_report report;
     rc = perf_validation_run_all(&report);
-    TEST_ASSERT(rc == HFSSS_OK,       "run_all returns HFSSS_OK");
-    TEST_ASSERT(report.count > 0,     "report.count > 0");
-    TEST_ASSERT(report.count <= 32,   "report.count <= 32");
-    TEST_ASSERT(report.passed + report.failed == report.count,
-                "passed + failed == count");
-    TEST_ASSERT(report.nand_timing_error_pct >= 0.0,
-                "nand_timing_error_pct >= 0");
+    TEST_ASSERT(rc == HFSSS_OK, "run_all returns HFSSS_OK");
+    TEST_ASSERT(report.count > 0, "report.count > 0");
+    TEST_ASSERT(report.count <= 32, "report.count <= 32");
+    TEST_ASSERT(report.passed + report.failed == report.count, "passed + failed == count");
+    TEST_ASSERT(report.nand_timing_error_pct >= 0.0, "nand_timing_error_pct >= 0");
 
-    printf("  Requirements: %d passed, %d failed\n",
-           report.passed, report.failed);
+    printf("  Requirements: %d passed, %d failed\n", report.passed, report.failed);
 }
 
 /* ------------------------------------------------------------------
  * Test 13: JSON report format contains req_id fields
  * ------------------------------------------------------------------ */
-static void test_json_report_format(void) {
+static void test_json_report_format(void)
+{
     separator("JSON report format");
 
     struct perf_validation_report report;
@@ -320,12 +335,12 @@ static void test_json_report_format(void) {
 
     char buf[8192];
     int rc = perf_validation_report_to_json(&report, buf, sizeof(buf));
-    TEST_ASSERT(rc == HFSSS_OK,                  "to_json returns HFSSS_OK");
-    TEST_ASSERT(strstr(buf, "req_id") != NULL,   "JSON contains 'req_id'");
-    TEST_ASSERT(strstr(buf, "passed") != NULL,   "JSON contains 'passed'");
-    TEST_ASSERT(strstr(buf, "REQ-116") != NULL,  "JSON contains 'REQ-116'");
-    TEST_ASSERT(strstr(buf, "REQ-121") != NULL,  "JSON contains 'REQ-121'");
-    TEST_ASSERT(strstr(buf, "results") != NULL,  "JSON contains 'results' array");
+    TEST_ASSERT(rc == HFSSS_OK, "to_json returns HFSSS_OK");
+    TEST_ASSERT(strstr(buf, "req_id") != NULL, "JSON contains 'req_id'");
+    TEST_ASSERT(strstr(buf, "passed") != NULL, "JSON contains 'passed'");
+    TEST_ASSERT(strstr(buf, "REQ-116") != NULL, "JSON contains 'REQ-116'");
+    TEST_ASSERT(strstr(buf, "REQ-121") != NULL, "JSON contains 'REQ-121'");
+    TEST_ASSERT(strstr(buf, "results") != NULL, "JSON contains 'results' array");
 
     /* NULL safety */
     rc = perf_validation_report_to_json(NULL, buf, sizeof(buf));
@@ -341,7 +356,8 @@ static void test_json_report_format(void) {
 /* ------------------------------------------------------------------
  * Test 14: report_print does not crash
  * ------------------------------------------------------------------ */
-static void test_report_print_no_crash(void) {
+static void test_report_print_no_crash(void)
+{
     separator("report_print does not crash");
 
     perf_validation_report_print(NULL);
@@ -361,7 +377,8 @@ static void test_report_print_no_crash(void) {
 /* ------------------------------------------------------------------
  * Test 15: NULL safety on all public APIs
  * ------------------------------------------------------------------ */
-static void test_null_safety(void) {
+static void test_null_safety(void)
+{
     separator("NULL safety on all public APIs");
 
     /* bench_run */
@@ -399,16 +416,16 @@ static void test_null_safety(void) {
 
     /* bench_run with zero op_count and zero duration uses internal default */
     struct bench_cfg cfg = {
-        .workload       = BENCH_RAND_READ,
-        .block_size     = 4096,
-        .queue_depth    = 1,
-        .duration_s     = 0,
-        .op_count       = 0,
-        .num_threads    = 0,  /* should default to 1 */
-        .capacity_bytes = 0,  /* should use internal default */
+        .workload = BENCH_RAND_READ,
+        .block_size = 4096,
+        .queue_depth = 1,
+        .duration_s = 0,
+        .op_count = 0,
+        .num_threads = 0,    /* should default to 1 */
+        .capacity_bytes = 0, /* should use internal default */
     };
     rc = bench_run(&cfg, &res);
-    TEST_ASSERT(rc == HFSSS_OK,    "bench_run with zeros uses defaults");
+    TEST_ASSERT(rc == HFSSS_OK, "bench_run with zeros uses defaults");
     TEST_ASSERT(res.total_ops > 0, "default op_count > 0");
 }
 
@@ -426,15 +443,14 @@ static void test_null_safety(void) {
 
 /* Test seam exposed by perf_validation.c (intentionally not in the
  * public header — see the comment near g_pthread_create). */
-typedef int (*perf_pthread_create_fn)(pthread_t *, const pthread_attr_t *,
-                                       void *(*)(void *), void *);
+typedef int (*perf_pthread_create_fn)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
 extern void __perf_test_set_pthread_create(perf_pthread_create_fn fn);
 
 static int g_create_calls = 0;
-static int g_create_fail_after = 0;  /* fail when calls exceed this count */
+static int g_create_fail_after = 0; /* fail when calls exceed this count */
 
-static int failing_pthread_create(pthread_t *t, const pthread_attr_t *a,
-                                   void *(*start)(void *), void *arg) {
+static int failing_pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*start)(void *), void *arg)
+{
     g_create_calls++;
     if (g_create_calls > g_create_fail_after) {
         return EAGAIN;
@@ -442,30 +458,32 @@ static int failing_pthread_create(pthread_t *t, const pthread_attr_t *a,
     return pthread_create(t, a, start, arg);
 }
 
-static uint64_t test_now_ms(void) {
+static uint64_t test_now_ms(void)
+{
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)ts.tv_nsec / 1000000ULL;
 }
 
-static void test_bench_run_create_fail_fast(void) {
+static void test_bench_run_create_fail_fast(void)
+{
     separator("bench_run pthread_create-failure rollback fails fast");
 
     /* Duration-based config: without the cancellation flag, an
      * already-started worker would run the full duration_s before its
      * loop exits, defeating any rollback attempt. */
     struct bench_cfg cfg = {
-        .workload       = BENCH_RAND_READ,
-        .block_size     = 4096,
-        .queue_depth    = 1,
-        .duration_s     = 5,        /* would block 5s without the fix */
-        .op_count       = 0,
-        .num_threads    = 4,        /* fail on the 2nd of 4 */
+        .workload = BENCH_RAND_READ,
+        .block_size = 4096,
+        .queue_depth = 1,
+        .duration_s = 5, /* would block 5s without the fix */
+        .op_count = 0,
+        .num_threads = 4, /* fail on the 2nd of 4 */
         .capacity_bytes = 64ULL * 1024 * 1024,
     };
 
     g_create_calls = 0;
-    g_create_fail_after = 1;        /* let #1 succeed, fail #2 */
+    g_create_fail_after = 1; /* let #1 succeed, fail #2 */
     __perf_test_set_pthread_create(failing_pthread_create);
 
     struct bench_result res;
@@ -475,25 +493,22 @@ static void test_bench_run_create_fail_fast(void) {
 
     __perf_test_set_pthread_create(NULL); /* restore real pthread_create */
 
-    TEST_ASSERT(rc != HFSSS_OK,
-                "bench_run returns error when a worker create fails");
-    TEST_ASSERT(g_create_calls == 2,
-                "bench_run attempted exactly 2 creates (1 ok + 1 fail)");
-    TEST_ASSERT(elapsed_ms < 1000,
-                "rollback fails fast (< 1s) instead of waiting out duration");
+    TEST_ASSERT(rc != HFSSS_OK, "bench_run returns error when a worker create fails");
+    TEST_ASSERT(g_create_calls == 2, "bench_run attempted exactly 2 creates (1 ok + 1 fail)");
+    TEST_ASSERT(elapsed_ms < 1000, "rollback fails fast (< 1s) instead of waiting out duration");
 
     /* Sanity: also exercise count-based mode. With the old behavior the
      * already-started worker would still drain its op_count budget. */
     g_create_calls = 0;
-    g_create_fail_after = 0;        /* fail on the very first create */
+    g_create_fail_after = 0; /* fail on the very first create */
     __perf_test_set_pthread_create(failing_pthread_create);
 
     struct bench_cfg cfg_count = {
-        .workload       = BENCH_RAND_READ,
-        .block_size     = 4096,
-        .queue_depth    = 1,
-        .op_count       = 1000000,  /* large budget to amplify the bug */
-        .num_threads    = 2,
+        .workload = BENCH_RAND_READ,
+        .block_size = 4096,
+        .queue_depth = 1,
+        .op_count = 1000000, /* large budget to amplify the bug */
+        .num_threads = 2,
         .capacity_bytes = 64ULL * 1024 * 1024,
     };
     t0 = test_now_ms();
@@ -502,16 +517,15 @@ static void test_bench_run_create_fail_fast(void) {
 
     __perf_test_set_pthread_create(NULL);
 
-    TEST_ASSERT(rc != HFSSS_OK,
-                "bench_run errors when first create fails");
-    TEST_ASSERT(elapsed_ms < 500,
-                "no started workers means immediate return");
+    TEST_ASSERT(rc != HFSSS_OK, "bench_run errors when first create fails");
+    TEST_ASSERT(elapsed_ms < 500, "no started workers means immediate return");
 }
 
 /* ------------------------------------------------------------------
  * main
  * ------------------------------------------------------------------ */
-int main(void) {
+int main(void)
+{
     printf("========================================\n");
     printf("Performance Validation Test Suite\n");
     printf("========================================\n\n");

--- a/tests/test_perf_validation.c
+++ b/tests/test_perf_validation.c
@@ -9,6 +9,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <inttypes.h>
+#include <pthread.h>
+#include <errno.h>
+#include <time.h>
 
 #include "perf/perf_validation.h"
 #include "common/common.h"
@@ -410,6 +413,102 @@ static void test_null_safety(void) {
 }
 
 /* ------------------------------------------------------------------
+ * Test 16: bench_run rollback path fails fast on pthread_create error
+ *
+ * Regression for the case where bench_run() returned the correct error
+ * code but the already-started workers ran out the configured duration
+ * (or op_count budget) before joining. The fix is a shared cancellation
+ * flag the workers consult inside their hot loop. We verify it by
+ * injecting a fake pthread_create() that succeeds for the first worker
+ * and fails for the second, then asserting bench_run() returns long
+ * before duration_s elapses.
+ * ------------------------------------------------------------------ */
+
+/* Test seam exposed by perf_validation.c (intentionally not in the
+ * public header — see the comment near g_pthread_create). */
+typedef int (*perf_pthread_create_fn)(pthread_t *, const pthread_attr_t *,
+                                       void *(*)(void *), void *);
+extern void __perf_test_set_pthread_create(perf_pthread_create_fn fn);
+
+static int g_create_calls = 0;
+static int g_create_fail_after = 0;  /* fail when calls exceed this count */
+
+static int failing_pthread_create(pthread_t *t, const pthread_attr_t *a,
+                                   void *(*start)(void *), void *arg) {
+    g_create_calls++;
+    if (g_create_calls > g_create_fail_after) {
+        return EAGAIN;
+    }
+    return pthread_create(t, a, start, arg);
+}
+
+static uint64_t test_now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)ts.tv_nsec / 1000000ULL;
+}
+
+static void test_bench_run_create_fail_fast(void) {
+    separator("bench_run pthread_create-failure rollback fails fast");
+
+    /* Duration-based config: without the cancellation flag, an
+     * already-started worker would run the full duration_s before its
+     * loop exits, defeating any rollback attempt. */
+    struct bench_cfg cfg = {
+        .workload       = BENCH_RAND_READ,
+        .block_size     = 4096,
+        .queue_depth    = 1,
+        .duration_s     = 5,        /* would block 5s without the fix */
+        .op_count       = 0,
+        .num_threads    = 4,        /* fail on the 2nd of 4 */
+        .capacity_bytes = 64ULL * 1024 * 1024,
+    };
+
+    g_create_calls = 0;
+    g_create_fail_after = 1;        /* let #1 succeed, fail #2 */
+    __perf_test_set_pthread_create(failing_pthread_create);
+
+    struct bench_result res;
+    uint64_t t0 = test_now_ms();
+    int rc = bench_run(&cfg, &res);
+    uint64_t elapsed_ms = test_now_ms() - t0;
+
+    __perf_test_set_pthread_create(NULL); /* restore real pthread_create */
+
+    TEST_ASSERT(rc != HFSSS_OK,
+                "bench_run returns error when a worker create fails");
+    TEST_ASSERT(g_create_calls == 2,
+                "bench_run attempted exactly 2 creates (1 ok + 1 fail)");
+    TEST_ASSERT(elapsed_ms < 1000,
+                "rollback fails fast (< 1s) instead of waiting out duration");
+
+    /* Sanity: also exercise count-based mode. With the old behavior the
+     * already-started worker would still drain its op_count budget. */
+    g_create_calls = 0;
+    g_create_fail_after = 0;        /* fail on the very first create */
+    __perf_test_set_pthread_create(failing_pthread_create);
+
+    struct bench_cfg cfg_count = {
+        .workload       = BENCH_RAND_READ,
+        .block_size     = 4096,
+        .queue_depth    = 1,
+        .op_count       = 1000000,  /* large budget to amplify the bug */
+        .num_threads    = 2,
+        .capacity_bytes = 64ULL * 1024 * 1024,
+    };
+    t0 = test_now_ms();
+    rc = bench_run(&cfg_count, &res);
+    elapsed_ms = test_now_ms() - t0;
+
+    __perf_test_set_pthread_create(NULL);
+
+    TEST_ASSERT(rc != HFSSS_OK,
+                "bench_run errors when first create fails");
+    TEST_ASSERT(elapsed_ms < 500,
+                "no started workers means immediate return");
+}
+
+/* ------------------------------------------------------------------
  * main
  * ------------------------------------------------------------------ */
 int main(void) {
@@ -446,6 +545,8 @@ int main(void) {
     test_report_print_no_crash();
     printf("\n");
     test_null_safety();
+    printf("\n");
+    test_bench_run_create_fail_fast();
 
     printf("\n========================================\n");
     printf("Total: %d  Passed: %d  Failed: %d\n", total, passed, failed);


### PR DESCRIPTION
## Summary

Fixes 4 pthread-related concurrency bugs flagged by Codex review (Round 3), all reproduced locally with wrapped-thread repros against current master.

Independent of PR #68 (which covers Round 2 findings + CB-004/007). This PR touches a disjoint set of files (\`ftl_worker.c\`, \`nbd_async.c\`, \`perf_validation.c\`).

## Bugs Fixed

### 1. \`ftl_mt_start()\` partial-startup deadlock
If \`pthread_create()\` fails for worker N after N-1 workers have started, the cleanup loop pushed \`IO_OP_STOP\` into each request ring and immediately called \`pthread_join()\` — but **never signaled \`request_cond\`**. Workers sleeping in \`pthread_cond_wait()\` never woke to see the stop request, so the join deadlocked.

**Fix**: Extracted a \`rollback_started_workers()\` helper that mirrors \`ftl_mt_stop()\`: push STOP, acquire \`request_lock\`, signal \`request_cond\`, release, then join.

**Bonus**: Also fixed the Round 4 companion bug where \`pthread_create()\` for the GC and WL background threads in \`ftl_mt_start()\` was unchecked. If either fails, we now unwind the previous bring-up steps cleanly: tear down GC (if it started), destroy the gc cond/mutex, and rewind all already-started workers.

### 2. \`nbd_async_start()\` CQ-failure deadlock
When CQ thread creation fails after SQ has started, the cleanup path called \`pthread_join(sq_thread)\` without first shutting down the client socket. The SQ thread stayed blocked in \`recv()\` and the join never returned.

**Fix**: Call \`shutdown(client_fd, SHUT_RD)\` before joining, matching the pattern used in \`nbd_async_stop()\`.

### 3. \`bench_run()\` ignored pthread return codes
Failing worker creation could leave \`bench_run()\` reporting \`rc=HFSSS_OK\` with inconsistent aggregated state.

**Fix**: Track per-worker \`started[]\` state, unwind on create failure (zero the \`op_count\` budget so in-flight workers exit quickly, then join), and return \`HFSSS_ERR_INVAL\` / \`HFSSS_ERR_IO\` on create / join failure respectively.

### 4. \`bench_run()\` silently dropped operations
A request of \`op_count=10, num_threads=3\` returned \`total_ops=9\` because each worker got \`(op_count / nt) = 3\` from integer division.

**Fix**: Distribute the remainder across the first \`(op_count % nt)\` workers so total ops match exactly.

## Test plan
- [x] Full clean build succeeds
- [x] \`test_mt_ftl\`: 10/10 PASS
- [x] \`test_perf_validation\`: 62/62 PASS
- [x] \`systest_data_integrity\`: 50/50 PASS
- [x] \`systest_nvme_compliance\`: 70/70 PASS
- [x] \`systest_error_boundary\`: 536/536 PASS (pre-PR-68 baseline)
- [x] \`systest_performance\`: 23/23 PASS
- [x] \`systest_persistence\`: 39/39 PASS
- [x] \`systest_wear_gc\`: 48/48 PASS
- [x] Standalone repro for bench_run divisibility returns \`total_ops=10\` for \`op_count=10, num_threads=3\` (was 9 before)
- [ ] CI validation