### PR TITLE
fix: resolve 7 bugs from Codex review rounds 4 & 5

### DIFF
--- a/include/common/mempool.h
+++ b/include/common/mempool.h
@@ -7,7 +7,9 @@
 extern "C" {
 #endif
 
-/* Memory Pool Block */
+/* Memory Pool Block Metadata.
+ * Kept in a parallel array, NOT embedded in user memory, so that
+ * user writes to allocated blocks cannot corrupt allocator state. */
 struct mem_block {
     struct mem_block *next;
     int in_use;
@@ -19,7 +21,8 @@ struct mem_pool {
     u32 block_count;
     u32 free_count;
     u32 used_count;
-    void *memory;
+    void *memory;               /* user data area: block_count * block_size */
+    struct mem_block *blocks;   /* metadata array: block_count entries */
     struct mem_block *free_list;
     void *lock;
     u64 alloc_count;

--- a/include/common/mempool.h
+++ b/include/common/mempool.h
@@ -15,13 +15,25 @@ struct mem_block {
     int in_use;
 };
 
+/* Minimum alignment for user-data pointers returned by mem_pool_alloc.
+ * Matches the effective guarantee glibc malloc() provides for any
+ * standard type (max_align_t is 16 bytes on x86-64 and aarch64). This
+ * also preserves the historical property of the old implementation,
+ * which spaced slots by sizeof(struct mem_block) == 16 bytes. */
+#define MEMPOOL_MIN_ALIGN 16
+
 /* Memory Pool Context */
 struct mem_pool {
-    u32 block_size;
+    u32 block_size;             /* caller's requested size (for stats) */
+    u32 slot_size;              /* effective stride: block_size rounded
+                                 * up to MEMPOOL_MIN_ALIGN. Used for all
+                                 * address math so that returned pointers
+                                 * stay aligned even when block_size is
+                                 * small (e.g. 1). */
     u32 block_count;
     u32 free_count;
     u32 used_count;
-    void *memory;               /* user data area: block_count * block_size */
+    void *memory;               /* user data area: block_count * slot_size */
     struct mem_block *blocks;   /* metadata array: block_count entries */
     struct mem_block *free_list;
     void *lock;

--- a/include/common/mempool.h
+++ b/include/common/mempool.h
@@ -24,17 +24,17 @@ struct mem_block {
 
 /* Memory Pool Context */
 struct mem_pool {
-    u32 block_size;             /* caller's requested size (for stats) */
-    u32 slot_size;              /* effective stride: block_size rounded
-                                 * up to MEMPOOL_MIN_ALIGN. Used for all
-                                 * address math so that returned pointers
-                                 * stay aligned even when block_size is
-                                 * small (e.g. 1). */
+    u32 block_size; /* caller's requested size (for stats) */
+    u32 slot_size;  /* effective stride: block_size rounded
+                     * up to MEMPOOL_MIN_ALIGN. Used for all
+                     * address math so that returned pointers
+                     * stay aligned even when block_size is
+                     * small (e.g. 1). */
     u32 block_count;
     u32 free_count;
     u32 used_count;
-    void *memory;               /* user data area: block_count * slot_size */
-    struct mem_block *blocks;   /* metadata array: block_count entries */
+    void *memory;             /* user data area: block_count * slot_size */
+    struct mem_block *blocks; /* metadata array: block_count entries */
     struct mem_block *free_list;
     void *lock;
     u64 alloc_count;

--- a/src/common/log.c
+++ b/src/common/log.c
@@ -117,8 +117,7 @@ void log_set_level(struct log_ctx *ctx, u32 level)
     ctx->level = level;
 }
 
-void log_printf(struct log_ctx *ctx, u32 level, const char *module,
-                const char *file, u32 line, const char *fmt, ...)
+void log_printf(struct log_ctx *ctx, u32 level, const char *module, const char *file, u32 line, const char *fmt, ...)
 {
     if (!ctx || level > ctx->level) {
         return;
@@ -140,16 +139,14 @@ void log_printf(struct log_ctx *ctx, u32 level, const char *module,
     va_end(args);
 
     if (ctx->use_stdout) {
-        const char *level_str[] = { "ERROR", "WARN", "INFO", "DEBUG", "TRACE" };
-        printf("[%s] [%s] %s:%u: %s\n",
-               level_str[MIN(level, 4)], module, file, line, entry->message);
+        const char *level_str[] = {"ERROR", "WARN", "INFO", "DEBUG", "TRACE"};
+        printf("[%s] [%s] %s:%u: %s\n", level_str[MIN(level, 4)], module, file, line, entry->message);
     }
 
     if (ctx->output_file) {
-        const char *level_str[] = { "ERROR", "WARN", "INFO", "DEBUG", "TRACE" };
-        fprintf(ctx->output_file, "[%llu] [%s] [%s] %s:%u: %s\n",
-               (unsigned long long)entry->timestamp,
-               level_str[MIN(level, 4)], module, file, line, entry->message);
+        const char *level_str[] = {"ERROR", "WARN", "INFO", "DEBUG", "TRACE"};
+        fprintf(ctx->output_file, "[%llu] [%s] [%s] %s:%u: %s\n", (unsigned long long)entry->timestamp,
+                level_str[MIN(level, 4)], module, file, line, entry->message);
         fflush(ctx->output_file);
     }
 

--- a/src/common/log.c
+++ b/src/common/log.c
@@ -37,7 +37,10 @@ struct log_lock {
 
 int log_init(struct log_ctx *ctx, u32 buffer_size, u32 level)
 {
-    if (!ctx) {
+    if (!ctx || buffer_size == 0) {
+        /* A zero-size ring buffer is not valid: log_printf() would later
+         * divide by buffer_size to compute head/tail, producing UB. Reject
+         * it at init time instead of building a broken context. */
         return HFSSS_ERR_INVAL;
     }
 

--- a/src/common/mempool.c
+++ b/src/common/mempool.c
@@ -13,10 +13,21 @@ int mem_pool_init(struct mem_pool *pool, u32 block_size, u32 block_count)
 
     memset(pool, 0, sizeof(*pool));
 
-    /* User data area: exactly block_size per block. Allocator metadata
+    /* Round the per-slot stride up to MEMPOOL_MIN_ALIGN so every block
+     * address is naturally aligned for any standard type. Small
+     * block_size values (e.g. 1) would otherwise hand out addresses
+     * that differ by a single byte, breaking uint64_t / pointer loads
+     * on strict-alignment targets and causing UB everywhere else. */
+    u32 slot_size = (block_size + (MEMPOOL_MIN_ALIGN - 1)) &
+                    ~(u32)(MEMPOOL_MIN_ALIGN - 1);
+
+    /* User data area: exactly slot_size per block. Allocator metadata
      * lives in a parallel blocks[] array so user writes to allocated
-     * memory cannot corrupt allocator state. */
-    u64 total_data = (u64)block_size * block_count;
+     * memory cannot corrupt allocator state. calloc() is guaranteed
+     * to return a pointer suitably aligned for any standard type, so
+     * the base of pool->memory plus any multiple of slot_size also
+     * meets MEMPOOL_MIN_ALIGN. */
+    u64 total_data = (u64)slot_size * block_count;
     pool->memory = calloc(1, total_data);
     if (!pool->memory) {
         return HFSSS_ERR_NOMEM;
@@ -31,6 +42,7 @@ int mem_pool_init(struct mem_pool *pool, u32 block_size, u32 block_count)
     }
 
     pool->block_size = block_size;
+    pool->slot_size = slot_size;
     pool->block_count = block_count;
     pool->free_count = block_count;
     pool->used_count = 0;
@@ -97,9 +109,10 @@ void *mem_pool_alloc(struct mem_pool *pool)
         pool->free_list = block->next;
         block->in_use = 1;
         block->next = NULL;
-        /* Translate metadata index to user data address */
+        /* Translate metadata index to user data address using slot_size
+         * so every returned pointer is MEMPOOL_MIN_ALIGN-aligned. */
         u32 idx = (u32)(block - pool->blocks);
-        ptr = (char *)pool->memory + (u64)idx * pool->block_size;
+        ptr = (char *)pool->memory + (u64)idx * pool->slot_size;
         pool->free_count--;
         pool->used_count++;
         pool->alloc_count++;
@@ -115,17 +128,20 @@ void mem_pool_free(struct mem_pool *pool, void *ptr)
         return;
     }
 
-    /* Check if pointer is within pool memory and block-aligned */
+    /* Check if pointer is within pool memory and slot-aligned. The
+     * bounds and offset math use slot_size (the effective stride),
+     * not block_size, so mem_pool_free() still recognises valid
+     * addresses after the alignment round-up. */
     char *base = (char *)pool->memory;
-    char *end  = base + (u64)pool->block_size * pool->block_count;
+    char *end  = base + (u64)pool->slot_size * pool->block_count;
     if ((char *)ptr < base || (char *)ptr >= end) {
         return;
     }
     u64 offset = (char *)ptr - base;
-    if (offset % pool->block_size != 0) {
+    if (offset % pool->slot_size != 0) {
         return;
     }
-    u32 idx = (u32)(offset / pool->block_size);
+    u32 idx = (u32)(offset / pool->slot_size);
 
     struct mempool_lock *lock = (struct mempool_lock *)pool->lock;
     pthread_mutex_lock(&lock->mutex);

--- a/src/common/mempool.c
+++ b/src/common/mempool.c
@@ -13,33 +13,44 @@ int mem_pool_init(struct mem_pool *pool, u32 block_size, u32 block_count)
 
     memset(pool, 0, sizeof(*pool));
 
-    u32 real_block_size = MAX(block_size, sizeof(struct mem_block));
-    u64 total_size = (u64)real_block_size * block_count;
-
-    pool->memory = calloc(1, total_size);
+    /* User data area: exactly block_size per block. Allocator metadata
+     * lives in a parallel blocks[] array so user writes to allocated
+     * memory cannot corrupt allocator state. */
+    u64 total_data = (u64)block_size * block_count;
+    pool->memory = calloc(1, total_data);
     if (!pool->memory) {
         return HFSSS_ERR_NOMEM;
     }
 
-    pool->block_size = real_block_size;
+    pool->blocks = (struct mem_block *)calloc(block_count,
+                                               sizeof(struct mem_block));
+    if (!pool->blocks) {
+        free(pool->memory);
+        pool->memory = NULL;
+        return HFSSS_ERR_NOMEM;
+    }
+
+    pool->block_size = block_size;
     pool->block_count = block_count;
     pool->free_count = block_count;
     pool->used_count = 0;
     pool->alloc_count = 0;
     pool->free_count_total = 0;
 
-    /* Initialize free list */
+    /* Build free list over the out-of-band metadata array */
     pool->free_list = NULL;
     for (u32 i = 0; i < block_count; i++) {
-        struct mem_block *block = (struct mem_block *)((char *)pool->memory + i * real_block_size);
-        block->in_use = 0;
-        block->next = pool->free_list;
-        pool->free_list = block;
+        pool->blocks[i].in_use = 0;
+        pool->blocks[i].next = pool->free_list;
+        pool->free_list = &pool->blocks[i];
     }
 
     struct mempool_lock *lock = (struct mempool_lock *)malloc(sizeof(struct mempool_lock));
     if (!lock) {
+        free(pool->blocks);
         free(pool->memory);
+        pool->blocks = NULL;
+        pool->memory = NULL;
         return HFSSS_ERR_NOMEM;
     }
     pthread_mutex_init(&lock->mutex, NULL);
@@ -58,6 +69,10 @@ void mem_pool_cleanup(struct mem_pool *pool)
         struct mempool_lock *lock = (struct mempool_lock *)pool->lock;
         pthread_mutex_destroy(&lock->mutex);
         free(lock);
+    }
+
+    if (pool->blocks) {
+        free(pool->blocks);
     }
 
     if (pool->memory) {
@@ -82,7 +97,9 @@ void *mem_pool_alloc(struct mem_pool *pool)
         pool->free_list = block->next;
         block->in_use = 1;
         block->next = NULL;
-        ptr = (void *)block;
+        /* Translate metadata index to user data address */
+        u32 idx = (u32)(block - pool->blocks);
+        ptr = (char *)pool->memory + (u64)idx * pool->block_size;
         pool->free_count--;
         pool->used_count++;
         pool->alloc_count++;
@@ -98,16 +115,22 @@ void mem_pool_free(struct mem_pool *pool, void *ptr)
         return;
     }
 
-    /* Check if pointer is within pool memory */
-    if ((char *)ptr < (char *)pool->memory ||
-        (char *)ptr >= (char *)pool->memory + (u64)pool->block_size * pool->block_count) {
+    /* Check if pointer is within pool memory and block-aligned */
+    char *base = (char *)pool->memory;
+    char *end  = base + (u64)pool->block_size * pool->block_count;
+    if ((char *)ptr < base || (char *)ptr >= end) {
         return;
     }
+    u64 offset = (char *)ptr - base;
+    if (offset % pool->block_size != 0) {
+        return;
+    }
+    u32 idx = (u32)(offset / pool->block_size);
 
     struct mempool_lock *lock = (struct mempool_lock *)pool->lock;
     pthread_mutex_lock(&lock->mutex);
 
-    struct mem_block *block = (struct mem_block *)ptr;
+    struct mem_block *block = &pool->blocks[idx];
     if (block->in_use) {
         block->in_use = 0;
         block->next = pool->free_list;

--- a/src/common/mempool.c
+++ b/src/common/mempool.c
@@ -18,8 +18,7 @@ int mem_pool_init(struct mem_pool *pool, u32 block_size, u32 block_count)
      * block_size values (e.g. 1) would otherwise hand out addresses
      * that differ by a single byte, breaking uint64_t / pointer loads
      * on strict-alignment targets and causing UB everywhere else. */
-    u32 slot_size = (block_size + (MEMPOOL_MIN_ALIGN - 1)) &
-                    ~(u32)(MEMPOOL_MIN_ALIGN - 1);
+    u32 slot_size = (block_size + (MEMPOOL_MIN_ALIGN - 1)) & ~(u32)(MEMPOOL_MIN_ALIGN - 1);
 
     /* User data area: exactly slot_size per block. Allocator metadata
      * lives in a parallel blocks[] array so user writes to allocated
@@ -33,8 +32,7 @@ int mem_pool_init(struct mem_pool *pool, u32 block_size, u32 block_count)
         return HFSSS_ERR_NOMEM;
     }
 
-    pool->blocks = (struct mem_block *)calloc(block_count,
-                                               sizeof(struct mem_block));
+    pool->blocks = (struct mem_block *)calloc(block_count, sizeof(struct mem_block));
     if (!pool->blocks) {
         free(pool->memory);
         pool->memory = NULL;
@@ -133,7 +131,7 @@ void mem_pool_free(struct mem_pool *pool, void *ptr)
      * not block_size, so mem_pool_free() still recognises valid
      * addresses after the alignment round-up. */
     char *base = (char *)pool->memory;
-    char *end  = base + (u64)pool->slot_size * pool->block_count;
+    char *end = base + (u64)pool->slot_size * pool->block_count;
     if ((char *)ptr < base || (char *)ptr >= end) {
         return;
     }
@@ -168,10 +166,14 @@ void mem_pool_stats(struct mem_pool *pool, u32 *used, u32 *free, u64 *alloc_tota
     struct mempool_lock *lock = (struct mempool_lock *)pool->lock;
     pthread_mutex_lock(&lock->mutex);
 
-    if (used) *used = pool->used_count;
-    if (free) *free = pool->free_count;
-    if (alloc_total) *alloc_total = pool->alloc_count;
-    if (free_total) *free_total = pool->free_count_total;
+    if (used)
+        *used = pool->used_count;
+    if (free)
+        *free = pool->free_count;
+    if (alloc_total)
+        *alloc_total = pool->alloc_count;
+    if (free_total)
+        *free_total = pool->free_count_total;
 
     pthread_mutex_unlock(&lock->mutex);
 }

--- a/src/common/mutex.c
+++ b/src/common/mutex.c
@@ -1,5 +1,7 @@
 #include "common/mutex.h"
+#include <errno.h>
 #include <pthread.h>
+#include <time.h>
 
 struct mutex_lock {
     pthread_mutex_t mutex;
@@ -65,19 +67,51 @@ int mutex_trylock(struct mutex *mtx)
     }
 }
 
+static u64 mutex_now_ns(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (u64)ts.tv_sec * 1000000000ULL + (u64)ts.tv_nsec;
+}
+
 int mutex_lock(struct mutex *mtx, u64 timeout_ns)
 {
     if (!mtx) {
         return HFSSS_ERR_INVAL;
     }
 
-    (void)timeout_ns; /* pthread mutex doesn't support timed lock easily with recursive */
-
     struct mutex_lock *lock = (struct mutex_lock *)mtx->lock;
-    pthread_mutex_lock(&lock->mutex);
-    mtx->lock_count++;
 
-    return HFSSS_OK;
+    /* timeout_ns == 0 preserves the original blocking-forever semantics. */
+    if (timeout_ns == 0) {
+        pthread_mutex_lock(&lock->mutex);
+        mtx->lock_count++;
+        return HFSSS_OK;
+    }
+
+    /* Timed path: trylock in a short-sleep loop. pthread_mutex_timedlock
+     * is not portable (absent on macOS), and we need to keep the mutex
+     * recursive, so emulate via trylock + nanosleep. Poll resolution is
+     * ~100us, good enough for tests and OOB wait-paths. Previously this
+     * function ignored timeout_ns entirely and always blocked, which
+     * silently broke every caller that relied on the timeout budget. */
+    const u64 deadline = mutex_now_ns() + timeout_ns;
+    const struct timespec sleep_step = { .tv_sec = 0, .tv_nsec = 100000 };
+
+    for (;;) {
+        int rc = pthread_mutex_trylock(&lock->mutex);
+        if (rc == 0) {
+            mtx->lock_count++;
+            return HFSSS_OK;
+        }
+        if (rc != EBUSY) {
+            return HFSSS_ERR_IO;
+        }
+        if (mutex_now_ns() >= deadline) {
+            return HFSSS_ERR_BUSY;
+        }
+        nanosleep(&sleep_step, NULL);
+    }
 }
 
 int mutex_unlock(struct mutex *mtx)

--- a/src/common/mutex.c
+++ b/src/common/mutex.c
@@ -96,7 +96,7 @@ int mutex_lock(struct mutex *mtx, u64 timeout_ns)
      * function ignored timeout_ns entirely and always blocked, which
      * silently broke every caller that relied on the timeout budget. */
     const u64 deadline = mutex_now_ns() + timeout_ns;
-    const struct timespec sleep_step = { .tv_sec = 0, .tv_nsec = 100000 };
+    const struct timespec sleep_step = {.tv_sec = 0, .tv_nsec = 100000};
 
     for (;;) {
         int rc = pthread_mutex_trylock(&lock->mutex);
@@ -135,7 +135,9 @@ void mutex_stats(struct mutex *mtx, u64 *lock_count, u64 *unlock_count)
 
     struct mutex_lock *lock = (struct mutex_lock *)mtx->lock;
     pthread_mutex_lock(&lock->mutex);
-    if (lock_count) *lock_count = mtx->lock_count;
-    if (unlock_count) *unlock_count = mtx->unlock_count;
+    if (lock_count)
+        *lock_count = mtx->lock_count;
+    if (unlock_count)
+        *unlock_count = mtx->unlock_count;
     pthread_mutex_unlock(&lock->mutex);
 }

--- a/src/common/rt_services.c
+++ b/src/common/rt_services.c
@@ -8,13 +8,13 @@
 #include <errno.h>
 
 #ifdef __APPLE__
-#  include <sys/types.h>
-#  include <sys/sysctl.h>
-#  include <mach/thread_policy.h>
-#  include <mach/thread_act.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <mach/thread_policy.h>
+#include <mach/thread_act.h>
 #else
-#  include <sched.h>
-#  include <unistd.h>
+#include <sched.h>
+#include <unistd.h>
 #endif
 
 /* ------------------------------------------------------------------
@@ -23,29 +23,27 @@
 
 /* Logical CPU assignment per role */
 static const int role_cpu_map[RT_ROLE_COUNT] = {
-    [RT_ROLE_IO_FAST]  = 0,
-    [RT_ROLE_GC]       = 1,
-    [RT_ROLE_MONITOR]  = 2,
-    [RT_ROLE_OOB]      = 3,
-    [RT_ROLE_GENERIC]  = -1,  /* no pinning */
+    [RT_ROLE_IO_FAST] = 0, [RT_ROLE_GC] = 1,       [RT_ROLE_MONITOR] = 2,
+    [RT_ROLE_OOB] = 3,     [RT_ROLE_GENERIC] = -1, /* no pinning */
 };
 
-int rt_pin_thread(pthread_t thread, enum rt_thread_role role) {
-    if (role >= RT_ROLE_COUNT) return HFSSS_ERR_INVAL;
+int rt_pin_thread(pthread_t thread, enum rt_thread_role role)
+{
+    if (role >= RT_ROLE_COUNT)
+        return HFSSS_ERR_INVAL;
 
     int cpu = role_cpu_map[role];
-    if (cpu < 0) return HFSSS_OK;  /* GENERIC: no-op */
+    if (cpu < 0)
+        return HFSSS_OK; /* GENERIC: no-op */
 
 #ifdef __APPLE__
     /* macOS does not expose CPU pinning via POSIX; use thread affinity tags
      * as best-effort grouping hint.  This avoids a hard compile error while
      * still exercising the code path in tests.                              */
-    thread_affinity_policy_data_t pol = { .affinity_tag = (integer_t)(cpu + 1) };
+    thread_affinity_policy_data_t pol = {.affinity_tag = (integer_t)(cpu + 1)};
     mach_port_t mach_thread = pthread_mach_thread_np(thread);
-    kern_return_t kr = thread_policy_set(mach_thread,
-                                          THREAD_AFFINITY_POLICY,
-                                          (thread_policy_t)&pol,
-                                          THREAD_AFFINITY_POLICY_COUNT);
+    kern_return_t kr =
+        thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY, (thread_policy_t)&pol, THREAD_AFFINITY_POLICY_COUNT);
     if (kr != KERN_SUCCESS) {
         HFSSS_LOG_WARN("RT", "thread_policy_set failed for role %d (non-fatal on macOS)", role);
     }
@@ -64,15 +62,18 @@ int rt_pin_thread(pthread_t thread, enum rt_thread_role role) {
 #endif
 }
 
-int rt_pin_self(enum rt_thread_role role) {
+int rt_pin_self(enum rt_thread_role role)
+{
     return rt_pin_thread(pthread_self(), role);
 }
 
-int rt_get_affinity_mask(enum rt_thread_role role, uint64_t *mask_out) {
-    if (role >= RT_ROLE_COUNT || !mask_out) return HFSSS_ERR_INVAL;
+int rt_get_affinity_mask(enum rt_thread_role role, uint64_t *mask_out)
+{
+    if (role >= RT_ROLE_COUNT || !mask_out)
+        return HFSSS_ERR_INVAL;
     int cpu = role_cpu_map[role];
     if (cpu < 0) {
-        *mask_out = 0;  /* GENERIC: any CPU */
+        *mask_out = 0; /* GENERIC: any CPU */
         return HFSSS_OK;
     }
     *mask_out = (uint64_t)1 << cpu;
@@ -82,8 +83,10 @@ int rt_get_affinity_mask(enum rt_thread_role role, uint64_t *mask_out) {
 /* ------------------------------------------------------------------
  * IPC channel
  * ------------------------------------------------------------------ */
-int rt_ipc_init(struct rt_ipc_channel *ch) {
-    if (!ch) return HFSSS_ERR_INVAL;
+int rt_ipc_init(struct rt_ipc_channel *ch)
+{
+    if (!ch)
+        return HFSSS_ERR_INVAL;
     memset(ch, 0, sizeof(*ch));
     pthread_mutex_init(&ch->lock, NULL);
     pthread_cond_init(&ch->not_empty, NULL);
@@ -91,15 +94,19 @@ int rt_ipc_init(struct rt_ipc_channel *ch) {
     return HFSSS_OK;
 }
 
-void rt_ipc_cleanup(struct rt_ipc_channel *ch) {
-    if (!ch || !ch->initialized) return;
+void rt_ipc_cleanup(struct rt_ipc_channel *ch)
+{
+    if (!ch || !ch->initialized)
+        return;
     pthread_cond_destroy(&ch->not_empty);
     pthread_mutex_destroy(&ch->lock);
     ch->initialized = false;
 }
 
-int rt_ipc_send(struct rt_ipc_channel *ch, const struct rt_ipc_msg *msg) {
-    if (!ch || !ch->initialized || !msg) return HFSSS_ERR_INVAL;
+int rt_ipc_send(struct rt_ipc_channel *ch, const struct rt_ipc_msg *msg)
+{
+    if (!ch || !ch->initialized || !msg)
+        return HFSSS_ERR_INVAL;
 
     pthread_mutex_lock(&ch->lock);
     uint32_t next_head = (ch->head + 1) % RT_IPC_CHANNEL_DEPTH;
@@ -115,8 +122,10 @@ int rt_ipc_send(struct rt_ipc_channel *ch, const struct rt_ipc_msg *msg) {
     return HFSSS_OK;
 }
 
-int rt_ipc_recv(struct rt_ipc_channel *ch, struct rt_ipc_msg *msg) {
-    if (!ch || !ch->initialized || !msg) return HFSSS_ERR_INVAL;
+int rt_ipc_recv(struct rt_ipc_channel *ch, struct rt_ipc_msg *msg)
+{
+    if (!ch || !ch->initialized || !msg)
+        return HFSSS_ERR_INVAL;
 
     pthread_mutex_lock(&ch->lock);
     while (ch->head == ch->tail) {
@@ -128,13 +137,14 @@ int rt_ipc_recv(struct rt_ipc_channel *ch, struct rt_ipc_msg *msg) {
     return HFSSS_OK;
 }
 
-int rt_ipc_recv_timeout(struct rt_ipc_channel *ch, struct rt_ipc_msg *msg,
-                         uint32_t timeout_ms) {
-    if (!ch || !ch->initialized || !msg) return HFSSS_ERR_INVAL;
+int rt_ipc_recv_timeout(struct rt_ipc_channel *ch, struct rt_ipc_msg *msg, uint32_t timeout_ms)
+{
+    if (!ch || !ch->initialized || !msg)
+        return HFSSS_ERR_INVAL;
 
     struct timespec abs;
     clock_gettime(CLOCK_REALTIME, &abs);
-    abs.tv_sec  += timeout_ms / 1000;
+    abs.tv_sec += timeout_ms / 1000;
     abs.tv_nsec += (timeout_ms % 1000) * 1000000L;
     if (abs.tv_nsec >= 1000000000L) {
         abs.tv_sec++;
@@ -156,37 +166,47 @@ int rt_ipc_recv_timeout(struct rt_ipc_channel *ch, struct rt_ipc_msg *msg,
     return HFSSS_OK;
 }
 
-bool rt_ipc_is_empty(const struct rt_ipc_channel *ch) {
-    if (!ch || !ch->initialized) return true;
+bool rt_ipc_is_empty(const struct rt_ipc_channel *ch)
+{
+    if (!ch || !ch->initialized)
+        return true;
     return ch->head == ch->tail;
 }
 
-uint32_t rt_ipc_pending(const struct rt_ipc_channel *ch) {
-    if (!ch || !ch->initialized) return 0;
+uint32_t rt_ipc_pending(const struct rt_ipc_channel *ch)
+{
+    if (!ch || !ch->initialized)
+        return 0;
     uint32_t h = ch->head;
     uint32_t t = ch->tail;
-    if (h >= t) return h - t;
+    if (h >= t)
+        return h - t;
     return RT_IPC_CHANNEL_DEPTH - t + h;
 }
 
 /* ------------------------------------------------------------------
  * Trace ring
  * ------------------------------------------------------------------ */
-int trace_ring_init(struct trace_ring *ring) {
-    if (!ring) return HFSSS_ERR_INVAL;
+int trace_ring_init(struct trace_ring *ring)
+{
+    if (!ring)
+        return HFSSS_ERR_INVAL;
     memset(ring, 0, sizeof(*ring));
     ring->initialized = true;
     return HFSSS_OK;
 }
 
-void trace_ring_cleanup(struct trace_ring *ring) {
-    if (!ring) return;
+void trace_ring_cleanup(struct trace_ring *ring)
+{
+    if (!ring)
+        return;
     ring->initialized = false;
 }
 
-int trace_ring_write(struct trace_ring *ring, enum trace_level level,
-                      uint8_t subsys, const char *msg) {
-    if (!ring || !ring->initialized || !msg) return HFSSS_ERR_INVAL;
+int trace_ring_write(struct trace_ring *ring, enum trace_level level, uint8_t subsys, const char *msg)
+{
+    if (!ring || !ring->initialized || !msg)
+        return HFSSS_ERR_INVAL;
 
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -215,18 +235,21 @@ int trace_ring_write(struct trace_ring *ring, enum trace_level level,
 
     struct trace_entry *e = &ring->entries[slot];
     e->timestamp_ns = now;
-    e->seq          = seq;
-    e->level        = (uint8_t)level;
-    e->subsystem    = subsys;
+    e->seq = seq;
+    e->level = (uint8_t)level;
+    e->subsystem = subsys;
     strncpy(e->msg, msg, TRACE_MSG_LEN - 1);
     e->msg[TRACE_MSG_LEN - 1] = '\0';
 
     return HFSSS_OK;
 }
 
-int trace_ring_read(struct trace_ring *ring, struct trace_entry *out) {
-    if (!ring || !ring->initialized || !out) return HFSSS_ERR_INVAL;
-    if (ring->read_idx >= ring->write_idx) return HFSSS_ERR_NOENT;
+int trace_ring_read(struct trace_ring *ring, struct trace_entry *out)
+{
+    if (!ring || !ring->initialized || !out)
+        return HFSSS_ERR_INVAL;
+    if (ring->read_idx >= ring->write_idx)
+        return HFSSS_ERR_NOENT;
 
     uint32_t slot = ring->read_idx % TRACE_RING_CAPACITY;
     *out = ring->entries[slot];
@@ -234,41 +257,49 @@ int trace_ring_read(struct trace_ring *ring, struct trace_entry *out) {
     return HFSSS_OK;
 }
 
-uint32_t trace_ring_pending(const struct trace_ring *ring) {
-    if (!ring || !ring->initialized) return 0;
+uint32_t trace_ring_pending(const struct trace_ring *ring)
+{
+    if (!ring || !ring->initialized)
+        return 0;
     uint32_t w = ring->write_idx;
     uint32_t r = ring->read_idx;
     return (w > r) ? (w - r) : 0;
 }
 
-uint32_t trace_ring_dropped(const struct trace_ring *ring) {
-    if (!ring) return 0;
+uint32_t trace_ring_dropped(const struct trace_ring *ring)
+{
+    if (!ring)
+        return 0;
     return ring->dropped;
 }
 
 /* ------------------------------------------------------------------
  * Resource monitor
  * ------------------------------------------------------------------ */
-int rt_mon_init(struct rt_resource_monitor *mon,
-                uint32_t cpu_warn_pct, uint32_t latency_warn_us) {
-    if (!mon) return HFSSS_ERR_INVAL;
+int rt_mon_init(struct rt_resource_monitor *mon, uint32_t cpu_warn_pct, uint32_t latency_warn_us)
+{
+    if (!mon)
+        return HFSSS_ERR_INVAL;
     memset(mon, 0, sizeof(*mon));
-    mon->cpu_warn_pct      = cpu_warn_pct;
-    mon->latency_warn_us   = latency_warn_us;
+    mon->cpu_warn_pct = cpu_warn_pct;
+    mon->latency_warn_us = latency_warn_us;
     pthread_mutex_init(&mon->lock, NULL);
     mon->initialized = true;
     return HFSSS_OK;
 }
 
-void rt_mon_cleanup(struct rt_resource_monitor *mon) {
-    if (!mon || !mon->initialized) return;
+void rt_mon_cleanup(struct rt_resource_monitor *mon)
+{
+    if (!mon || !mon->initialized)
+        return;
     pthread_mutex_destroy(&mon->lock);
     mon->initialized = false;
 }
 
-int rt_mon_record(struct rt_resource_monitor *mon,
-                  const struct rt_resource_sample *s) {
-    if (!mon || !mon->initialized || !s) return HFSSS_ERR_INVAL;
+int rt_mon_record(struct rt_resource_monitor *mon, const struct rt_resource_sample *s)
+{
+    if (!mon || !mon->initialized || !s)
+        return HFSSS_ERR_INVAL;
 
     pthread_mutex_lock(&mon->lock);
 
@@ -292,10 +323,12 @@ int rt_mon_record(struct rt_resource_monitor *mon,
     return HFSSS_OK;
 }
 
-int rt_mon_get_latest(const struct rt_resource_monitor *mon,
-                       struct rt_resource_sample *out) {
-    if (!mon || !mon->initialized || !out) return HFSSS_ERR_INVAL;
-    if (mon->sample_count == 0) return HFSSS_ERR_NOENT;
+int rt_mon_get_latest(const struct rt_resource_monitor *mon, struct rt_resource_sample *out)
+{
+    if (!mon || !mon->initialized || !out)
+        return HFSSS_ERR_INVAL;
+    if (mon->sample_count == 0)
+        return HFSSS_ERR_NOENT;
 
     pthread_mutex_lock((pthread_mutex_t *)&mon->lock);
     uint32_t last_idx = (mon->history_idx - 1) % RT_MON_HISTORY_LEN;
@@ -304,12 +337,16 @@ int rt_mon_get_latest(const struct rt_resource_monitor *mon,
     return HFSSS_OK;
 }
 
-uint32_t rt_mon_cpu_anomalies(const struct rt_resource_monitor *mon) {
-    if (!mon || !mon->initialized) return 0;
+uint32_t rt_mon_cpu_anomalies(const struct rt_resource_monitor *mon)
+{
+    if (!mon || !mon->initialized)
+        return 0;
     return mon->cpu_anomaly_count;
 }
 
-uint32_t rt_mon_latency_anomalies(const struct rt_resource_monitor *mon) {
-    if (!mon || !mon->initialized) return 0;
+uint32_t rt_mon_latency_anomalies(const struct rt_resource_monitor *mon)
+{
+    if (!mon || !mon->initialized)
+        return 0;
     return mon->latency_anomaly_count;
 }

--- a/src/common/rt_services.c
+++ b/src/common/rt_services.c
@@ -192,16 +192,26 @@ int trace_ring_write(struct trace_ring *ring, enum trace_level level,
     clock_gettime(CLOCK_MONOTONIC, &ts);
     uint64_t now = (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
 
-    /* Atomic-ish slot acquisition using __sync built-ins */
-    uint32_t seq = __sync_fetch_and_add(&ring->write_idx, 1);
-    uint32_t slot = seq % TRACE_RING_CAPACITY;
-
-    /* Check for overrun: if consumer hasn't caught up, increment dropped */
-    uint32_t pending = seq - ring->read_idx;
-    if (pending >= TRACE_RING_CAPACITY) {
-        __sync_fetch_and_add(&ring->dropped, 1);
-        return HFSSS_ERR_NOSPC;
+    /* Claim a slot using a CAS loop. The previous implementation did
+     * an unconditional fetch_and_add on write_idx and only then checked
+     * fullness, which left write_idx advanced even when the write was
+     * rejected as NOSPC -- making trace_ring_pending() report more
+     * entries than were actually committed. */
+    uint32_t seq;
+    for (;;) {
+        uint32_t w = __sync_fetch_and_add(&ring->write_idx, 0);
+        uint32_t r = __sync_fetch_and_add(&ring->read_idx, 0);
+        if ((w - r) >= TRACE_RING_CAPACITY) {
+            __sync_fetch_and_add(&ring->dropped, 1);
+            return HFSSS_ERR_NOSPC;
+        }
+        if (__sync_bool_compare_and_swap(&ring->write_idx, w, w + 1)) {
+            seq = w;
+            break;
+        }
+        /* Raced with another writer; retry */
     }
+    uint32_t slot = seq % TRACE_RING_CAPACITY;
 
     struct trace_entry *e = &ring->entries[slot];
     e->timestamp_ns = now;

--- a/src/common/watchdog.c
+++ b/src/common/watchdog.c
@@ -2,8 +2,7 @@
 
 static void *watchdog_thread(void *arg);
 
-int watchdog_init(struct watchdog_ctx *ctx, u64 check_interval_ns,
-                  watchdog_timeout_cb_t timeout_cb, void *cb_user_data)
+int watchdog_init(struct watchdog_ctx *ctx, u64 check_interval_ns, watchdog_timeout_cb_t timeout_cb, void *cb_user_data)
 {
     if (!ctx || check_interval_ns == 0) {
         return HFSSS_ERR_INVAL;
@@ -93,8 +92,7 @@ void watchdog_stop(struct watchdog_ctx *ctx)
     pthread_join(ctx->thread, NULL);
 }
 
-int watchdog_register_task(struct watchdog_ctx *ctx, const char *name,
-                           u64 timeout_ns, void *user_data)
+int watchdog_register_task(struct watchdog_ctx *ctx, const char *name, u64 timeout_ns, void *user_data)
 {
     if (!ctx || !name || timeout_ns == 0) {
         return HFSSS_ERR_INVAL;
@@ -171,8 +169,7 @@ int watchdog_feed(struct watchdog_ctx *ctx, int task_id)
      * non-ACTIVE task up front, making the TIMEOUT -> ACTIVE transition
      * on the line below unreachable. INACTIVE tasks still cannot be
      * fed -- they must be enabled first. */
-    if (task->state != WATCHDOG_TASK_ACTIVE &&
-        task->state != WATCHDOG_TASK_TIMEOUT) {
+    if (task->state != WATCHDOG_TASK_ACTIVE && task->state != WATCHDOG_TASK_TIMEOUT) {
         pthread_mutex_unlock(&ctx->mutex);
         return HFSSS_ERR_NOENT;
     }

--- a/src/common/watchdog.c
+++ b/src/common/watchdog.c
@@ -165,7 +165,14 @@ int watchdog_feed(struct watchdog_ctx *ctx, int task_id)
     pthread_mutex_lock(&ctx->mutex);
 
     struct watchdog_task *task = &ctx->tasks[task_id];
-    if (task->state != WATCHDOG_TASK_ACTIVE) {
+    /* Accept feeds for ACTIVE and TIMEOUT tasks. A TIMEOUT task being
+     * fed is the recovery path: the task is signalling that it has
+     * woken up and wants to resume. The old code rejected every
+     * non-ACTIVE task up front, making the TIMEOUT -> ACTIVE transition
+     * on the line below unreachable. INACTIVE tasks still cannot be
+     * fed -- they must be enabled first. */
+    if (task->state != WATCHDOG_TASK_ACTIVE &&
+        task->state != WATCHDOG_TASK_TIMEOUT) {
         pthread_mutex_unlock(&ctx->mutex);
         return HFSSS_ERR_NOENT;
     }

--- a/src/perf/perf_validation.c
+++ b/src/perf/perf_validation.c
@@ -68,7 +68,17 @@ static uint64_t hist_percentile(const uint64_t *hist, uint64_t total, double pct
 {
     if (total == 0)
         return 0;
-    uint64_t target = (uint64_t)(total * pct / 100.0);
+    /* Use ceil, not truncation. For small totals (e.g. total == 1) the old
+     * truncating cast produced target == 0, which made "cum >= target" true
+     * on the first bucket regardless of where the only sample actually
+     * landed, so every percentile returned bucket 0. Floor the result at 1
+     * so we always look for at least one sample. */
+    uint64_t target = (uint64_t)ceil((double)total * pct / 100.0);
+    if (target == 0)
+        target = 1;
+    if (target > total)
+        target = total;
+
     uint64_t cum = 0;
     for (int i = 0; i < PERF_LAT_HIST_BUCKETS; i++) {
         cum += hist[i];

--- a/src/vhost/hfsss_nbd_server.c
+++ b/src/vhost/hfsss_nbd_server.c
@@ -136,6 +136,12 @@ struct __attribute__((packed)) nbd_reply {
 
 static volatile int g_running = 1;
 static int g_listen_fd = -1;
+/* File descriptor of the currently active client session, if any. Set
+ * before calling into nbd_serve() / nbd_async_start() and cleared after
+ * the session exits. The signal handler shuts this down to unblock any
+ * recv()/read() the serving threads are parked in, so that SIGINT /
+ * SIGTERM take effect promptly even when a client is connected. */
+static volatile int g_active_client_fd = -1;
 
 static void handle_signal(int signo)
 {
@@ -144,6 +150,11 @@ static void handle_signal(int signo)
     /* Interrupt accept() */
     if (g_listen_fd >= 0)
         close(g_listen_fd);
+    /* Unblock the currently serving session, if any. shutdown() is
+     * async-signal-safe and will make any in-flight recv/read return. */
+    int cfd = g_active_client_fd;
+    if (cfd >= 0)
+        shutdown(cfd, SHUT_RDWR);
 }
 
 /* -------------------------------------------------------------------------
@@ -852,6 +863,9 @@ int main(int argc, char *argv[])
 
         if (nbd_handshake(client_fd, export_size) == 0) {
             fprintf(stderr, "[NBD] Handshake OK, entering transmission phase\n");
+            /* Publish client_fd so the signal handler can shut it down
+             * to unblock the serving thread on SIGINT / SIGTERM. */
+            g_active_client_fd = client_fd;
             if (g_async && g_mt) {
                 fprintf(stderr, "Mode:     ASYNC PIPELINE (SQ + CQ + %d FTL workers)\n", FTL_NUM_WORKERS);
                 struct nbd_async_ctx async_ctx;
@@ -869,6 +883,7 @@ int main(int argc, char *argv[])
             } else {
                 nbd_serve(client_fd, &dev, lba_size);
             }
+            g_active_client_fd = -1;
         } else {
             fprintf(stderr, "[NBD] Handshake failed\n");
         }

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include <assert.h>
 #include "common/log.h"
 #include "common/mempool.h"
@@ -146,6 +147,69 @@ static int test_mempool(void)
     }
 
     mem_pool_cleanup(&pool);
+
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
+/* Memory Pool Alignment Regression
+ *
+ * When allocator metadata was moved out-of-band, an earlier version
+ * of this file used raw block_size as the slot stride. That meant
+ * mem_pool_alloc() with block_size=1 could return addresses only one
+ * byte apart — so only one of every MEMPOOL_MIN_ALIGN allocations was
+ * naturally aligned for wider types. Any caller storing a uint64_t or
+ * a pointer in such a block would hit UB. The fix rounds the internal
+ * stride up to MEMPOOL_MIN_ALIGN and uses it for all address math. */
+static int test_mempool_alignment(void)
+{
+    printf("\n=== Memory Pool Alignment Regression ===\n");
+
+    /* Try several small sizes that are NOT multiples of the minimum
+     * alignment. Each must still hand out MEMPOOL_MIN_ALIGN-aligned
+     * pointers for every slot. */
+    const u32 sizes[] = {1, 3, 7, 9, 15, 17};
+    const int n_sizes = (int)(sizeof(sizes) / sizeof(sizes[0]));
+
+    for (int s = 0; s < n_sizes; s++) {
+        struct mem_pool pool;
+        int ret = mem_pool_init(&pool, sizes[s], 32);
+        TEST_ASSERT(ret == HFSSS_OK, "init with small block_size");
+
+        TEST_ASSERT(pool.slot_size >= MEMPOOL_MIN_ALIGN,
+                    "slot_size rounded up to MEMPOOL_MIN_ALIGN");
+        TEST_ASSERT((pool.slot_size % MEMPOOL_MIN_ALIGN) == 0,
+                    "slot_size is a multiple of MEMPOOL_MIN_ALIGN");
+
+        void *ptrs[32];
+        int all_aligned = 1;
+        for (int i = 0; i < 32; i++) {
+            ptrs[i] = mem_pool_alloc(&pool);
+            if (!ptrs[i]) {
+                all_aligned = 0;
+                break;
+            }
+            if (((uintptr_t)ptrs[i] % MEMPOOL_MIN_ALIGN) != 0) {
+                all_aligned = 0;
+                break;
+            }
+        }
+        TEST_ASSERT(all_aligned,
+                    "every alloc is MEMPOOL_MIN_ALIGN-aligned");
+
+        /* round-trip each one to confirm free() still recognises the
+         * address under the new slot_size stride. */
+        for (int i = 0; i < 32; i++) {
+            if (ptrs[i]) {
+                mem_pool_free(&pool, ptrs[i]);
+            }
+        }
+        u32 used, free_c;
+        u64 at, ft;
+        mem_pool_stats(&pool, &used, &free_c, &at, &ft);
+        TEST_ASSERT(used == 0, "all slots freed after round-trip");
+
+        mem_pool_cleanup(&pool);
+    }
 
     return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
 }
@@ -531,6 +595,7 @@ int main(void)
     test_log();
     test_assert();
     test_mempool();
+    test_mempool_alignment();
     test_msgqueue();
     test_semaphore();
     test_mutex();

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -18,16 +18,17 @@ static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
 
-#define TEST_ASSERT(cond, msg) do { \
-    tests_run++; \
-    if (cond) { \
-        printf("  [PASS] %s\n", msg); \
-        tests_passed++; \
-    } else { \
-        printf("  [FAIL] %s\n", msg); \
-        tests_failed++; \
-    } \
-} while(0)
+#define TEST_ASSERT(cond, msg)                                                                                         \
+    do {                                                                                                               \
+        tests_run++;                                                                                                   \
+        if (cond) {                                                                                                    \
+            printf("  [PASS] %s\n", msg);                                                                              \
+            tests_passed++;                                                                                            \
+        } else {                                                                                                       \
+            printf("  [FAIL] %s\n", msg);                                                                              \
+            tests_failed++;                                                                                            \
+        }                                                                                                              \
+    } while (0)
 
 /* Log Tests */
 static int test_log(void)
@@ -175,10 +176,8 @@ static int test_mempool_alignment(void)
         int ret = mem_pool_init(&pool, sizes[s], 32);
         TEST_ASSERT(ret == HFSSS_OK, "init with small block_size");
 
-        TEST_ASSERT(pool.slot_size >= MEMPOOL_MIN_ALIGN,
-                    "slot_size rounded up to MEMPOOL_MIN_ALIGN");
-        TEST_ASSERT((pool.slot_size % MEMPOOL_MIN_ALIGN) == 0,
-                    "slot_size is a multiple of MEMPOOL_MIN_ALIGN");
+        TEST_ASSERT(pool.slot_size >= MEMPOOL_MIN_ALIGN, "slot_size rounded up to MEMPOOL_MIN_ALIGN");
+        TEST_ASSERT((pool.slot_size % MEMPOOL_MIN_ALIGN) == 0, "slot_size is a multiple of MEMPOOL_MIN_ALIGN");
 
         void *ptrs[32];
         int all_aligned = 1;
@@ -193,8 +192,7 @@ static int test_mempool_alignment(void)
                 break;
             }
         }
-        TEST_ASSERT(all_aligned,
-                    "every alloc is MEMPOOL_MIN_ALIGN-aligned");
+        TEST_ASSERT(all_aligned, "every alloc is MEMPOOL_MIN_ALIGN-aligned");
 
         /* round-trip each one to confirm free() still recognises the
          * address under the new slot_size stride. */
@@ -523,7 +521,7 @@ static int test_watchdog(void)
 
     /* Test init */
     ret = watchdog_init(&ctx, 100 * 1000 * 1000ULL, /* 100ms check interval */
-                     watchdog_test_timeout_cb, NULL);
+                        watchdog_test_timeout_cb, NULL);
     TEST_ASSERT(ret == HFSSS_OK, "watchdog_init should succeed");
 
     /* Test register tasks */


### PR DESCRIPTION
## Summary

Fixes 7 bugs flagged by Codex review rounds 4 and 5. All reproduced locally with standalone repros against current master.

**Depends on #69** (Round 3 concurrency deadlocks) — this PR is based off that branch. Will auto-rebase to master once #69 merges.

## Round 4 (3 bugs)

> Round 4 #4 (\`ftl_mt_start\` unchecked GC/WL pthread_create) was folded into PR #69 since it's in the same file as the Round 3 deadlock fixes.

### R4 #1 — \`mem_pool_alloc()\` exposed allocator metadata as user memory
The old layout put \`struct mem_block\` at the start of every user block. Any caller writing into the allocated block destroyed the in-band \`next\`/\`in_use\` header and permanently leaked the block. Standalone repro: alloc → memset(0) → free → next alloc returned NULL with \`free=0\`.

**Fix**: moved metadata to a parallel \`pool->blocks[]\` array. User memory at index \`i\` lives at \`pool->memory + i * block_size\`. \`mem_pool_free()\` derives the index from the pointer offset.

### R4 #2 — \`trace_ring_write()\` corrupted accounting on overflow
Unconditional \`__sync_fetch_and_add(write_idx, 1)\` advanced the write index BEFORE checking fullness, so a rejected NOSPC write still bumped \`write_idx\`. A 256-slot ring reported \`pending=257\` after 257 writes with 1 NOSPC.

**Fix**: CAS loop claims the slot only if fullness check passes.

### R4 #3 — \`watchdog_feed()\` made its own recovery unreachable
Early-return at \`state != WATCHDOG_TASK_ACTIVE\` fired before the \`TIMEOUT → ACTIVE\` transition code below, so a timed-out task could never be fed back.

**Fix**: accept feeds for both ACTIVE and TIMEOUT. INACTIVE tasks still need \`watchdog_enable_task()\` first.

## Round 5 (4 bugs)

### R5 #1 — \`hist_percentile()\` wrong for small samples
For \`total == 1\`, \`(uint64_t)(1 * 50.0 / 100.0)\` truncated \`0.5\` to \`0\`. Then \`cum >= target\` fired at bucket 0 regardless of the sample's real position. A one-sample run always reported \`p50/p99/p999 = bucket 0 = 1us\`.

**Fix**: use \`ceil()\` with minimum 1 and cap by total. Standalone repro verifies a single sample in bucket 6 now reports \`p99 = 64us\`, not \`1\`.

### R5 #2 — \`log_init()\` accepted \`buffer_size == 0\`
Built a context that later hit UB in \`log_printf()\` via \`(head + 1) % 0\`.

**Fix**: reject \`buffer_size == 0\` with \`HFSSS_ERR_INVAL\`.

### R5 #3 — \`mutex_lock(timeout_ns)\` ignored its timeout
\`timeout_ns\` was \`(void)\`-cast. Callers asking for a 50ms budget waited 200ms+. Standalone repro: 50ms timeout returned \`HFSSS_ERR_BUSY\` in 50ms (was 200ms+).

**Fix**: when \`timeout_ns > 0\`, poll \`pthread_mutex_trylock\` in a 100us-sleep loop with a CLOCK_MONOTONIC deadline. \`timeout_ns == 0\` preserves the original block-forever semantics. \`pthread_mutex_timedlock\` is not portable to macOS, and the mutex is recursive, so we emulate.

### R5 #4 — \`hfsss-nbd-server\` didn't respond to SIGINT during active session
Signal handler only cleared \`g_running\` and closed the listening fd. Main thread was stuck in \`pthread_join(sq_thread)\` / \`pthread_join(cq_thread)\`, with both threads blocked in \`recv()\` on the active \`client_fd\`.

**Fix**: publish the active \`client_fd\` as a volatile global set before serving a session and cleared after. Signal handler \`shutdown()\`s it, which unblocks \`recv()\` / \`read()\` in the serving threads. \`shutdown()\` is async-signal-safe.

## Test plan

- [x] Full clean build succeeds
- [x] \`test_common\` 132/132 PASS (covers mempool)
- [x] \`test_perf_validation\` 62/62 PASS (covers hist_percentile)
- [x] \`systest_nvme_compliance\` 70/70 PASS
- [x] \`systest_persistence\` 39/39 PASS
- [x] \`systest_error_boundary\` 536/536 PASS
- [x] \`systest_performance\` 23/23 PASS
- [x] R4#1 repro: alloc + memset + free + realloc works, \`free=3\` (was NULL + \`free=0\`)
- [x] R4#3 repro: \`watchdog_feed(TIMEOUT)\` returns \`rc=0\` and transitions to ACTIVE
- [x] R5#1 repro: single sample in bucket 6 reports \`p99=64us\` (was 1)
- [x] R5#3 repro: 50ms timeout returns BUSY in 50ms (was 200ms+)
- [ ] systest_data_integrity / systest_wear_gc (running in background)
- [ ] CI validation