### PR TITLE
feat: NAND command engine phase 2 foundational standard commands

### DIFF
--- a/include/media/cmd_engine.h
+++ b/include/media/cmd_engine.h
@@ -3,6 +3,7 @@
 
 #include "common/common.h"
 #include "media/cmd_state.h"
+#include "media/nand_identity.h"
 
 struct nand_device;
 struct eat_ctx;
@@ -35,6 +36,28 @@ int nand_cmd_engine_submit_reset(struct nand_device *dev, const struct nand_cmd_
 
 int nand_cmd_engine_snapshot(struct nand_device *dev, const struct nand_cmd_target *target,
                              struct nand_die_cmd_state *out);
+
+/*
+ * Status submission paths. Both take only the die-level lock so they remain
+ * observable mid-flight; neither touches the channel lock or the cmd_state
+ * begin/advance path.
+ */
+int nand_cmd_engine_submit_read_status(struct nand_device *dev, const struct nand_cmd_target *target,
+                                       u8 *out_status_byte);
+
+int nand_cmd_engine_submit_read_status_enhanced(struct nand_device *dev, const struct nand_cmd_target *target,
+                                                struct nand_status_enhanced *out);
+
+/*
+ * Identity submission paths. Both take the full channel+die lock order and
+ * are legal only from DIE_IDLE or the suspend states (non-conflicting reads).
+ * Current phase skips EAT advancement for these bus-bound operations — see
+ * engine_submit_identity in cmd_engine.c.
+ */
+int nand_cmd_engine_submit_read_id(struct nand_device *dev, const struct nand_cmd_target *target, struct nand_id *out);
+
+int nand_cmd_engine_submit_read_param_page(struct nand_device *dev, const struct nand_cmd_target *target,
+                                           struct nand_parameter_page *out);
 
 /*
  * Stage-budget split. Kept in its own translation unit so the partition

--- a/include/media/cmd_state.h
+++ b/include/media/cmd_state.h
@@ -32,7 +32,17 @@ enum nand_cmd_phase {
  * Engine-level opcode enum. Distinct from the hardware-facing enum nand_cmd
  * in nand.h which encodes raw NAND command bytes.
  */
-enum nand_cmd_opcode { NAND_OP_READ = 0, NAND_OP_PROG, NAND_OP_ERASE, NAND_OP_RESET, NAND_OP_COUNT };
+enum nand_cmd_opcode {
+    NAND_OP_READ = 0,
+    NAND_OP_PROG,
+    NAND_OP_ERASE,
+    NAND_OP_RESET,
+    NAND_OP_READ_STATUS,
+    NAND_OP_READ_STATUS_ENHANCED,
+    NAND_OP_READ_ID,
+    NAND_OP_READ_PARAM_PAGE,
+    NAND_OP_COUNT
+};
 
 struct nand_cmd_target {
     u32 ch;
@@ -56,6 +66,13 @@ struct nand_die_cmd_state {
     u64 last_suspend_ts_ns;
     int result_status;
     bool in_flight;
+    /*
+     * Sticky FAIL latch per ONFI 4.2 Status Register semantics: set when the
+     * most recent PROG/ERASE completes with an error; cleared only by the next
+     * successful PROG/ERASE completion or by RESET. Read-class and identity
+     * operations must not disturb it.
+     */
+    bool latched_fail;
 };
 
 void nand_cmd_state_init(struct nand_die_cmd_state *s);

--- a/include/media/media.h
+++ b/include/media/media.h
@@ -4,6 +4,7 @@
 #include "common/common.h"
 #include "common/mutex.h"
 #include "media/nand.h"
+#include "media/nand_identity.h"
 #include "media/timing.h"
 #include "media/eat.h"
 #include "media/reliability.h"
@@ -60,6 +61,10 @@ int media_nand_program(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 pla
                        const void *data, const void *spare);
 int media_nand_erase(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block);
 int media_nand_read_status(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_die_cmd_state *out);
+int media_nand_read_status_byte(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u8 *out);
+int media_nand_read_status_enhanced(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_status_enhanced *out);
+int media_nand_read_id(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_id *out);
+int media_nand_read_parameter_page(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_parameter_page *out);
 int media_nand_is_bad_block(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block);
 int media_nand_mark_bad_block(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block);
 u32 media_nand_get_erase_count(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block);

--- a/include/media/nand.h
+++ b/include/media/nand.h
@@ -5,6 +5,7 @@
 #include "common/mutex.h"
 #include "media/cmd_state.h"
 #include "media/eat.h"
+#include "media/nand_identity.h"
 #include "media/timing.h"
 
 #define MAX_BLOCKS_PER_PLANE 4096
@@ -102,6 +103,8 @@ struct nand_device {
     u32 channel_count;
     struct timing_model *timing;
     struct eat_ctx *eat;
+    struct nand_id nand_id;
+    struct nand_parameter_page param_page;
 };
 
 /* Function Prototypes */

--- a/include/media/nand_identity.h
+++ b/include/media/nand_identity.h
@@ -1,0 +1,146 @@
+#ifndef __HFSSS_NAND_IDENTITY_H
+#define __HFSSS_NAND_IDENTITY_H
+
+#include "common/common.h"
+#include "media/cmd_state.h"
+
+struct media_config;
+struct nand_device;
+struct nand_die_cmd_state;
+
+/*
+ * 8-byte NAND ID. Bytes [0..4] follow ONFI 4.2 Table 37 "Read ID Parameters".
+ * Bytes [5..7] are reserved for Toggle-extended fields and stay zero in the
+ * current phase.
+ *
+ * Byte 0: manufacturer code (simulator pseudo-vendor)
+ * Byte 1: device code derived from nand_type + geometry
+ * Byte 2: [7:6] chip_number | [5:4] cell_type | [3:2] simultaneous_pages |
+ *         [1] interleave_support | [0] cache_support
+ * Byte 3: [7:6] page_size | [5:4] spare_ratio | [3:2] reserved | [1:0] block_size
+ * Byte 4: [7:6] plane_number | [5:3] plane_size | [2:0] reserved
+ * Bytes 5..7: 0x00 (Toggle-extended reserved)
+ */
+struct nand_id {
+    u8 bytes[8];
+};
+
+#define NAND_ID_MFR_SIMULATOR 0xFE
+
+/*
+ * ONFI 4.2 cell type encoding, Table 37 byte 2 bits [5:4].
+ */
+#define NAND_ID_CELL_TYPE_SLC 0x0
+#define NAND_ID_CELL_TYPE_MLC 0x1
+#define NAND_ID_CELL_TYPE_TLC 0x2
+#define NAND_ID_CELL_TYPE_QLC 0x3
+
+/*
+ * Parameter page minimum contract from NAND/media design section
+ * "Read Parameter Page Minimum Contract". Fields outside this minimum are
+ * intentionally omitted in the current phase.
+ *
+ * The leading revision/size_bytes pair lets callers detect struct growth in
+ * later phases without an ABI break.
+ */
+#define NAND_PARAMETER_PAGE_REVISION 1
+#define NAND_PARAMETER_PAGE_MFR_NAME_LEN 12
+#define NAND_PARAMETER_PAGE_MODEL_LEN 20
+
+struct nand_parameter_page {
+    u16 revision;
+    u16 size_bytes;
+
+    /* Identity */
+    u8 manufacturer_id;
+    u8 device_id;
+    char manufacturer_name[NAND_PARAMETER_PAGE_MFR_NAME_LEN];
+    char device_model[NAND_PARAMETER_PAGE_MODEL_LEN];
+
+    /* Geometry */
+    u32 bytes_per_page;
+    u16 spare_bytes_per_page;
+    u32 pages_per_block;
+    u32 blocks_per_lun;
+    u8 luns_per_ce;
+    u8 planes_per_die;
+    u8 bits_per_cell;
+
+    /* Addressing */
+    u8 addr_cycles_row;
+    u8 addr_cycles_col;
+
+    /* ECC advertisement */
+    u16 ecc_bits_required;
+    u16 ecc_codeword_size;
+
+    /* Supported command bitmap — bit index matches enum nand_cmd_opcode */
+    u32 supported_cmd_bitmap;
+
+    /* Timing advertisement */
+    u64 tR_ns;
+    u64 tPROG_ns;
+    u64 tBERS_ns;
+
+    /* Integrity */
+    u16 crc;
+    u8 reserved[8];
+};
+
+/*
+ * Classic 1-byte status register. Bit layout matches ONFI 4.2 Status Register:
+ *   bit 0 = FAIL   (last PROG/ERASE failed when set)
+ *   bit 1 = FAILC  (cache/previous op failed)
+ *   bit 5 = ARDY   (array ready; 1 = array not busy)
+ *   bit 6 = RDY    (device ready; 1 = ready for next command)
+ *   bit 7 = WP_N   (write protect not asserted; 1 = writable)
+ */
+struct nand_status_byte {
+    u8 value;
+};
+
+#define NAND_STATUS_FAIL (1u << 0)
+#define NAND_STATUS_FAILC (1u << 1)
+#define NAND_STATUS_ARDY (1u << 5)
+#define NAND_STATUS_RDY (1u << 6)
+#define NAND_STATUS_WP_N (1u << 7)
+
+/*
+ * Decoded structured status. Pure projection of a nand_die_cmd_state snapshot
+ * plus the classic status byte. No hidden locking.
+ */
+struct nand_status_enhanced {
+    bool ready;
+    bool array_ready;
+    bool write_protect_off;
+    bool last_op_failed;
+    bool suspended_program;
+    bool suspended_erase;
+    bool resetting;
+
+    enum nand_die_state state;
+    enum nand_cmd_phase phase;
+    enum nand_cmd_opcode last_opcode;
+    u32 suspend_count;
+    u64 start_ts_ns;
+    u64 phase_start_ts_ns;
+    u64 total_budget_ns;
+    u64 remaining_ns;
+    int result_status;
+
+    u8 classic_status;
+};
+
+/*
+ * Build the device-level identity and parameter page from the active config.
+ * Pure function; performs no locking, no allocation, no I/O.
+ */
+void nand_identity_build_from_config(struct nand_device *dev, const struct media_config *cfg);
+
+/*
+ * Decode helpers over a previously taken snapshot. Safe to call without locks.
+ */
+void nand_status_byte_from_cmd_state(const struct nand_die_cmd_state *s, u8 *out);
+void nand_status_enhanced_from_cmd_state(const struct nand_die_cmd_state *s, struct nand_status_enhanced *out);
+
+#endif /* __HFSSS_NAND_IDENTITY_H */

--- a/src/media/cmd_engine.c
+++ b/src/media/cmd_engine.c
@@ -106,8 +106,16 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         return HFSSS_ERR_INVAL;
     }
 
-    /* Channel-level serialization is the first-order command submission
-     * boundary in early phases; per-die work is gated underneath it. */
+    /*
+     * Channel-level serialization is the first-order command submission
+     * boundary in early phases; per-die work is gated underneath it. The
+     * die_lock is held only across the short cmd_state transactional
+     * updates (begin, each advance_phase, completion) so a concurrent
+     * status reader can take a coherent snapshot while the command is
+     * busy-waiting or running its commit hook — satisfying the
+     * "status observable concurrently with in-flight command" contract
+     * in the design spec concurrency section.
+     */
     mutex_lock(&channel->lock, 0);
     mutex_lock(&die->die_lock, 0);
 
@@ -117,12 +125,12 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         return HFSSS_ERR_BUSY;
     }
 
-    enum op_type eat_op = op_to_eat_op(op);
-
-    engine_wait_until_available(dev->eat, eat_op, target->ch, target->chip, target->die, plane);
-
     u64 total_ns = engine_total_budget(dev->timing, op, target->page);
     nand_cmd_state_begin(&die->cmd_state, op, target, total_ns);
+    mutex_unlock(&die->die_lock);
+
+    enum op_type eat_op = op_to_eat_op(op);
+    engine_wait_until_available(dev->eat, eat_op, target->ch, target->chip, target->die, plane);
 
     u64 setup_ns = 0;
     u64 array_ns = 0;
@@ -146,8 +154,10 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
      * caller-visible completion boundary is reached at the start of the
      * array mutation, matching the legacy eat-before-memcpy ordering. */
     if (stage_rc == HFSSS_OK) {
+        mutex_lock(&die->die_lock, 0);
         enum nand_die_state next_array_state = nand_cmd_next_state_on_complete(die->cmd_state.state, op);
         nand_cmd_state_advance_phase(&die->cmd_state, CMD_PHASE_ARRAY_BUSY, next_array_state);
+        mutex_unlock(&die->die_lock);
         eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, array_ns);
         if (ops && ops->on_array_commit) {
             stage_rc = ops->on_array_commit(cb_ctx);
@@ -158,8 +168,10 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
      * transition is wired so future opcodes can plug in without engine
      * changes. */
     if (stage_rc == HFSSS_OK && op == NAND_OP_READ) {
+        mutex_lock(&die->die_lock, 0);
         enum nand_die_state next_xfer_state = nand_cmd_next_state_on_complete(die->cmd_state.state, op);
         nand_cmd_state_advance_phase(&die->cmd_state, CMD_PHASE_DATA_XFER, next_xfer_state);
+        mutex_unlock(&die->die_lock);
         eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, xfer_ns);
         if (ops && ops->on_data_xfer_commit) {
             stage_rc = ops->on_data_xfer_commit(cb_ctx);
@@ -167,13 +179,19 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
     }
 
     /* Drive the die back to IDLE regardless of commit status so a failed
-     * hook does not strand the die. */
+     * hook does not strand the die. PROG/ERASE completions update the
+     * ONFI sticky FAIL latch: a successful completion clears the latch,
+     * a failed completion sets it; any intervening READ or identity op
+     * must not touch it (spec "Suspend/Resume Semantics" status layer). */
+    mutex_lock(&die->die_lock, 0);
     die->cmd_state.result_status = stage_rc;
     die->cmd_state.in_flight = false;
     die->cmd_state.phase = CMD_PHASE_COMPLETE;
     die->cmd_state.state = DIE_IDLE;
     die->cmd_state.remaining_ns = 0;
-
+    if (op == NAND_OP_PROG || op == NAND_OP_ERASE) {
+        die->cmd_state.latched_fail = (stage_rc != HFSSS_OK);
+    }
     mutex_unlock(&die->die_lock);
     mutex_unlock(&channel->lock);
     return stage_rc;
@@ -252,6 +270,8 @@ int nand_cmd_engine_submit_reset(struct nand_device *dev, const struct nand_cmd_
     die->cmd_state.in_flight = false;
     die->cmd_state.remaining_ns = 0;
     die->cmd_state.result_status = HFSSS_OK;
+    /* ONFI 4.2: RESET clears the sticky FAIL latch. */
+    die->cmd_state.latched_fail = false;
 
     mutex_unlock(&die->die_lock);
     mutex_unlock(&channel->lock);
@@ -274,4 +294,133 @@ int nand_cmd_engine_snapshot(struct nand_device *dev, const struct nand_cmd_targ
     nand_cmd_state_snapshot(&die->cmd_state, out);
     mutex_unlock(&die->die_lock);
     return HFSSS_OK;
+}
+
+/*
+ * Lightweight status path. LOCKING: die_lock only — the channel lock is
+ * deliberately skipped so a status read never blocks on an in-flight command.
+ * A snapshot is taken under the die lock, then decoded on the caller's stack.
+ */
+static int engine_submit_status_byte(struct nand_device *dev, const struct nand_cmd_target *target, u8 *out_byte)
+{
+    if (!dev || !target || !out_byte) {
+        return HFSSS_ERR_INVAL;
+    }
+    struct nand_die *die = engine_get_die(dev, target->ch, target->chip, target->die);
+    if (!die) {
+        return HFSSS_ERR_INVAL;
+    }
+
+    struct nand_die_cmd_state snap;
+    mutex_lock(&die->die_lock, 0);
+    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, NAND_OP_READ_STATUS)) {
+        mutex_unlock(&die->die_lock);
+        return HFSSS_ERR_BUSY;
+    }
+    nand_cmd_state_snapshot(&die->cmd_state, &snap);
+    mutex_unlock(&die->die_lock);
+
+    nand_status_byte_from_cmd_state(&snap, out_byte);
+    return HFSSS_OK;
+}
+
+static int engine_submit_status_enhanced(struct nand_device *dev, const struct nand_cmd_target *target,
+                                         struct nand_status_enhanced *out)
+{
+    if (!dev || !target || !out) {
+        return HFSSS_ERR_INVAL;
+    }
+    struct nand_die *die = engine_get_die(dev, target->ch, target->chip, target->die);
+    if (!die) {
+        return HFSSS_ERR_INVAL;
+    }
+
+    struct nand_die_cmd_state snap;
+    mutex_lock(&die->die_lock, 0);
+    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, NAND_OP_READ_STATUS_ENHANCED)) {
+        mutex_unlock(&die->die_lock);
+        return HFSSS_ERR_BUSY;
+    }
+    nand_cmd_state_snapshot(&die->cmd_state, &snap);
+    mutex_unlock(&die->die_lock);
+
+    nand_status_enhanced_from_cmd_state(&snap, out);
+    return HFSSS_OK;
+}
+
+/*
+ * Identity path for READ_ID / READ_PARAM_PAGE. Takes the channel→die lock
+ * order so the data bus is serialized against concurrent submits. The helper
+ * performs a pure payload copy and does NOT disturb the in-flight command
+ * bookkeeping: it must not touch cmd_state.opcode/target/state/phase/
+ * result_status/in_flight/remaining_ns/latched_fail, because identity reads
+ * are legal while a program or erase is suspended (DIE_SUSPENDED_*) and
+ * clobbering those fields would destroy the suspension context for the
+ * later resume path, and would also clear the ONFI sticky FAIL latch on
+ * every identity read. EAT is intentionally not advanced: these are
+ * bus-bound ops and the current timing model does not expose
+ * tWHR / tRR / tDCBSYR1 fidelity — that is a later-phase refinement.
+ */
+static int engine_submit_identity(struct nand_device *dev, enum nand_cmd_opcode op,
+                                  const struct nand_cmd_target *target, void *out)
+{
+    if (!dev || !target || !out) {
+        return HFSSS_ERR_INVAL;
+    }
+    if (op != NAND_OP_READ_ID && op != NAND_OP_READ_PARAM_PAGE) {
+        return HFSSS_ERR_INVAL;
+    }
+
+    struct nand_channel *channel = engine_get_channel(dev, target->ch);
+    if (!channel) {
+        return HFSSS_ERR_INVAL;
+    }
+    struct nand_die *die = engine_get_die(dev, target->ch, target->chip, target->die);
+    if (!die) {
+        return HFSSS_ERR_INVAL;
+    }
+
+    mutex_lock(&channel->lock, 0);
+    mutex_lock(&die->die_lock, 0);
+
+    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, op)) {
+        mutex_unlock(&die->die_lock);
+        mutex_unlock(&channel->lock);
+        return HFSSS_ERR_BUSY;
+    }
+
+    if (op == NAND_OP_READ_ID) {
+        struct nand_id *dst = (struct nand_id *)out;
+        *dst = dev->nand_id;
+    } else {
+        struct nand_parameter_page *dst = (struct nand_parameter_page *)out;
+        *dst = dev->param_page;
+    }
+
+    mutex_unlock(&die->die_lock);
+    mutex_unlock(&channel->lock);
+    return HFSSS_OK;
+}
+
+int nand_cmd_engine_submit_read_status(struct nand_device *dev, const struct nand_cmd_target *target,
+                                       u8 *out_status_byte)
+{
+    return engine_submit_status_byte(dev, target, out_status_byte);
+}
+
+int nand_cmd_engine_submit_read_status_enhanced(struct nand_device *dev, const struct nand_cmd_target *target,
+                                                struct nand_status_enhanced *out)
+{
+    return engine_submit_status_enhanced(dev, target, out);
+}
+
+int nand_cmd_engine_submit_read_id(struct nand_device *dev, const struct nand_cmd_target *target, struct nand_id *out)
+{
+    return engine_submit_identity(dev, NAND_OP_READ_ID, target, out);
+}
+
+int nand_cmd_engine_submit_read_param_page(struct nand_device *dev, const struct nand_cmd_target *target,
+                                           struct nand_parameter_page *out)
+{
+    return engine_submit_identity(dev, NAND_OP_READ_PARAM_PAGE, target, out);
 }

--- a/src/media/cmd_legality.c
+++ b/src/media/cmd_legality.c
@@ -4,6 +4,17 @@
  * Legality matrix — rows are current die state, columns are incoming opcode.
  * 'true' means the engine accepts the submission in that state. RESET is
  * always accepted except when the die is already resetting.
+ *
+ * Status operations (READ_STATUS, READ_STATUS_ENHANCED) are legal in every
+ * die state because ONFI 4.2 requires status to be observable mid-flight so
+ * the host can detect RDY/ARDY transitions. They take the lightweight
+ * die-lock-only snapshot path and never cancel or interfere with an in-flight
+ * command.
+ *
+ * Identity operations (READ_ID, READ_PARAM_PAGE) use the data bus and cannot
+ * race an active array operation, so they are legal only in DIE_IDLE and the
+ * suspend states (design spec "Suspend/Resume Semantics" allows
+ * non-conflicting reads during suspend).
  */
 static const bool k_legal[DIE_STATE_COUNT][NAND_OP_COUNT] = {
     [DIE_IDLE] =
@@ -12,17 +23,74 @@ static const bool k_legal[DIE_STATE_COUNT][NAND_OP_COUNT] = {
             [NAND_OP_PROG] = true,
             [NAND_OP_ERASE] = true,
             [NAND_OP_RESET] = true,
+            [NAND_OP_READ_STATUS] = true,
+            [NAND_OP_READ_STATUS_ENHANCED] = true,
+            [NAND_OP_READ_ID] = true,
+            [NAND_OP_READ_PARAM_PAGE] = true,
         },
-    [DIE_READ_SETUP] = {[NAND_OP_RESET] = true},
-    [DIE_READ_ARRAY_BUSY] = {[NAND_OP_RESET] = true},
-    [DIE_READ_DATA_XFER] = {[NAND_OP_RESET] = true},
-    [DIE_PROG_SETUP] = {[NAND_OP_RESET] = true},
-    [DIE_PROG_ARRAY_BUSY] = {[NAND_OP_RESET] = true},
-    [DIE_ERASE_SETUP] = {[NAND_OP_RESET] = true},
-    [DIE_ERASE_ARRAY_BUSY] = {[NAND_OP_RESET] = true},
-    [DIE_SUSPENDED_PROG] = {[NAND_OP_RESET] = true},
-    [DIE_SUSPENDED_ERASE] = {[NAND_OP_RESET] = true},
-    [DIE_RESETTING] = {0},
+    [DIE_READ_SETUP] =
+        {
+            [NAND_OP_RESET] = true,
+            [NAND_OP_READ_STATUS] = true,
+            [NAND_OP_READ_STATUS_ENHANCED] = true,
+        },
+    [DIE_READ_ARRAY_BUSY] =
+        {
+            [NAND_OP_RESET] = true,
+            [NAND_OP_READ_STATUS] = true,
+            [NAND_OP_READ_STATUS_ENHANCED] = true,
+        },
+    [DIE_READ_DATA_XFER] =
+        {
+            [NAND_OP_RESET] = true,
+            [NAND_OP_READ_STATUS] = true,
+            [NAND_OP_READ_STATUS_ENHANCED] = true,
+        },
+    [DIE_PROG_SETUP] =
+        {
+            [NAND_OP_RESET] = true,
+            [NAND_OP_READ_STATUS] = true,
+            [NAND_OP_READ_STATUS_ENHANCED] = true,
+        },
+    [DIE_PROG_ARRAY_BUSY] =
+        {
+            [NAND_OP_RESET] = true,
+            [NAND_OP_READ_STATUS] = true,
+            [NAND_OP_READ_STATUS_ENHANCED] = true,
+        },
+    [DIE_ERASE_SETUP] =
+        {
+            [NAND_OP_RESET] = true,
+            [NAND_OP_READ_STATUS] = true,
+            [NAND_OP_READ_STATUS_ENHANCED] = true,
+        },
+    [DIE_ERASE_ARRAY_BUSY] =
+        {
+            [NAND_OP_RESET] = true,
+            [NAND_OP_READ_STATUS] = true,
+            [NAND_OP_READ_STATUS_ENHANCED] = true,
+        },
+    [DIE_SUSPENDED_PROG] =
+        {
+            [NAND_OP_RESET] = true,
+            [NAND_OP_READ_STATUS] = true,
+            [NAND_OP_READ_STATUS_ENHANCED] = true,
+            [NAND_OP_READ_ID] = true,
+            [NAND_OP_READ_PARAM_PAGE] = true,
+        },
+    [DIE_SUSPENDED_ERASE] =
+        {
+            [NAND_OP_RESET] = true,
+            [NAND_OP_READ_STATUS] = true,
+            [NAND_OP_READ_STATUS_ENHANCED] = true,
+            [NAND_OP_READ_ID] = true,
+            [NAND_OP_READ_PARAM_PAGE] = true,
+        },
+    [DIE_RESETTING] =
+        {
+            [NAND_OP_READ_STATUS] = true,
+            [NAND_OP_READ_STATUS_ENHANCED] = true,
+        },
 };
 
 bool nand_cmd_is_legal_in_state(enum nand_die_state state, enum nand_cmd_opcode op)

--- a/src/media/media.c
+++ b/src/media/media.c
@@ -89,6 +89,11 @@ int media_init(struct media_ctx *ctx, struct media_config *config)
     /* Associate EAT context with NAND device */
     ctx->nand->eat = ctx->eat;
 
+    /* Populate device identity and parameter page from the active config
+     * after timing/EAT wiring so tR/tPROG/tBERS advertisement reflects the
+     * real timing model. */
+    nand_identity_build_from_config(ctx->nand, &ctx->config);
+
     /* Allocate and initialize reliability model */
     ctx->reliability = (struct reliability_model *)malloc(sizeof(struct reliability_model));
     if (!ctx->reliability) {
@@ -514,6 +519,70 @@ int media_nand_read_status(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, str
     };
 
     return nand_cmd_engine_snapshot(ctx->nand, &target, out);
+}
+
+int media_nand_read_status_byte(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u8 *out)
+{
+    if (!ctx || !ctx->initialized || !out) {
+        return HFSSS_ERR_INVAL;
+    }
+    struct nand_cmd_target target = {
+        .ch = ch,
+        .chip = chip,
+        .die = die,
+        .plane_mask = 0,
+        .block = 0,
+        .page = 0,
+    };
+    return nand_cmd_engine_submit_read_status(ctx->nand, &target, out);
+}
+
+int media_nand_read_status_enhanced(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_status_enhanced *out)
+{
+    if (!ctx || !ctx->initialized || !out) {
+        return HFSSS_ERR_INVAL;
+    }
+    struct nand_cmd_target target = {
+        .ch = ch,
+        .chip = chip,
+        .die = die,
+        .plane_mask = 0,
+        .block = 0,
+        .page = 0,
+    };
+    return nand_cmd_engine_submit_read_status_enhanced(ctx->nand, &target, out);
+}
+
+int media_nand_read_id(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_id *out)
+{
+    if (!ctx || !ctx->initialized || !out) {
+        return HFSSS_ERR_INVAL;
+    }
+    struct nand_cmd_target target = {
+        .ch = ch,
+        .chip = chip,
+        .die = die,
+        .plane_mask = 0,
+        .block = 0,
+        .page = 0,
+    };
+    return nand_cmd_engine_submit_read_id(ctx->nand, &target, out);
+}
+
+int media_nand_read_parameter_page(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_parameter_page *out)
+{
+    if (!ctx || !ctx->initialized || !out) {
+        return HFSSS_ERR_INVAL;
+    }
+    struct nand_cmd_target target = {
+        .ch = ch,
+        .chip = chip,
+        .die = die,
+        .plane_mask = 0,
+        .block = 0,
+        .page = 0,
+    };
+    return nand_cmd_engine_submit_read_param_page(ctx->nand, &target, out);
 }
 
 int media_nand_is_bad_block(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block)

--- a/src/media/nand_identity.c
+++ b/src/media/nand_identity.c
@@ -1,0 +1,339 @@
+#include "media/nand_identity.h"
+
+#include "common/common.h"
+#include "media/cmd_state.h"
+#include "media/media.h"
+#include "media/nand.h"
+#include "media/timing.h"
+
+#include <string.h>
+
+/*
+ * CRC-16-CCITT (polynomial 0x1021, init 0xFFFF). Small enough to keep
+ * self-contained; avoids pulling in a dedicated CRC translation unit for a
+ * single call site.
+ */
+static u16 crc16_ccitt(const void *buf, size_t len)
+{
+    const u8 *p = (const u8 *)buf;
+    u16 crc = 0xFFFF;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= (u16)p[i] << 8;
+        for (int b = 0; b < 8; b++) {
+            if (crc & 0x8000) {
+                crc = (u16)((crc << 1) ^ 0x1021);
+            } else {
+                crc = (u16)(crc << 1);
+            }
+        }
+    }
+    return crc;
+}
+
+static u8 cell_type_from_nand_type(enum nand_type t)
+{
+    switch (t) {
+    case NAND_TYPE_SLC:
+        return NAND_ID_CELL_TYPE_SLC;
+    case NAND_TYPE_MLC:
+        return NAND_ID_CELL_TYPE_MLC;
+    case NAND_TYPE_TLC:
+        return NAND_ID_CELL_TYPE_TLC;
+    case NAND_TYPE_QLC:
+        return NAND_ID_CELL_TYPE_QLC;
+    default:
+        return NAND_ID_CELL_TYPE_TLC;
+    }
+}
+
+static u8 bits_per_cell_from_nand_type(enum nand_type t)
+{
+    switch (t) {
+    case NAND_TYPE_SLC:
+        return 1;
+    case NAND_TYPE_MLC:
+        return 2;
+    case NAND_TYPE_TLC:
+        return 3;
+    case NAND_TYPE_QLC:
+        return 4;
+    default:
+        return 3;
+    }
+}
+
+static u16 ecc_bits_from_nand_type(enum nand_type t)
+{
+    switch (t) {
+    case NAND_TYPE_SLC:
+        return 1;
+    case NAND_TYPE_MLC:
+        return 8;
+    case NAND_TYPE_TLC:
+        return 60;
+    case NAND_TYPE_QLC:
+        return 120;
+    default:
+        return 60;
+    }
+}
+
+static u8 log2_u32(u32 v)
+{
+    u8 n = 0;
+    while (v > 1) {
+        v >>= 1;
+        n++;
+    }
+    return n;
+}
+
+static u8 encode_field_log2(u32 value, u8 base_log2, u8 max_code)
+{
+    if (value == 0) {
+        return 0;
+    }
+    u8 lg = log2_u32(value);
+    if (lg < base_log2) {
+        return 0;
+    }
+    u8 code = (u8)(lg - base_log2);
+    if (code > max_code) {
+        code = max_code;
+    }
+    return code;
+}
+
+/*
+ * Pack the 8-byte ID per ONFI 4.2 Table 37. The simulator supports enterprise
+ * TLC/QLC geometries whose page/block sizes commonly exceed the 2-bit encoded
+ * values defined by ONFI 4.2. Where that happens we clamp to the maximum legal
+ * code and mirror the true value in the parameter page.
+ */
+static void build_nand_id(struct nand_id *id, const struct media_config *cfg)
+{
+    memset(id, 0, sizeof(*id));
+    id->bytes[0] = NAND_ID_MFR_SIMULATOR;
+
+    u8 cell_type = cell_type_from_nand_type(cfg->nand_type);
+    u8 device_code = (u8)(0x10 | (cell_type & 0x03));
+    id->bytes[1] = device_code;
+
+    u32 dies_per_ce = cfg->chips_per_channel * cfg->dies_per_chip;
+    u8 chip_number_code = encode_field_log2(dies_per_ce, 0, 0x3);
+    u8 cache_support = 0;
+    u8 interleave_support = cfg->enable_die_interleaving ? 1 : 0;
+    u8 simultaneous_pages = encode_field_log2(cfg->planes_per_die, 0, 0x3);
+    id->bytes[2] = (u8)((chip_number_code << 6) | ((cell_type & 0x3) << 4) | ((simultaneous_pages & 0x3) << 2) |
+                        ((interleave_support & 0x1) << 1) | (cache_support & 0x1));
+
+    u8 page_size_code = encode_field_log2(cfg->page_size, 10, 0x3);
+    u8 spare_ratio_code = 0;
+    if (cfg->page_size > 0) {
+        u32 spare_per_512 = (cfg->spare_size * 512u) / cfg->page_size;
+        if (spare_per_512 >= 24) {
+            spare_ratio_code = 0x2;
+        } else if (spare_per_512 >= 16) {
+            spare_ratio_code = 0x1;
+        } else {
+            spare_ratio_code = 0x0;
+        }
+    }
+    u32 block_bytes = cfg->page_size * cfg->pages_per_block;
+    u8 block_size_code = encode_field_log2(block_bytes, 16, 0x3);
+    id->bytes[3] =
+        (u8)(((page_size_code & 0x3) << 6) | ((spare_ratio_code & 0x3) << 4) | ((block_size_code & 0x3) << 0));
+
+    u8 plane_number_code = encode_field_log2(cfg->planes_per_die, 0, 0x3);
+    u8 plane_size_code = encode_field_log2(cfg->blocks_per_plane, 0, 0x7);
+    id->bytes[4] = (u8)(((plane_number_code & 0x3) << 6) | ((plane_size_code & 0x7) << 3));
+}
+
+static void build_parameter_page(struct nand_parameter_page *pp, const struct media_config *cfg,
+                                 const struct nand_id *id, struct timing_model *timing)
+{
+    memset(pp, 0, sizeof(*pp));
+
+    pp->revision = NAND_PARAMETER_PAGE_REVISION;
+    pp->size_bytes = (u16)sizeof(*pp);
+
+    pp->manufacturer_id = id->bytes[0];
+    pp->device_id = id->bytes[1];
+    memcpy(pp->manufacturer_name, "HFSSS-SIM   ", NAND_PARAMETER_PAGE_MFR_NAME_LEN);
+
+    const char *model = "GENERIC-NAND-0001   ";
+    switch (cfg->nand_type) {
+    case NAND_TYPE_SLC:
+        model = "GENERIC-SLC-0001    ";
+        break;
+    case NAND_TYPE_MLC:
+        model = "GENERIC-MLC-0001    ";
+        break;
+    case NAND_TYPE_TLC:
+        model = "GENERIC-TLC-0001    ";
+        break;
+    case NAND_TYPE_QLC:
+        model = "GENERIC-QLC-0001    ";
+        break;
+    default:
+        break;
+    }
+    memcpy(pp->device_model, model, NAND_PARAMETER_PAGE_MODEL_LEN);
+
+    pp->bytes_per_page = cfg->page_size;
+    pp->spare_bytes_per_page = (u16)cfg->spare_size;
+    pp->pages_per_block = cfg->pages_per_block;
+    pp->blocks_per_lun = cfg->blocks_per_plane * cfg->planes_per_die;
+    pp->luns_per_ce = (u8)(cfg->dies_per_chip);
+    pp->planes_per_die = (u8)cfg->planes_per_die;
+    pp->bits_per_cell = bits_per_cell_from_nand_type(cfg->nand_type);
+
+    /* Row address space spans pages × blocks × LUNs so the advertised cycle
+     * count can address every page in the CE. Use u64 to avoid overflow on
+     * enterprise TLC/QLC geometries. */
+    u32 luns = pp->luns_per_ce ? pp->luns_per_ce : 1;
+    u64 row_addresses = (u64)pp->pages_per_block * (u64)pp->blocks_per_lun * (u64)luns;
+    u8 row_bits = 0;
+    u64 tmp = row_addresses ? row_addresses : 1;
+    while (tmp > 1) {
+        tmp >>= 1;
+        row_bits++;
+    }
+    pp->addr_cycles_row = (u8)((row_bits + 7) / 8);
+    if (pp->addr_cycles_row == 0) {
+        pp->addr_cycles_row = 1;
+    }
+
+    u32 col_addresses = cfg->page_size + cfg->spare_size;
+    u8 col_bits = log2_u32(col_addresses ? col_addresses : 1);
+    pp->addr_cycles_col = (u8)((col_bits + 7) / 8);
+    if (pp->addr_cycles_col == 0) {
+        pp->addr_cycles_col = 1;
+    }
+
+    pp->ecc_bits_required = ecc_bits_from_nand_type(cfg->nand_type);
+    pp->ecc_codeword_size = 1024;
+
+    pp->supported_cmd_bitmap = (1u << NAND_OP_READ) | (1u << NAND_OP_PROG) | (1u << NAND_OP_ERASE) |
+                               (1u << NAND_OP_RESET) | (1u << NAND_OP_READ_STATUS) |
+                               (1u << NAND_OP_READ_STATUS_ENHANCED) | (1u << NAND_OP_READ_ID) |
+                               (1u << NAND_OP_READ_PARAM_PAGE);
+
+    if (timing) {
+        pp->tR_ns = timing_get_read_latency(timing, 0);
+        pp->tPROG_ns = timing_get_prog_latency(timing, 0);
+        pp->tBERS_ns = timing_get_erase_latency(timing);
+    }
+
+    pp->crc = crc16_ccitt(pp, offsetof(struct nand_parameter_page, crc));
+}
+
+void nand_identity_build_from_config(struct nand_device *dev, const struct media_config *cfg)
+{
+    if (!dev || !cfg) {
+        return;
+    }
+    build_nand_id(&dev->nand_id, cfg);
+    build_parameter_page(&dev->param_page, cfg, &dev->nand_id, dev->timing);
+}
+
+void nand_status_byte_from_cmd_state(const struct nand_die_cmd_state *s, u8 *out)
+{
+    if (!out) {
+        return;
+    }
+    u8 value = NAND_STATUS_WP_N;
+    if (!s) {
+        *out = (u8)(value | NAND_STATUS_RDY | NAND_STATUS_ARDY);
+        return;
+    }
+
+    bool array_busy = false;
+    bool suspended = false;
+    switch (s->state) {
+    case DIE_IDLE:
+        break;
+    case DIE_SUSPENDED_PROG:
+    case DIE_SUSPENDED_ERASE:
+        suspended = true;
+        break;
+    case DIE_RESETTING:
+    case DIE_READ_SETUP:
+    case DIE_READ_ARRAY_BUSY:
+    case DIE_READ_DATA_XFER:
+    case DIE_PROG_SETUP:
+    case DIE_PROG_ARRAY_BUSY:
+    case DIE_ERASE_SETUP:
+    case DIE_ERASE_ARRAY_BUSY:
+    default:
+        array_busy = true;
+        break;
+    }
+
+    if (!array_busy) {
+        value |= NAND_STATUS_ARDY;
+    }
+    if (!array_busy || suspended) {
+        value |= NAND_STATUS_RDY;
+    }
+
+    /* ONFI 4.2 FAIL semantics: the latch is sticky across intervening
+     * non-write operations and is cleared only by the next successful
+     * PROG/ERASE completion or by RESET. The engine sets/clears
+     * latched_fail at PROG/ERASE completion and on RESET. */
+    if (s->latched_fail) {
+        value |= NAND_STATUS_FAIL;
+    }
+
+    *out = value;
+}
+
+void nand_status_enhanced_from_cmd_state(const struct nand_die_cmd_state *s, struct nand_status_enhanced *out)
+{
+    if (!out) {
+        return;
+    }
+    memset(out, 0, sizeof(*out));
+
+    if (!s) {
+        out->ready = true;
+        out->array_ready = true;
+        out->write_protect_off = true;
+        out->state = DIE_IDLE;
+        out->phase = CMD_PHASE_NONE;
+        nand_status_byte_from_cmd_state(NULL, &out->classic_status);
+        return;
+    }
+
+    out->state = s->state;
+    out->phase = s->phase;
+    out->last_opcode = s->opcode;
+    out->suspend_count = s->suspend_count;
+    out->start_ts_ns = s->start_ts_ns;
+    out->phase_start_ts_ns = s->phase_start_ts_ns;
+    out->total_budget_ns = s->total_budget_ns;
+    out->remaining_ns = s->remaining_ns;
+    out->result_status = s->result_status;
+    out->write_protect_off = true;
+
+    out->suspended_program = (s->state == DIE_SUSPENDED_PROG);
+    out->suspended_erase = (s->state == DIE_SUSPENDED_ERASE);
+    out->resetting = (s->state == DIE_RESETTING);
+
+    bool array_busy = false;
+    switch (s->state) {
+    case DIE_IDLE:
+    case DIE_SUSPENDED_PROG:
+    case DIE_SUSPENDED_ERASE:
+        break;
+    default:
+        array_busy = true;
+        break;
+    }
+    out->array_ready = !array_busy;
+    out->ready = !array_busy || out->suspended_program || out->suspended_erase;
+
+    out->last_op_failed = s->latched_fail;
+
+    nand_status_byte_from_cmd_state(s, &out->classic_status);
+}

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -570,6 +570,274 @@ static int test_cmd_state_machine(void)
     return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
 }
 
+/* Phase 2 foundational standard commands */
+static int test_cmd_phase2_commands(void)
+{
+    printf("\n=== NAND Phase 2 Foundational Command Tests ===\n");
+
+    struct media_config config = {
+        .channel_count = 1,
+        .chips_per_channel = 1,
+        .dies_per_chip = 1,
+        .planes_per_die = 1,
+        .blocks_per_plane = 4,
+        .pages_per_block = 16,
+        .page_size = 4096,
+        .spare_size = 64,
+        .nand_type = NAND_TYPE_TLC,
+    };
+
+    struct media_ctx ctx;
+    int ret = media_init(&ctx, &config);
+    TEST_ASSERT(ret == HFSSS_OK, "Phase2: media_init succeeds");
+    if (ret != HFSSS_OK) {
+        return TEST_FAIL;
+    }
+
+    /* SM-14: read status byte on fresh idle die */
+    u8 sr = 0;
+    ret = media_nand_read_status_byte(&ctx, 0, 0, 0, &sr);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-14: status byte on fresh die OK");
+    TEST_ASSERT((sr & NAND_STATUS_RDY) != 0, "SM-14: RDY set on idle die");
+    TEST_ASSERT((sr & NAND_STATUS_ARDY) != 0, "SM-14: ARDY set on idle die");
+    TEST_ASSERT((sr & NAND_STATUS_WP_N) != 0, "SM-14: WP_N asserted");
+    TEST_ASSERT((sr & NAND_STATUS_FAIL) == 0, "SM-14: FAIL clear on fresh die");
+
+    /* SM-15: status byte after a completed program */
+    u8 prog_buf[4096];
+    memset(prog_buf, 0x5A, sizeof(prog_buf));
+    ret = media_nand_program(&ctx, 0, 0, 0, 0, 0, 0, prog_buf, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-15: program succeeds");
+    ret = media_nand_read_status_byte(&ctx, 0, 0, 0, &sr);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-15: status byte after program OK");
+    TEST_ASSERT((sr & NAND_STATUS_RDY) != 0, "SM-15: RDY set post-program");
+    TEST_ASSERT((sr & NAND_STATUS_ARDY) != 0, "SM-15: ARDY set post-program");
+    TEST_ASSERT((sr & NAND_STATUS_FAIL) == 0, "SM-15: FAIL clear on successful program");
+
+    /* SM-16: enhanced status decode after reset */
+    struct nand_cmd_target target = {
+        .ch = 0,
+        .chip = 0,
+        .die = 0,
+        .plane_mask = 1u,
+        .block = 0,
+        .page = 0,
+    };
+    ret = nand_cmd_engine_submit_reset(ctx.nand, &target);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-16: reset submit OK");
+    struct nand_status_enhanced enh;
+    ret = media_nand_read_status_enhanced(&ctx, 0, 0, 0, &enh);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-16: enhanced status OK after reset");
+    TEST_ASSERT(enh.state == DIE_IDLE, "SM-16: state is DIE_IDLE after reset");
+    TEST_ASSERT(enh.ready == true, "SM-16: ready bit set");
+    TEST_ASSERT(enh.array_ready == true, "SM-16: array_ready bit set");
+    TEST_ASSERT(enh.resetting == false, "SM-16: resetting bit clear");
+    TEST_ASSERT(enh.last_op_failed == false, "SM-16: last_op_failed clear");
+    TEST_ASSERT(enh.result_status == HFSSS_OK, "SM-16: result_status OK");
+    TEST_ASSERT((enh.classic_status & NAND_STATUS_RDY) != 0, "SM-16: classic status RDY set");
+
+    /* SM-17: exhaustive legality matrix for status/identity opcodes */
+    for (int s = 0; s < DIE_STATE_COUNT; s++) {
+        TEST_ASSERT(nand_cmd_is_legal_in_state((enum nand_die_state)s, NAND_OP_READ_STATUS) == true,
+                    "SM-17: READ_STATUS legal in every die state");
+        TEST_ASSERT(nand_cmd_is_legal_in_state((enum nand_die_state)s, NAND_OP_READ_STATUS_ENHANCED) == true,
+                    "SM-17: READ_STATUS_ENHANCED legal in every die state");
+    }
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_IDLE, NAND_OP_READ_ID) == true, "SM-17: READ_ID legal in DIE_IDLE");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_READ_ARRAY_BUSY, NAND_OP_READ_ID) == false,
+                "SM-17: READ_ID illegal in DIE_READ_ARRAY_BUSY");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_SUSPENDED_PROG, NAND_OP_READ_ID) == true,
+                "SM-17: READ_ID legal in DIE_SUSPENDED_PROG");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_SUSPENDED_ERASE, NAND_OP_READ_PARAM_PAGE) == true,
+                "SM-17: READ_PARAM_PAGE legal in DIE_SUSPENDED_ERASE");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_RESETTING, NAND_OP_READ_ID) == false,
+                "SM-17: READ_ID illegal in DIE_RESETTING");
+
+    /* SM-18: read id structural correctness */
+    struct nand_id id;
+    memset(&id, 0, sizeof(id));
+    ret = media_nand_read_id(&ctx, 0, 0, 0, &id);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-18: read id returns OK");
+    TEST_ASSERT(id.bytes[0] == NAND_ID_MFR_SIMULATOR, "SM-18: manufacturer byte matches simulator code");
+    TEST_ASSERT(id.bytes[1] != 0, "SM-18: device code populated");
+    TEST_ASSERT(((id.bytes[2] >> 4) & 0x3) == NAND_ID_CELL_TYPE_TLC, "SM-18: cell_type encodes TLC");
+    TEST_ASSERT(id.bytes[5] == 0 && id.bytes[6] == 0 && id.bytes[7] == 0, "SM-18: Toggle-extended bytes zero-filled");
+
+    /* SM-19: parameter page minimum contract */
+    struct nand_parameter_page pp;
+    memset(&pp, 0, sizeof(pp));
+    ret = media_nand_read_parameter_page(&ctx, 0, 0, 0, &pp);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-19: read parameter page OK");
+    TEST_ASSERT(pp.revision == NAND_PARAMETER_PAGE_REVISION, "SM-19: revision matches constant");
+    TEST_ASSERT(pp.size_bytes == sizeof(struct nand_parameter_page), "SM-19: size_bytes matches struct size");
+    TEST_ASSERT(pp.bytes_per_page == 4096, "SM-19: bytes_per_page matches config");
+    TEST_ASSERT(pp.spare_bytes_per_page == 64, "SM-19: spare_bytes_per_page matches config");
+    TEST_ASSERT(pp.pages_per_block == 16, "SM-19: pages_per_block matches config");
+    TEST_ASSERT(pp.blocks_per_lun == 4, "SM-19: blocks_per_lun derived from blocks_per_plane*planes_per_die");
+    TEST_ASSERT(pp.planes_per_die == 1, "SM-19: planes_per_die matches config");
+    TEST_ASSERT(pp.bits_per_cell == 3, "SM-19: TLC bits_per_cell == 3");
+    TEST_ASSERT(pp.ecc_bits_required > 0, "SM-19: ECC advertisement non-zero");
+    TEST_ASSERT((pp.supported_cmd_bitmap & (1u << NAND_OP_READ)) != 0, "SM-19: READ advertised");
+    TEST_ASSERT((pp.supported_cmd_bitmap & (1u << NAND_OP_PROG)) != 0, "SM-19: PROG advertised");
+    TEST_ASSERT((pp.supported_cmd_bitmap & (1u << NAND_OP_ERASE)) != 0, "SM-19: ERASE advertised");
+    TEST_ASSERT((pp.supported_cmd_bitmap & (1u << NAND_OP_READ_STATUS)) != 0, "SM-19: READ_STATUS advertised");
+    TEST_ASSERT((pp.supported_cmd_bitmap & (1u << NAND_OP_READ_STATUS_ENHANCED)) != 0,
+                "SM-19: READ_STATUS_ENHANCED advertised");
+    TEST_ASSERT((pp.supported_cmd_bitmap & (1u << NAND_OP_READ_ID)) != 0, "SM-19: READ_ID advertised");
+    TEST_ASSERT((pp.supported_cmd_bitmap & (1u << NAND_OP_READ_PARAM_PAGE)) != 0, "SM-19: READ_PARAM_PAGE advertised");
+    TEST_ASSERT(pp.tR_ns == timing_get_read_latency(ctx.timing, 0), "SM-19: tR_ns matches timing model");
+    TEST_ASSERT(pp.tPROG_ns == timing_get_prog_latency(ctx.timing, 0), "SM-19: tPROG_ns matches timing model");
+    TEST_ASSERT(pp.tBERS_ns == timing_get_erase_latency(ctx.timing), "SM-19: tBERS_ns matches timing model");
+    TEST_ASSERT(pp.manufacturer_id == id.bytes[0], "SM-19: parameter page manufacturer matches ID");
+    TEST_ASSERT(pp.crc != 0, "SM-19: parameter page CRC computed");
+
+    /* SM-20: parameter page is stable across reads */
+    struct nand_parameter_page pp2;
+    ret = media_nand_read_parameter_page(&ctx, 0, 0, 0, &pp2);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-20: second parameter page read OK");
+    TEST_ASSERT(memcmp(&pp, &pp2, sizeof(pp)) == 0, "SM-20: parameter page stable across reads");
+
+    /* SM-21: reset produces deterministic clean baseline with no EAT drift */
+    u64 eat_before_reset = eat_get_for_plane(ctx.eat, 0, 0, 0, 0);
+    ret = nand_cmd_engine_submit_reset(ctx.nand, &target);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-21: reset returns OK");
+    u64 eat_after_reset = eat_get_for_plane(ctx.eat, 0, 0, 0, 0);
+    TEST_ASSERT(eat_after_reset == eat_before_reset, "SM-21: reset does not advance plane EAT");
+
+    struct nand_die_cmd_state snap_after_reset;
+    ret = media_nand_read_status(&ctx, 0, 0, 0, &snap_after_reset);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-21: snapshot after reset OK");
+    TEST_ASSERT(snap_after_reset.state == DIE_IDLE, "SM-21: state == DIE_IDLE");
+    TEST_ASSERT(snap_after_reset.in_flight == false, "SM-21: in_flight clear");
+    TEST_ASSERT(snap_after_reset.result_status == HFSSS_OK, "SM-21: result_status OK");
+    TEST_ASSERT(snap_after_reset.remaining_ns == 0, "SM-21: remaining_ns zero");
+
+    u8 sr_after_reset = 0;
+    ret = media_nand_read_status_byte(&ctx, 0, 0, 0, &sr_after_reset);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-21: classic status after reset OK");
+    TEST_ASSERT((sr_after_reset & NAND_STATUS_RDY) != 0, "SM-21: RDY after reset");
+    TEST_ASSERT((sr_after_reset & NAND_STATUS_ARDY) != 0, "SM-21: ARDY after reset");
+
+    /* Identity read must also be available in IDLE post-reset */
+    struct nand_id id2;
+    ret = media_nand_read_id(&ctx, 0, 0, 0, &id2);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-21: read_id OK after reset");
+    TEST_ASSERT(memcmp(&id, &id2, sizeof(id)) == 0, "SM-21: read_id stable across reset");
+
+    /* SM-22: invalid-argument rejection for the four Phase 2 entry points. */
+    ret = media_nand_read_status_byte(&ctx, 0, 0, 0, NULL);
+    TEST_ASSERT(ret == HFSSS_ERR_INVAL, "SM-22: status_byte(NULL) returns INVAL");
+    ret = media_nand_read_status_enhanced(&ctx, 0, 0, 0, NULL);
+    TEST_ASSERT(ret == HFSSS_ERR_INVAL, "SM-22: status_enhanced(NULL) returns INVAL");
+    ret = media_nand_read_id(&ctx, 0, 0, 0, NULL);
+    TEST_ASSERT(ret == HFSSS_ERR_INVAL, "SM-22: read_id(NULL) returns INVAL");
+    ret = media_nand_read_parameter_page(&ctx, 0, 0, 0, NULL);
+    TEST_ASSERT(ret == HFSSS_ERR_INVAL, "SM-22: read_param_page(NULL) returns INVAL");
+
+    u8 sr_tmp = 0;
+    ret = media_nand_read_status_byte(&ctx, 99, 0, 0, &sr_tmp);
+    TEST_ASSERT(ret == HFSSS_ERR_INVAL, "SM-22: out-of-range channel returns INVAL");
+
+    /* SM-23: FAIL latch stickiness across intervening non-write operations.
+     * Drive the latch directly via nand_die_cmd_state since the sync engine
+     * has no builtin path to produce a failed PROG/ERASE in the test
+     * geometry. This also validates that READ / READ_ID / READ_STATUS do not
+     * clobber the latch. */
+    struct nand_die *die0 = &ctx.nand->channels[0].chips[0].dies[0];
+    die0->cmd_state.latched_fail = true;
+
+    ret = media_nand_read_status_byte(&ctx, 0, 0, 0, &sr_tmp);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-23: status_byte OK with latched FAIL");
+    TEST_ASSERT((sr_tmp & NAND_STATUS_FAIL) != 0, "SM-23: FAIL bit reflects latched state");
+
+    /* An intervening READ must not clear the latch. */
+    u8 read_buf[4096];
+    memset(read_buf, 0, sizeof(read_buf));
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 0, 0, read_buf, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-23: intervening read OK");
+    ret = media_nand_read_status_byte(&ctx, 0, 0, 0, &sr_tmp);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-23: status_byte OK after intervening read");
+    TEST_ASSERT((sr_tmp & NAND_STATUS_FAIL) != 0, "SM-23: FAIL latch persists across read");
+
+    /* An intervening READ_ID must not clear the latch. */
+    struct nand_id id3;
+    ret = media_nand_read_id(&ctx, 0, 0, 0, &id3);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-23: intervening read_id OK");
+    ret = media_nand_read_status_byte(&ctx, 0, 0, 0, &sr_tmp);
+    TEST_ASSERT((sr_tmp & NAND_STATUS_FAIL) != 0, "SM-23: FAIL latch persists across read_id");
+
+    /* RESET must clear the latch. */
+    struct nand_cmd_target target_reset = {
+        .ch = 0,
+        .chip = 0,
+        .die = 0,
+        .plane_mask = 1u,
+        .block = 0,
+        .page = 0,
+    };
+    ret = nand_cmd_engine_submit_reset(ctx.nand, &target_reset);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-23: reset OK");
+    ret = media_nand_read_status_byte(&ctx, 0, 0, 0, &sr_tmp);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-23: status_byte OK after reset");
+    TEST_ASSERT((sr_tmp & NAND_STATUS_FAIL) == 0, "SM-23: reset clears FAIL latch");
+
+    /* A successful PROG must also clear the latch. */
+    die0->cmd_state.latched_fail = true;
+    memset(prog_buf, 0x3C, sizeof(prog_buf));
+    ret = media_nand_program(&ctx, 0, 0, 0, 0, 2, 0, prog_buf, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-23: follow-up program OK");
+    ret = media_nand_read_status_byte(&ctx, 0, 0, 0, &sr_tmp);
+    TEST_ASSERT((sr_tmp & NAND_STATUS_FAIL) == 0, "SM-23: successful program clears FAIL latch");
+
+    /* SM-24: identity path does not disturb synthetic suspend context.
+     * Drives the die into DIE_SUSPENDED_PROG by directly manipulating the
+     * cmd_state, issues a READ_ID (legal per matrix), then verifies that
+     * the state, opcode, target.block, and in_flight fields survive.
+     * This is the regression guard for the CRITICAL "identity destroys
+     * suspend context" finding. */
+    struct nand_cmd_target synthetic = {
+        .ch = 0,
+        .chip = 0,
+        .die = 0,
+        .plane_mask = 1u,
+        .block = 1,
+        .page = 3,
+    };
+    die0->cmd_state.state = DIE_SUSPENDED_PROG;
+    die0->cmd_state.phase = CMD_PHASE_ARRAY_BUSY;
+    die0->cmd_state.opcode = NAND_OP_PROG;
+    die0->cmd_state.target = synthetic;
+    die0->cmd_state.in_flight = true;
+    die0->cmd_state.remaining_ns = 123456;
+    die0->cmd_state.suspend_count = 2;
+    die0->cmd_state.result_status = HFSSS_OK;
+
+    struct nand_id id4;
+    ret = media_nand_read_id(&ctx, 0, 0, 0, &id4);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-24: read_id OK during synthetic suspend");
+    TEST_ASSERT(die0->cmd_state.state == DIE_SUSPENDED_PROG, "SM-24: state preserved");
+    TEST_ASSERT(die0->cmd_state.phase == CMD_PHASE_ARRAY_BUSY, "SM-24: phase preserved");
+    TEST_ASSERT(die0->cmd_state.opcode == NAND_OP_PROG, "SM-24: opcode preserved");
+    TEST_ASSERT(die0->cmd_state.target.block == 1, "SM-24: target.block preserved");
+    TEST_ASSERT(die0->cmd_state.target.page == 3, "SM-24: target.page preserved");
+    TEST_ASSERT(die0->cmd_state.in_flight == true, "SM-24: in_flight preserved");
+    TEST_ASSERT(die0->cmd_state.remaining_ns == 123456, "SM-24: remaining_ns preserved");
+    TEST_ASSERT(die0->cmd_state.suspend_count == 2, "SM-24: suspend_count preserved");
+
+    /* READ_PARAM_PAGE during suspend: same invariant. */
+    struct nand_parameter_page pp3;
+    ret = media_nand_read_parameter_page(&ctx, 0, 0, 0, &pp3);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-24: read_param_page OK during synthetic suspend");
+    TEST_ASSERT(die0->cmd_state.state == DIE_SUSPENDED_PROG, "SM-24: state preserved across param_page");
+    TEST_ASSERT(die0->cmd_state.remaining_ns == 123456, "SM-24: remaining_ns preserved across param_page");
+
+    /* Restore the die to a clean state so cleanup doesn't trip. */
+    nand_cmd_engine_submit_reset(ctx.nand, &target_reset);
+
+    media_cleanup(&ctx);
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
 /* Main */
 int main(void)
 {
@@ -589,6 +857,7 @@ int main(void)
     test_media();
     test_persistence();
     test_cmd_state_machine();
+    test_cmd_phase2_commands();
 
     printf("\n========================================\n");
     printf("Test Summary\n");


### PR DESCRIPTION
## Summary

Implements **Phase 2** of the NAND/Media command coverage design spec (`docs/superpowers/specs/2026-04-10-nand-media-command-coverage-design.md` §11). Builds on the Phase 1 engine skeleton merged in #73.

New foundational standard commands exposed through both the internal engine and the public media API:

- **read_status** — 1-byte classic ONFI status (RDY / ARDY / WP_N / FAIL)
- **read_status_enhanced** — structured decode over the in-flight command-state snapshot
- **read_id** — 8-byte ID with ONFI 4.2 Table 37 bit layout in bytes [0..4] and Toggle-extended reserved bytes [5..7]
- **read_parameter_page** — minimum §6.3 contract: identity, geometry, addressing, ECC advertisement, supported-command bitmap, timing advertisement, revision/size prefix, CRC-16-CCITT over stable prefix

Identity and parameter page live on `struct nand_device` and are populated in `media_init` after the timing/EAT wiring so `tR` / `tPROG` / `tBERS` advertised values reflect the active timing model.

## Critical review fixes included

During internal code review these issues were found and fixed in the same branch before the initial PR:

1. **CRITICAL — identity-during-suspend destroyed suspend context.** The initial implementation routed identity ops through `nand_cmd_state_begin` which clobbered `target`, `remaining_ns`, `suspend_count`, `in_flight`, and forced `DIE_IDLE`. Legality allows identity ops during `DIE_SUSPENDED_*` per ONFI, so this would have silently broken Phase 3 resume. Fixed by simplifying `engine_submit_identity` to a pure payload copy that never touches `cmd_state`.

2. **CRITICAL — status observability hole.** `engine_submit` in Phase 1 held `die_lock` across the entire submission (busy-wait + commit hooks), so concurrent `read_status` callers would block until the command completed and could only observe settled states. This violated the design spec concurrency contract. Fixed by narrowing `die_lock` to short transactional segments around `cmd_state` updates and releasing it across the busy-wait and commit callbacks. Channel-level serialization still comes from `channel_lock`.

3. **HIGH — FAIL latch semantics.** ONFI 4.2 Status Register requires FAIL to latch until the next PROG/ERASE completes successfully or a RESET occurs. The initial implementation derived FAIL from the last op's `result_status` which was cleared by any intervening read or identity op. Added a sticky `latched_fail` field on `nand_die_cmd_state`; set on PROG/ERASE failure completion, cleared on successful PROG/ERASE completion and on RESET, untouched by READ / READ_ID / READ_STATUS / READ_PARAM_PAGE.

4. **HIGH — addr_cycles_row computation.** Dead `if/else` branches, self-overwriting assignment, and missing `luns_per_ce` multiplier under-reported row-address cycles on multi-LUN parts. Replaced with a single `u64` computation across `pages_per_block × blocks_per_lun × luns_per_ce`.

## Test coverage

New test cases `SM-14` .. `SM-24` in `tests/test_media.c`:

| Case | Focus |
|------|-------|
| SM-14 | Status byte on fresh idle die |
| SM-15 | Status byte across a completed program |
| SM-16 | Enhanced status decode post-reset |
| SM-17 | Exhaustive legality matrix for status and identity opcodes |
| SM-18 | read_id structural correctness with TLC cell-type field |
| SM-19 | Parameter page minimum field contract |
| SM-20 | Parameter page stability across consecutive reads |
| SM-21 | Reset produces deterministic clean baseline with no EAT drift |
| SM-22 | Invalid-argument rejection paths |
| SM-23 | FAIL latch persistence across read and read_id, cleared by reset and successful program |
| SM-24 | Identity ops during synthetic `DIE_SUSPENDED_PROG` preserve state, phase, opcode, target, in_flight, remaining_ns, suspend_count |

## Test plan

- [x] \`test_media\` 243/243 (126 Phase 1 + 88 Phase 2 + 29 review-fix)
- [x] \`test_hal\` 61/61
- [x] \`test_reliability\` 76/76
- [x] \`test_ftl_reliability\` 31/31
- [x] \`test_mt_ftl\` 10/10 (0 TAA conflicts)
- [x] \`systest_data_integrity\` 50/50 (400.8 s)
- [x] \`systest_wear_gc\` 48/48 (1456.7 s)
- [x] Clean rebuild after clang-format, no new warnings