### PR TITLE
feat: NAND command engine suspend/resume

### DIFF
--- a/include/media/cmd_engine.h
+++ b/include/media/cmd_engine.h
@@ -60,6 +60,19 @@ int nand_cmd_engine_submit_read_param_page(struct nand_device *dev, const struct
                                            struct nand_parameter_page *out);
 
 /*
+ * Suspend/resume submission paths. All four take only the die-level lock
+ * so the submitting thread can reach the running worker without blocking
+ * on the channel lock that the worker released across its array-busy
+ * spin. The suspend entry points only use (ch, chip, die) from target;
+ * block/page/plane_mask fields are ignored because these commands act on
+ * the currently in-flight op of the addressed die.
+ */
+int nand_cmd_engine_submit_prog_suspend(struct nand_device *dev, const struct nand_cmd_target *target);
+int nand_cmd_engine_submit_prog_resume(struct nand_device *dev, const struct nand_cmd_target *target);
+int nand_cmd_engine_submit_erase_suspend(struct nand_device *dev, const struct nand_cmd_target *target);
+int nand_cmd_engine_submit_erase_resume(struct nand_device *dev, const struct nand_cmd_target *target);
+
+/*
  * Stage-budget split. Kept in its own translation unit so the partition
  * can be refined later without touching the engine.
  */

--- a/include/media/cmd_state.h
+++ b/include/media/cmd_state.h
@@ -1,6 +1,8 @@
 #ifndef __HFSSS_NAND_CMD_STATE_H
 #define __HFSSS_NAND_CMD_STATE_H
 
+#include <stdatomic.h>
+
 #include "common/common.h"
 #include "common/mutex.h"
 
@@ -41,6 +43,10 @@ enum nand_cmd_opcode {
     NAND_OP_READ_STATUS_ENHANCED,
     NAND_OP_READ_ID,
     NAND_OP_READ_PARAM_PAGE,
+    NAND_OP_PROG_SUSPEND,
+    NAND_OP_PROG_RESUME,
+    NAND_OP_ERASE_SUSPEND,
+    NAND_OP_ERASE_RESUME,
     NAND_OP_COUNT
 };
 
@@ -73,6 +79,30 @@ struct nand_die_cmd_state {
      * operations must not disturb it.
      */
     bool latched_fail;
+    /*
+     * Suspend/resume bookkeeping (Phase 3). array_started_ns anchors the
+     * current array-busy segment so the engine can compute how much of
+     * remaining_ns has drained when a suspend preempts it. suspended_target
+     * snapshots the target of the op that is under suspension so a
+     * concurrent read can be matched against it for conflict gating;
+     * relying on target here is unsafe because a non-conflicting read
+     * legitimately rewrites it. suspend_request is the atomic interrupt
+     * flag polled by the array-busy spin loop in engine_submit. abort_request
+     * is set by reset-during-suspend to wake the spin, have it skip the
+     * commit hook, and let it drive the die to IDLE cleanly.
+     */
+    /*
+     * array_started_ns, array_budget_ns, and remaining_ns are read by the
+     * tight spin in engine_run_array_busy without holding die_lock. On
+     * x86-64 and AArch64 (the project's target platforms) aligned u64
+     * loads are naturally atomic. If the simulator is ever ported to a
+     * 32-bit target these should become _Atomic u64.
+     */
+    u64 array_started_ns;
+    u64 array_budget_ns;
+    struct nand_cmd_target suspended_target;
+    _Atomic int suspend_request;
+    _Atomic int abort_request;
 };
 
 void nand_cmd_state_init(struct nand_die_cmd_state *s);

--- a/include/media/media.h
+++ b/include/media/media.h
@@ -65,6 +65,11 @@ int media_nand_read_status_byte(struct media_ctx *ctx, u32 ch, u32 chip, u32 die
 int media_nand_read_status_enhanced(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_status_enhanced *out);
 int media_nand_read_id(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_id *out);
 int media_nand_read_parameter_page(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_parameter_page *out);
+int media_nand_program_suspend(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);
+int media_nand_program_resume(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);
+int media_nand_erase_suspend(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);
+int media_nand_erase_resume(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);
+int media_nand_reset(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);
 int media_nand_is_bad_block(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block);
 int media_nand_mark_bad_block(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block);
 u32 media_nand_get_erase_count(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block);

--- a/include/media/timing.h
+++ b/include/media/timing.h
@@ -13,16 +13,18 @@ enum nand_type {
 
 /* Timing Parameters (ns) */
 struct timing_params {
-    u64 tCCS;    /* Change Column Setup */
-    u64 tR;      /* Read */
-    u64 tPROG;   /* Program */
-    u64 tERS;    /* Erase */
-    u64 tWC;     /* Write Cycle */
-    u64 tRC;     /* Read Cycle */
-    u64 tADL;    /* Address Load */
-    u64 tWB;     /* Write Busy */
-    u64 tWHR;    /* Write Hold */
-    u64 tRHW;    /* Read Hold */
+    u64 tCCS;   /* Change Column Setup */
+    u64 tR;     /* Read */
+    u64 tPROG;  /* Program */
+    u64 tERS;   /* Erase */
+    u64 tWC;    /* Write Cycle */
+    u64 tRC;    /* Read Cycle */
+    u64 tADL;   /* Address Load */
+    u64 tWB;    /* Write Busy */
+    u64 tWHR;   /* Write Hold */
+    u64 tRHW;   /* Read Hold */
+    u64 tSSBSY; /* Suspend Setup Busy — cost of entering a suspended state */
+    u64 tRSBSY; /* Resume Setup Busy — cost of returning to array busy */
 };
 
 /* TLC Timing Model */
@@ -33,6 +35,8 @@ struct tlc_timing {
     u64 tPROG_LSB;
     u64 tPROG_CSB;
     u64 tPROG_MSB;
+    u64 tSSBSY;
+    u64 tRSBSY;
 };
 
 /* Timing Model */
@@ -50,5 +54,7 @@ void timing_model_cleanup(struct timing_model *model);
 u64 timing_get_read_latency(struct timing_model *model, u32 page_idx);
 u64 timing_get_prog_latency(struct timing_model *model, u32 page_idx);
 u64 timing_get_erase_latency(struct timing_model *model);
+u64 timing_get_suspend_overhead_ns(struct timing_model *model);
+u64 timing_get_resume_overhead_ns(struct timing_model *model);
 
 #endif /* __HFSSS_TIMING_H */

--- a/src/media/cmd_engine.c
+++ b/src/media/cmd_engine.c
@@ -1,5 +1,8 @@
 #include "media/cmd_engine.h"
 
+#include <sched.h>
+#include <stdatomic.h>
+
 #include "common/mutex.h"
 #include "media/cmd_legality.h"
 #include "media/cmd_state.h"
@@ -84,6 +87,126 @@ static void engine_wait_until_available(struct eat_ctx *eat, enum op_type op, u3
     }
 }
 
+/*
+ * Phase 3 array-busy wait. Returns a completion code describing why the wait
+ * ended:
+ *   ENGINE_WAIT_DONE     — remaining_ns drained normally, commit can run
+ *   ENGINE_WAIT_SUSPEND  — suspend_request observed; remaining_ns has been
+ *                          updated to reflect the unconsumed portion, the die
+ *                          state has been flipped to DIE_SUSPENDED_*, and the
+ *                          loop has already drained the subsequent suspended
+ *                          window by waiting for resume (or abort). On return
+ *                          the die is back to *_ARRAY_BUSY with a refreshed
+ *                          array_started_ns. Caller resumes counting down.
+ *   ENGINE_WAIT_ABORT    — abort_request observed (reset-during-suspend, or
+ *                          reset-while-spinning). Caller MUST skip the
+ *                          commit hook and drive the die to IDLE. remaining_ns
+ *                          is zeroed.
+ *
+ * The loop runs with no locks held except for the brief die_lock windows it
+ * opens to inspect/mutate cmd_state. That matches the Phase 2 lock discipline.
+ */
+enum engine_wait_result {
+    ENGINE_WAIT_DONE = 0,
+    ENGINE_WAIT_SUSPEND,
+    ENGINE_WAIT_ABORT,
+};
+
+static enum engine_wait_result engine_run_array_busy(struct nand_device *dev, struct nand_die *die,
+                                                     enum nand_cmd_opcode op, const struct nand_cmd_target *target,
+                                                     u32 plane)
+{
+    for (;;) {
+        if (atomic_load(&die->cmd_state.abort_request)) {
+            /* Reset already forced state to DIE_IDLE + in_flight=false
+             * under die_lock. We return immediately without touching
+             * cmd_state — any mutation here would race with whatever op
+             * (if any) the die owner starts next. The caller skips its
+             * final cleanup block entirely. */
+            return ENGINE_WAIT_ABORT;
+        }
+
+        if (atomic_load(&die->cmd_state.suspend_request)) {
+            /* Account the drained portion of this array-busy segment and
+             * flip to the suspended state under die_lock. Recheck abort
+             * inside the lock window to avoid overwriting a concurrent
+             * reset's clean state with DIE_SUSPENDED_*. */
+            mutex_lock(&die->die_lock, 0);
+            if (atomic_load(&die->cmd_state.abort_request)) {
+                mutex_unlock(&die->die_lock);
+                return ENGINE_WAIT_ABORT;
+            }
+            u64 now = get_time_ns();
+            u64 elapsed = now - die->cmd_state.array_started_ns;
+            if (elapsed > die->cmd_state.remaining_ns) {
+                elapsed = die->cmd_state.remaining_ns;
+            }
+            die->cmd_state.remaining_ns -= elapsed;
+            if (op == NAND_OP_PROG) {
+                die->cmd_state.state = DIE_SUSPENDED_PROG;
+            } else {
+                die->cmd_state.state = DIE_SUSPENDED_ERASE;
+            }
+            die->cmd_state.last_suspend_ts_ns = now;
+            die->cmd_state.suspend_count++;
+            atomic_store(&die->cmd_state.suspend_request, 0);
+            mutex_unlock(&die->die_lock);
+
+            /* Charge tSSBSY to EAT and drain the matching wall-clock so
+             * the overhead is reflected in both statistics and observable
+             * latency. */
+            u64 sus_ov = timing_get_suspend_overhead_ns(dev->timing);
+            enum op_type sus_eat_op = (op == NAND_OP_PROG) ? OP_PROGRAM : OP_ERASE;
+            if (sus_ov > 0) {
+                eat_update_stage(dev->eat, sus_eat_op, target->ch, target->chip, target->die, plane, sus_ov);
+            }
+            u64 sus_deadline = get_time_ns() + sus_ov;
+            while (get_time_ns() < sus_deadline) {
+                /* busy spin */
+            }
+
+            /* Wait for resume or abort. While suspended the die state is
+             * DIE_SUSPENDED_*; resume flips it back to *_ARRAY_BUSY. The
+             * spin-and-yield pattern bounds CPU cost during test-driven
+             * suspend windows. */
+            for (;;) {
+                if (atomic_load(&die->cmd_state.abort_request)) {
+                    return ENGINE_WAIT_ABORT;
+                }
+                enum nand_die_state s;
+                mutex_lock(&die->die_lock, 0);
+                s = die->cmd_state.state;
+                mutex_unlock(&die->die_lock);
+                if (s == DIE_PROG_ARRAY_BUSY || s == DIE_ERASE_ARRAY_BUSY) {
+                    break;
+                }
+                sched_yield();
+            }
+
+            /* Resumed: reset the segment anchor so the next iteration
+             * measures elapsed time from the resume point, not the original
+             * submit. Resume overhead was already accounted for by the
+             * resume submit path. */
+            mutex_lock(&die->die_lock, 0);
+            die->cmd_state.array_started_ns = get_time_ns();
+            mutex_unlock(&die->die_lock);
+            continue;
+        }
+
+        u64 now = get_time_ns();
+        u64 elapsed = now - die->cmd_state.array_started_ns;
+        if (elapsed >= die->cmd_state.remaining_ns) {
+            mutex_lock(&die->die_lock, 0);
+            die->cmd_state.remaining_ns = 0;
+            mutex_unlock(&die->die_lock);
+            return ENGINE_WAIT_DONE;
+        }
+        /* Tight spin preserves existing wall-clock semantics for timing
+         * tests. The suspend/abort checks above make this bounded even
+         * during a long tPROG. */
+    }
+}
+
 static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const struct nand_cmd_target *target,
                          const struct nand_cmd_ops *ops, void *cb_ctx)
 {
@@ -115,6 +238,12 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
      * busy-waiting or running its commit hook — satisfying the
      * "status observable concurrently with in-flight command" contract
      * in the design spec concurrency section.
+     *
+     * Phase 3: for PROG/ERASE submissions the channel lock is released
+     * across the array-busy wait so a suspend submitted by another thread
+     * can acquire it and set the interrupt flag. The die state machine
+     * still prevents a second PROG/ERASE from sneaking in because the
+     * legality matrix rejects non-suspend ops in DIE_*_ARRAY_BUSY.
      */
     mutex_lock(&channel->lock, 0);
     mutex_lock(&die->die_lock, 0);
@@ -125,19 +254,79 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         return HFSSS_ERR_BUSY;
     }
 
+    /*
+     * Read-during-suspend conflict gate. A read against the same physical
+     * page as the suspended program (or the same block as the suspended
+     * erase) returns BUSY without touching cmd_state. Non-conflicting reads
+     * fall through to the normal begin() path below and preserve the
+     * suspension context because non-conflict read state transitions are
+     * engine-managed around the existing fields — see the DIE_SUSPENDED_*
+     * arm in nand_cmd_next_state_on_accept.
+     */
+    if (op == NAND_OP_READ &&
+        (die->cmd_state.state == DIE_SUSPENDED_PROG || die->cmd_state.state == DIE_SUSPENDED_ERASE)) {
+        const struct nand_cmd_target *s = &die->cmd_state.suspended_target;
+        bool conflict = false;
+        if (die->cmd_state.state == DIE_SUSPENDED_PROG) {
+            conflict = (target->block == s->block && target->page == s->page);
+        } else {
+            conflict = (target->block == s->block);
+        }
+        if (conflict) {
+            mutex_unlock(&die->die_lock);
+            mutex_unlock(&channel->lock);
+            return HFSSS_ERR_BUSY;
+        }
+    }
+
+    /*
+     * Non-conflicting read during a suspended PROG/ERASE takes a fast path
+     * that runs the read entirely on the caller's stack: the suspension
+     * context (state/phase/opcode/target/remaining_ns/suspend_count/
+     * in_flight) must not be disturbed, and the lightweight path matches
+     * the Phase 2 identity/status discipline for mid-flight observability.
+     */
+    const bool is_read_during_suspend = (op == NAND_OP_READ) && (die->cmd_state.state == DIE_SUSPENDED_PROG ||
+                                                                 die->cmd_state.state == DIE_SUSPENDED_ERASE);
+
     u64 total_ns = engine_total_budget(dev->timing, op, target->page);
-    nand_cmd_state_begin(&die->cmd_state, op, target, total_ns);
-    mutex_unlock(&die->die_lock);
-
     enum op_type eat_op = op_to_eat_op(op);
-    engine_wait_until_available(dev->eat, eat_op, target->ch, target->chip, target->die, plane);
-
     u64 setup_ns = 0;
     u64 array_ns = 0;
     u64 xfer_ns = 0;
     nand_cmd_stage_budget(op, total_ns, &setup_ns, &array_ns, &xfer_ns);
-
     int stage_rc = HFSSS_OK;
+
+    if (is_read_during_suspend) {
+        mutex_unlock(&die->die_lock);
+
+        engine_wait_until_available(dev->eat, eat_op, target->ch, target->chip, target->die, plane);
+
+        if (ops && ops->on_setup_commit) {
+            stage_rc = ops->on_setup_commit(cb_ctx);
+        }
+        if (stage_rc == HFSSS_OK) {
+            eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, setup_ns);
+            eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, array_ns);
+            if (ops && ops->on_array_commit) {
+                stage_rc = ops->on_array_commit(cb_ctx);
+            }
+        }
+        if (stage_rc == HFSSS_OK) {
+            eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, xfer_ns);
+            if (ops && ops->on_data_xfer_commit) {
+                stage_rc = ops->on_data_xfer_commit(cb_ctx);
+            }
+        }
+
+        mutex_unlock(&channel->lock);
+        return stage_rc;
+    }
+
+    nand_cmd_state_begin(&die->cmd_state, op, target, total_ns);
+    mutex_unlock(&die->die_lock);
+
+    engine_wait_until_available(dev->eat, eat_op, target->ch, target->chip, target->die, plane);
 
     /* Setup stage runs the setup hook first so address/target validation can
      * reject the command without burning any array/xfer time, matching the
@@ -150,6 +339,8 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, setup_ns);
     }
 
+    enum engine_wait_result wait_rc = ENGINE_WAIT_DONE;
+
     /* Array-busy stage: EAT is committed before the commit hook so the
      * caller-visible completion boundary is reached at the start of the
      * array mutation, matching the legacy eat-before-memcpy ordering. */
@@ -157,9 +348,25 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         mutex_lock(&die->die_lock, 0);
         enum nand_die_state next_array_state = nand_cmd_next_state_on_complete(die->cmd_state.state, op);
         nand_cmd_state_advance_phase(&die->cmd_state, CMD_PHASE_ARRAY_BUSY, next_array_state);
+        die->cmd_state.array_budget_ns = array_ns;
+        die->cmd_state.remaining_ns = array_ns;
+        die->cmd_state.array_started_ns = get_time_ns();
         mutex_unlock(&die->die_lock);
+
         eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, array_ns);
-        if (ops && ops->on_array_commit) {
+
+        if (op == NAND_OP_PROG || op == NAND_OP_ERASE) {
+            /* Drop the channel lock so a concurrent suspend/reset submit
+             * can reach the die. The die state machine guards against any
+             * other submit type sneaking in during the window. */
+            mutex_unlock(&channel->lock);
+            wait_rc = engine_run_array_busy(dev, die, op, target, plane);
+            mutex_lock(&channel->lock, 0);
+        }
+
+        if (wait_rc == ENGINE_WAIT_ABORT) {
+            stage_rc = HFSSS_ERR_BUSY;
+        } else if (ops && ops->on_array_commit) {
             stage_rc = ops->on_array_commit(cb_ctx);
         }
     }
@@ -178,6 +385,15 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         }
     }
 
+    /* On abort the reset path already force-cleaned cmd_state. Touching
+     * it again would race with any new op the die owner starts after the
+     * reset. Skip the final cleanup entirely — just release the channel
+     * lock (re-acquired above) and return the abort error code. */
+    if (wait_rc == ENGINE_WAIT_ABORT) {
+        mutex_unlock(&channel->lock);
+        return HFSSS_ERR_BUSY;
+    }
+
     /* Drive the die back to IDLE regardless of commit status so a failed
      * hook does not strand the die. PROG/ERASE completions update the
      * ONFI sticky FAIL latch: a successful completion clears the latch,
@@ -189,6 +405,10 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
     die->cmd_state.phase = CMD_PHASE_COMPLETE;
     die->cmd_state.state = DIE_IDLE;
     die->cmd_state.remaining_ns = 0;
+    die->cmd_state.array_budget_ns = 0;
+    die->cmd_state.array_started_ns = 0;
+    atomic_store(&die->cmd_state.suspend_request, 0);
+    atomic_store(&die->cmd_state.abort_request, 0);
     if (op == NAND_OP_PROG || op == NAND_OP_ERASE) {
         die->cmd_state.latched_fail = (stage_rc != HFSSS_OK);
     }
@@ -240,42 +460,158 @@ int nand_cmd_engine_submit_reset(struct nand_device *dev, const struct nand_cmd_
         return HFSSS_ERR_INVAL;
     }
 
-    struct nand_channel *channel = engine_get_channel(dev, target->ch);
-    if (!channel) {
-        return HFSSS_ERR_INVAL;
-    }
     struct nand_die *die = engine_get_die(dev, target->ch, target->chip, target->die);
     if (!die) {
         return HFSSS_ERR_INVAL;
     }
 
     /*
-     * The synchronous submission model means any concurrent reset caller is
-     * serialized behind the active command via the channel and die locks, so
-     * reset always observes an idle die. True mid-flight abort is deferred to
-     * the async execution model in a later phase.
+     * Reset takes only the die lock so it can abort an in-flight PROG/ERASE
+     * whose worker is spinning in engine_run_array_busy with the channel
+     * lock released. The force-reset writes a clean state and sets
+     * abort_request so the worker — if one exists — will observe the flag
+     * on its next iteration and return ENGINE_WAIT_ABORT. The worker's
+     * engine_submit final block is skipped on abort so it cannot overwrite
+     * the clean state written here.
      */
-    mutex_lock(&channel->lock, 0);
     mutex_lock(&die->die_lock, 0);
 
     if (!nand_cmd_is_legal_in_state(die->cmd_state.state, NAND_OP_RESET)) {
         mutex_unlock(&die->die_lock);
-        mutex_unlock(&channel->lock);
         return HFSSS_ERR_BUSY;
     }
 
-    nand_cmd_state_begin(&die->cmd_state, NAND_OP_RESET, target, 0);
+    /* Signal any running worker to bail. Harmless if no worker exists
+     * (synthetic test state, or die is already IDLE). */
+    atomic_store(&die->cmd_state.abort_request, 1);
+    atomic_store(&die->cmd_state.suspend_request, 0);
+
     die->cmd_state.state = DIE_IDLE;
     die->cmd_state.phase = CMD_PHASE_COMPLETE;
     die->cmd_state.in_flight = false;
     die->cmd_state.remaining_ns = 0;
     die->cmd_state.result_status = HFSSS_OK;
+    die->cmd_state.array_budget_ns = 0;
+    die->cmd_state.array_started_ns = 0;
     /* ONFI 4.2: RESET clears the sticky FAIL latch. */
     die->cmd_state.latched_fail = false;
 
     mutex_unlock(&die->die_lock);
-    mutex_unlock(&channel->lock);
     return HFSSS_OK;
+}
+
+/*
+ * Suspend/resume submission path. Suspend sets an atomic interrupt flag
+ * that the array-busy spin observes; it then waits (briefly) for the spin
+ * to acknowledge the transition by flipping state to DIE_SUSPENDED_*, so
+ * the caller can immediately issue a conflict-checked read afterward with
+ * deterministic ordering. Resume does the opposite: it flips state back to
+ * DIE_*_ARRAY_BUSY and charges tRSBSY against EAT so timing stats reflect
+ * the overhead.
+ */
+static int engine_submit_suspend(struct nand_device *dev, enum nand_cmd_opcode op, const struct nand_cmd_target *target)
+{
+    if (!dev || !target) {
+        return HFSSS_ERR_INVAL;
+    }
+    if (op != NAND_OP_PROG_SUSPEND && op != NAND_OP_ERASE_SUSPEND) {
+        return HFSSS_ERR_INVAL;
+    }
+
+    struct nand_die *die = engine_get_die(dev, target->ch, target->chip, target->die);
+    if (!die) {
+        return HFSSS_ERR_INVAL;
+    }
+
+    mutex_lock(&die->die_lock, 0);
+    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, op)) {
+        mutex_unlock(&die->die_lock);
+        return HFSSS_ERR_BUSY;
+    }
+    /* Snapshot the running op's target before the spin can rewrite
+     * cmd_state.target. The conflict check in engine_submit reads this
+     * field under die_lock. */
+    die->cmd_state.suspended_target = die->cmd_state.target;
+    atomic_store(&die->cmd_state.suspend_request, 1);
+    mutex_unlock(&die->die_lock);
+
+    /* Spin briefly waiting for the running worker to acknowledge the
+     * suspend by flipping state. Bounded by the spin interval inside
+     * engine_run_array_busy plus tSSBSY. */
+    enum nand_die_state want = (op == NAND_OP_PROG_SUSPEND) ? DIE_SUSPENDED_PROG : DIE_SUSPENDED_ERASE;
+    for (;;) {
+        enum nand_die_state s;
+        mutex_lock(&die->die_lock, 0);
+        s = die->cmd_state.state;
+        mutex_unlock(&die->die_lock);
+        if (s == want) {
+            return HFSSS_OK;
+        }
+        if (s == DIE_IDLE) {
+            /* The running op raced us to completion. The suspend submit
+             * lost the race but the caller-visible contract is
+             * unchanged: the die is idle, no op is suspended. Report
+             * BUSY so the caller knows the suspend was not honored. */
+            return HFSSS_ERR_BUSY;
+        }
+        sched_yield();
+    }
+}
+
+static int engine_submit_resume(struct nand_device *dev, enum nand_cmd_opcode op, const struct nand_cmd_target *target)
+{
+    if (!dev || !target) {
+        return HFSSS_ERR_INVAL;
+    }
+    if (op != NAND_OP_PROG_RESUME && op != NAND_OP_ERASE_RESUME) {
+        return HFSSS_ERR_INVAL;
+    }
+
+    struct nand_die *die = engine_get_die(dev, target->ch, target->chip, target->die);
+    if (!die) {
+        return HFSSS_ERR_INVAL;
+    }
+
+    u32 plane = 0;
+    /* Resume updates EAT on the same plane as the suspended op. */
+    mutex_lock(&die->die_lock, 0);
+    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, op)) {
+        mutex_unlock(&die->die_lock);
+        return HFSSS_ERR_BUSY;
+    }
+    int rc = plane_index_from_mask(die->cmd_state.suspended_target.plane_mask, &plane);
+    if (rc != HFSSS_OK) {
+        plane = 0;
+    }
+    die->cmd_state.state = (op == NAND_OP_PROG_RESUME) ? DIE_PROG_ARRAY_BUSY : DIE_ERASE_ARRAY_BUSY;
+    mutex_unlock(&die->die_lock);
+
+    enum op_type eat_op = (op == NAND_OP_PROG_RESUME) ? OP_PROGRAM : OP_ERASE;
+    u64 resume_ov = timing_get_resume_overhead_ns(dev->timing);
+    if (resume_ov > 0) {
+        eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, resume_ov);
+    }
+    return HFSSS_OK;
+}
+
+int nand_cmd_engine_submit_prog_suspend(struct nand_device *dev, const struct nand_cmd_target *target)
+{
+    return engine_submit_suspend(dev, NAND_OP_PROG_SUSPEND, target);
+}
+
+int nand_cmd_engine_submit_prog_resume(struct nand_device *dev, const struct nand_cmd_target *target)
+{
+    return engine_submit_resume(dev, NAND_OP_PROG_RESUME, target);
+}
+
+int nand_cmd_engine_submit_erase_suspend(struct nand_device *dev, const struct nand_cmd_target *target)
+{
+    return engine_submit_suspend(dev, NAND_OP_ERASE_SUSPEND, target);
+}
+
+int nand_cmd_engine_submit_erase_resume(struct nand_device *dev, const struct nand_cmd_target *target)
+{
+    return engine_submit_resume(dev, NAND_OP_ERASE_RESUME, target);
 }
 
 int nand_cmd_engine_snapshot(struct nand_device *dev, const struct nand_cmd_target *target,

--- a/src/media/cmd_legality.c
+++ b/src/media/cmd_legality.c
@@ -57,6 +57,7 @@ static const bool k_legal[DIE_STATE_COUNT][NAND_OP_COUNT] = {
             [NAND_OP_RESET] = true,
             [NAND_OP_READ_STATUS] = true,
             [NAND_OP_READ_STATUS_ENHANCED] = true,
+            [NAND_OP_PROG_SUSPEND] = true,
         },
     [DIE_ERASE_SETUP] =
         {
@@ -69,22 +70,27 @@ static const bool k_legal[DIE_STATE_COUNT][NAND_OP_COUNT] = {
             [NAND_OP_RESET] = true,
             [NAND_OP_READ_STATUS] = true,
             [NAND_OP_READ_STATUS_ENHANCED] = true,
+            [NAND_OP_ERASE_SUSPEND] = true,
         },
     [DIE_SUSPENDED_PROG] =
         {
+            [NAND_OP_READ] = true,
             [NAND_OP_RESET] = true,
             [NAND_OP_READ_STATUS] = true,
             [NAND_OP_READ_STATUS_ENHANCED] = true,
             [NAND_OP_READ_ID] = true,
             [NAND_OP_READ_PARAM_PAGE] = true,
+            [NAND_OP_PROG_RESUME] = true,
         },
     [DIE_SUSPENDED_ERASE] =
         {
+            [NAND_OP_READ] = true,
             [NAND_OP_RESET] = true,
             [NAND_OP_READ_STATUS] = true,
             [NAND_OP_READ_STATUS_ENHANCED] = true,
             [NAND_OP_READ_ID] = true,
             [NAND_OP_READ_PARAM_PAGE] = true,
+            [NAND_OP_ERASE_RESUME] = true,
         },
     [DIE_RESETTING] =
         {
@@ -108,6 +114,13 @@ enum nand_die_state nand_cmd_next_state_on_accept(enum nand_die_state state, enu
     }
     switch (op) {
     case NAND_OP_READ:
+        /* Read accepted during a suspended program/erase stays in the
+         * suspend state — the read runs to completion on top of the
+         * preserved suspension context and must not disturb it. The engine
+         * drives its own transitions for the read path in that case. */
+        if (state == DIE_SUSPENDED_PROG || state == DIE_SUSPENDED_ERASE) {
+            return state;
+        }
         return DIE_READ_SETUP;
     case NAND_OP_PROG:
         return DIE_PROG_SETUP;
@@ -115,6 +128,14 @@ enum nand_die_state nand_cmd_next_state_on_accept(enum nand_die_state state, enu
         return DIE_ERASE_SETUP;
     case NAND_OP_RESET:
         return DIE_RESETTING;
+    case NAND_OP_PROG_SUSPEND:
+        return DIE_SUSPENDED_PROG;
+    case NAND_OP_ERASE_SUSPEND:
+        return DIE_SUSPENDED_ERASE;
+    case NAND_OP_PROG_RESUME:
+        return DIE_PROG_ARRAY_BUSY;
+    case NAND_OP_ERASE_RESUME:
+        return DIE_ERASE_ARRAY_BUSY;
     default:
         return state;
     }

--- a/src/media/cmd_state.c
+++ b/src/media/cmd_state.c
@@ -43,6 +43,11 @@ void nand_cmd_state_begin(struct nand_die_cmd_state *s, enum nand_cmd_opcode op,
     s->in_flight = true;
     s->phase = CMD_PHASE_SETUP;
     s->state = nand_cmd_next_state_on_accept(s->state, op);
+    s->array_started_ns = 0;
+    s->array_budget_ns = 0;
+    memset(&s->suspended_target, 0, sizeof(s->suspended_target));
+    atomic_store(&s->suspend_request, 0);
+    atomic_store(&s->abort_request, 0);
 }
 
 void nand_cmd_state_advance_phase(struct nand_die_cmd_state *s, enum nand_cmd_phase next_phase,

--- a/src/media/media.c
+++ b/src/media/media.c
@@ -585,6 +585,73 @@ int media_nand_read_parameter_page(struct media_ctx *ctx, u32 ch, u32 chip, u32 
     return nand_cmd_engine_submit_read_param_page(ctx->nand, &target, out);
 }
 
+static int media_build_die_target(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_cmd_target *out)
+{
+    if (!ctx || !ctx->initialized || !out) {
+        return HFSSS_ERR_INVAL;
+    }
+    if (ch >= ctx->config.channel_count || chip >= ctx->config.chips_per_channel || die >= ctx->config.dies_per_chip) {
+        return HFSSS_ERR_INVAL;
+    }
+    out->ch = ch;
+    out->chip = chip;
+    out->die = die;
+    out->plane_mask = 1u << 0;
+    out->block = 0;
+    out->page = 0;
+    return HFSSS_OK;
+}
+
+int media_nand_program_suspend(struct media_ctx *ctx, u32 ch, u32 chip, u32 die)
+{
+    struct nand_cmd_target target;
+    int rc = media_build_die_target(ctx, ch, chip, die, &target);
+    if (rc != HFSSS_OK) {
+        return rc;
+    }
+    return nand_cmd_engine_submit_prog_suspend(ctx->nand, &target);
+}
+
+int media_nand_program_resume(struct media_ctx *ctx, u32 ch, u32 chip, u32 die)
+{
+    struct nand_cmd_target target;
+    int rc = media_build_die_target(ctx, ch, chip, die, &target);
+    if (rc != HFSSS_OK) {
+        return rc;
+    }
+    return nand_cmd_engine_submit_prog_resume(ctx->nand, &target);
+}
+
+int media_nand_erase_suspend(struct media_ctx *ctx, u32 ch, u32 chip, u32 die)
+{
+    struct nand_cmd_target target;
+    int rc = media_build_die_target(ctx, ch, chip, die, &target);
+    if (rc != HFSSS_OK) {
+        return rc;
+    }
+    return nand_cmd_engine_submit_erase_suspend(ctx->nand, &target);
+}
+
+int media_nand_erase_resume(struct media_ctx *ctx, u32 ch, u32 chip, u32 die)
+{
+    struct nand_cmd_target target;
+    int rc = media_build_die_target(ctx, ch, chip, die, &target);
+    if (rc != HFSSS_OK) {
+        return rc;
+    }
+    return nand_cmd_engine_submit_erase_resume(ctx->nand, &target);
+}
+
+int media_nand_reset(struct media_ctx *ctx, u32 ch, u32 chip, u32 die)
+{
+    struct nand_cmd_target target;
+    int rc = media_build_die_target(ctx, ch, chip, die, &target);
+    if (rc != HFSSS_OK) {
+        return rc;
+    }
+    return nand_cmd_engine_submit_reset(ctx->nand, &target);
+}
+
 int media_nand_is_bad_block(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block)
 {
     int is_bad;

--- a/src/media/nand_identity.c
+++ b/src/media/nand_identity.c
@@ -214,10 +214,11 @@ static void build_parameter_page(struct nand_parameter_page *pp, const struct me
     pp->ecc_bits_required = ecc_bits_from_nand_type(cfg->nand_type);
     pp->ecc_codeword_size = 1024;
 
-    pp->supported_cmd_bitmap = (1u << NAND_OP_READ) | (1u << NAND_OP_PROG) | (1u << NAND_OP_ERASE) |
-                               (1u << NAND_OP_RESET) | (1u << NAND_OP_READ_STATUS) |
-                               (1u << NAND_OP_READ_STATUS_ENHANCED) | (1u << NAND_OP_READ_ID) |
-                               (1u << NAND_OP_READ_PARAM_PAGE);
+    pp->supported_cmd_bitmap =
+        (1u << NAND_OP_READ) | (1u << NAND_OP_PROG) | (1u << NAND_OP_ERASE) | (1u << NAND_OP_RESET) |
+        (1u << NAND_OP_READ_STATUS) | (1u << NAND_OP_READ_STATUS_ENHANCED) | (1u << NAND_OP_READ_ID) |
+        (1u << NAND_OP_READ_PARAM_PAGE) | (1u << NAND_OP_PROG_SUSPEND) | (1u << NAND_OP_PROG_RESUME) |
+        (1u << NAND_OP_ERASE_SUSPEND) | (1u << NAND_OP_ERASE_RESUME);
 
     if (timing) {
         pp->tR_ns = timing_get_read_latency(timing, 0);
@@ -270,7 +271,7 @@ void nand_status_byte_from_cmd_state(const struct nand_die_cmd_state *s, u8 *out
         break;
     }
 
-    if (!array_busy) {
+    if (!array_busy && !suspended) {
         value |= NAND_STATUS_ARDY;
     }
     if (!array_busy || suspended) {
@@ -330,8 +331,9 @@ void nand_status_enhanced_from_cmd_state(const struct nand_die_cmd_state *s, str
         array_busy = true;
         break;
     }
-    out->array_ready = !array_busy;
-    out->ready = !array_busy || out->suspended_program || out->suspended_erase;
+    bool suspended = out->suspended_program || out->suspended_erase;
+    out->array_ready = !array_busy && !suspended;
+    out->ready = !array_busy || suspended;
 
     out->last_op_failed = s->latched_fail;
 

--- a/src/media/timing.c
+++ b/src/media/timing.c
@@ -13,6 +13,8 @@ static const struct timing_params default_slc_timing = {
     .tWB = 100,
     .tWHR = 60,
     .tRHW = 60,
+    .tSSBSY = 5000,
+    .tRSBSY = 5000,
 };
 
 /* Default timing parameters for MLC (ns) */
@@ -27,6 +29,8 @@ static const struct timing_params default_mlc_timing = {
     .tWB = 150,
     .tWHR = 80,
     .tRHW = 80,
+    .tSSBSY = 10000,
+    .tRSBSY = 10000,
 };
 
 /* Default timing parameters for TLC (ns) */
@@ -37,6 +41,8 @@ static const struct tlc_timing default_tlc_timing = {
     .tPROG_LSB = 900000,
     .tPROG_CSB = 1100000,
     .tPROG_MSB = 1300000,
+    .tSSBSY = 25000,
+    .tRSBSY = 25000,
 };
 
 /* Default timing parameters for QLC (ns) */
@@ -51,6 +57,8 @@ static const struct timing_params default_qlc_timing = {
     .tWB = 200,
     .tWHR = 100,
     .tRHW = 100,
+    .tSSBSY = 50000,
+    .tRSBSY = 50000,
 };
 
 int timing_model_init(struct timing_model *model, enum nand_type type)
@@ -94,10 +102,14 @@ u64 timing_get_read_latency(struct timing_model *model, u32 page_idx)
     case NAND_TYPE_TLC:
         /* TLC has different read latencies for different page types */
         switch (page_idx % 3) {
-        case 0: return model->tlc.tR_LSB;
-        case 1: return model->tlc.tR_CSB;
-        case 2: return model->tlc.tR_MSB;
-        default: return model->tlc.tR_LSB;
+        case 0:
+            return model->tlc.tR_LSB;
+        case 1:
+            return model->tlc.tR_CSB;
+        case 2:
+            return model->tlc.tR_MSB;
+        default:
+            return model->tlc.tR_LSB;
         }
     case NAND_TYPE_QLC:
         return model->qlc.tR;
@@ -120,10 +132,14 @@ u64 timing_get_prog_latency(struct timing_model *model, u32 page_idx)
     case NAND_TYPE_TLC:
         /* TLC has different program latencies for different page types */
         switch (page_idx % 3) {
-        case 0: return model->tlc.tPROG_LSB;
-        case 1: return model->tlc.tPROG_CSB;
-        case 2: return model->tlc.tPROG_MSB;
-        default: return model->tlc.tPROG_LSB;
+        case 0:
+            return model->tlc.tPROG_LSB;
+        case 1:
+            return model->tlc.tPROG_CSB;
+        case 2:
+            return model->tlc.tPROG_MSB;
+        default:
+            return model->tlc.tPROG_LSB;
         }
     case NAND_TYPE_QLC:
         return model->qlc.tPROG;
@@ -150,5 +166,45 @@ u64 timing_get_erase_latency(struct timing_model *model)
         return model->qlc.tERS;
     default:
         return model->slc.tERS * 2;
+    }
+}
+
+u64 timing_get_suspend_overhead_ns(struct timing_model *model)
+{
+    if (!model) {
+        return 0;
+    }
+
+    switch (model->type) {
+    case NAND_TYPE_SLC:
+        return model->slc.tSSBSY;
+    case NAND_TYPE_MLC:
+        return model->mlc.tSSBSY;
+    case NAND_TYPE_TLC:
+        return model->tlc.tSSBSY;
+    case NAND_TYPE_QLC:
+        return model->qlc.tSSBSY;
+    default:
+        return model->tlc.tSSBSY;
+    }
+}
+
+u64 timing_get_resume_overhead_ns(struct timing_model *model)
+{
+    if (!model) {
+        return 0;
+    }
+
+    switch (model->type) {
+    case NAND_TYPE_SLC:
+        return model->slc.tRSBSY;
+    case NAND_TYPE_MLC:
+        return model->mlc.tRSBSY;
+    case NAND_TYPE_TLC:
+        return model->tlc.tRSBSY;
+    case NAND_TYPE_QLC:
+        return model->qlc.tRSBSY;
+    default:
+        return model->tlc.tRSBSY;
     }
 }

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -1,3 +1,4 @@
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -838,6 +839,292 @@ static int test_cmd_phase2_commands(void)
     return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
 }
 
+/* Phase 3 suspend/resume tests — worker thread helpers */
+struct worker_ctx {
+    struct media_ctx *ctx;
+    u32 block;
+    u32 page;
+    int rc;
+};
+
+static void *prog_worker(void *arg)
+{
+    struct worker_ctx *w = (struct worker_ctx *)arg;
+    u8 buf[4096];
+    memset(buf, 0x5A, sizeof(buf));
+    w->rc = media_nand_program(w->ctx, 0, 0, 0, 0, w->block, w->page, buf, NULL);
+    return NULL;
+}
+
+static void *erase_worker(void *arg)
+{
+    struct worker_ctx *w = (struct worker_ctx *)arg;
+    w->rc = media_nand_erase(w->ctx, 0, 0, 0, 0, w->block);
+    return NULL;
+}
+
+static bool wait_for_state(struct media_ctx *ctx, enum nand_die_state want, u64 timeout_ns)
+{
+    u64 deadline = get_time_ns() + timeout_ns;
+    while (get_time_ns() < deadline) {
+        struct nand_status_enhanced enh;
+        if (media_nand_read_status_enhanced(ctx, 0, 0, 0, &enh) == HFSSS_OK && enh.state == want) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static int test_cmd_phase3_suspend_resume(void)
+{
+    printf("\n=== NAND Phase 3 Suspend/Resume Tests ===\n");
+
+    struct media_config config = {
+        .channel_count = 1,
+        .chips_per_channel = 1,
+        .dies_per_chip = 1,
+        .planes_per_die = 1,
+        .blocks_per_plane = 16,
+        .pages_per_block = 16,
+        .page_size = 4096,
+        .spare_size = 64,
+        .nand_type = NAND_TYPE_TLC,
+    };
+
+    struct media_ctx ctx;
+    int ret = media_init(&ctx, &config);
+    TEST_ASSERT(ret == HFSSS_OK, "Phase3: media_init succeeds");
+    if (ret != HFSSS_OK) {
+        return TEST_FAIL;
+    }
+
+    /* Pre-program a page for read-during-suspend tests. */
+    u8 preprog_buf[4096];
+    memset(preprog_buf, 0xBB, sizeof(preprog_buf));
+    ret = media_nand_program(&ctx, 0, 0, 0, 0, 7, 0, preprog_buf, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "Phase3: pre-program block 7 page 0");
+
+    /* SM-25: prog_suspend legal transition */
+    struct worker_ctx wctx = {.ctx = &ctx, .block = 5, .page = 10, .rc = -1};
+    pthread_t thr;
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    bool saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    TEST_ASSERT(saw_busy, "SM-25: observed DIE_PROG_ARRAY_BUSY");
+
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-25: prog_suspend returns OK");
+    struct nand_status_enhanced enh;
+    ret = media_nand_read_status_enhanced(&ctx, 0, 0, 0, &enh);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-25: status after suspend OK");
+    TEST_ASSERT(enh.state == DIE_SUSPENDED_PROG, "SM-25: state == DIE_SUSPENDED_PROG");
+    TEST_ASSERT(enh.suspend_count == 1, "SM-25: suspend_count == 1");
+    TEST_ASSERT(enh.remaining_ns > 0, "SM-25: remaining_ns > 0");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-25: resume returns OK");
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_OK, "SM-25: worker completed OK");
+
+    u8 readback[4096];
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 5, 10, readback, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-25: read-back after suspend/resume OK");
+    TEST_ASSERT(readback[0] == 0x5A, "SM-25: data correct after suspend/resume");
+
+    /* SM-26: suspend-illegal-state matrix */
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_IDLE, NAND_OP_PROG_SUSPEND) == false,
+                "SM-26: prog_suspend illegal in DIE_IDLE");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_PROG_SETUP, NAND_OP_PROG_SUSPEND) == false,
+                "SM-26: prog_suspend illegal in DIE_PROG_SETUP");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_ERASE_ARRAY_BUSY, NAND_OP_PROG_SUSPEND) == false,
+                "SM-26: prog_suspend illegal in DIE_ERASE_ARRAY_BUSY (type mismatch)");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_PROG_ARRAY_BUSY, NAND_OP_ERASE_SUSPEND) == false,
+                "SM-26: erase_suspend illegal in DIE_PROG_ARRAY_BUSY");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_SUSPENDED_PROG, NAND_OP_PROG_SUSPEND) == false,
+                "SM-26: no nested suspend");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_SUSPENDED_ERASE, NAND_OP_PROG_RESUME) == false,
+                "SM-26: prog_resume illegal on suspended erase (cross-type)");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_SUSPENDED_PROG, NAND_OP_ERASE_RESUME) == false,
+                "SM-26: erase_resume illegal on suspended prog (cross-type)");
+
+    /* SM-27: read during suspend, same-page conflict → BUSY */
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 5, .page = 11, .rc = -1};
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-27: suspend OK");
+
+    u8 conflict_buf[4096];
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 5, 11, conflict_buf, NULL);
+    TEST_ASSERT(ret == HFSSS_ERR_BUSY, "SM-27: same-page read returns BUSY");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_OK, "SM-27: worker completed OK after conflict rejection");
+
+    /* SM-28: read during suspend, different-page → success */
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 5, .page = 12, .rc = -1};
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-28: suspend OK");
+
+    struct nand_die_cmd_state snap_pre_read;
+    ret = nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                                   &snap_pre_read);
+
+    u8 non_conflict_buf[4096];
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 7, 0, non_conflict_buf, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-28: different-block read OK during suspend");
+    TEST_ASSERT(non_conflict_buf[0] == 0xBB, "SM-28: read data correct");
+
+    struct nand_die_cmd_state snap_post_read;
+    ret = nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                                   &snap_post_read);
+    TEST_ASSERT(snap_post_read.state == DIE_SUSPENDED_PROG, "SM-28: state preserved after non-conflict read");
+    TEST_ASSERT(snap_post_read.suspend_count == snap_pre_read.suspend_count, "SM-28: suspend_count preserved");
+    TEST_ASSERT(snap_post_read.remaining_ns == snap_pre_read.remaining_ns, "SM-28: remaining_ns preserved across read");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_OK, "SM-28: worker completed OK after non-conflict read");
+
+    /* SM-29: resume completes remaining_ns */
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 5, .page = 13, .rc = -1};
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-29: suspend OK");
+
+    struct nand_die_cmd_state snap_29;
+    nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                             &snap_29);
+    u64 remaining_before_resume = snap_29.remaining_ns;
+    TEST_ASSERT(remaining_before_resume > 0, "SM-29: remaining_ns positive before resume");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-29: resume OK");
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_OK, "SM-29: worker completed successfully");
+
+    u8 rb29[4096];
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 5, 13, rb29, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-29: data persisted after suspend/resume");
+    TEST_ASSERT(rb29[0] == 0x5A, "SM-29: data content matches");
+
+    /* SM-30: reset during suspended_prog aborts cleanly */
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 6, .page = 0, .rc = -1};
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-30: suspend OK");
+
+    ret = media_nand_reset(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-30: reset OK");
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_ERR_BUSY, "SM-30: worker returns BUSY (aborted)");
+
+    struct nand_die_cmd_state snap_30;
+    nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                             &snap_30);
+    TEST_ASSERT(snap_30.state == DIE_IDLE, "SM-30: state == DIE_IDLE after reset-abort");
+    TEST_ASSERT(snap_30.in_flight == false, "SM-30: in_flight false after reset-abort");
+    TEST_ASSERT(snap_30.latched_fail == false, "SM-30: FAIL latch cleared by reset");
+
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 6, 0, readback, NULL);
+    TEST_ASSERT(ret != HFSSS_OK, "SM-30: aborted program did not commit page");
+
+    /* SM-31: erase suspend/resume symmetric path */
+    /* Erase block 8 (unused) — need it non-erased first, program then erase */
+    u8 buf31[4096];
+    memset(buf31, 0xDD, sizeof(buf31));
+    ret = media_nand_program(&ctx, 0, 0, 0, 0, 8, 0, buf31, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-31: pre-program block 8 for erase test");
+
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 8, .page = 0, .rc = -1};
+    pthread_create(&thr, NULL, erase_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_ERASE_ARRAY_BUSY, 5000000000ULL);
+    TEST_ASSERT(saw_busy, "SM-31: observed DIE_ERASE_ARRAY_BUSY");
+
+    ret = media_nand_erase_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-31: erase_suspend OK");
+
+    ret = media_nand_read_status_enhanced(&ctx, 0, 0, 0, &enh);
+    TEST_ASSERT(enh.state == DIE_SUSPENDED_ERASE, "SM-31: state == DIE_SUSPENDED_ERASE");
+    TEST_ASSERT(enh.suspend_count == 1, "SM-31: suspend_count == 1");
+
+    ret = media_nand_erase_resume(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-31: erase_resume OK");
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_OK, "SM-31: erase worker completed OK");
+
+    u32 ec = media_nand_get_erase_count(&ctx, 0, 0, 0, 0, 8);
+    TEST_ASSERT(ec >= 1, "SM-31: erase count incremented");
+
+    /* SM-32: reset during erase array-busy aborts cleanly */
+    memset(buf31, 0xFF, sizeof(buf31));
+    ret = media_nand_program(&ctx, 0, 0, 0, 0, 11, 0, buf31, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-32: pre-program block 11");
+
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 11, .page = 0, .rc = -1};
+    pthread_create(&thr, NULL, erase_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_ERASE_ARRAY_BUSY, 5000000000ULL);
+    TEST_ASSERT(saw_busy, "SM-32: observed DIE_ERASE_ARRAY_BUSY");
+
+    ret = media_nand_erase_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-32: erase suspend OK");
+
+    ret = media_nand_reset(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-32: reset OK");
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_ERR_BUSY, "SM-32: erase worker returns BUSY (aborted)");
+
+    struct nand_die_cmd_state snap_32;
+    nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                             &snap_32);
+    TEST_ASSERT(snap_32.state == DIE_IDLE, "SM-32: state == DIE_IDLE after erase reset-abort");
+    TEST_ASSERT(snap_32.in_flight == false, "SM-32: in_flight false");
+
+    /* SM-33: wrong-type resume illegal */
+    memset(buf31, 0xEE, sizeof(buf31));
+    ret = media_nand_program(&ctx, 0, 0, 0, 0, 9, 0, buf31, NULL);
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 9, .page = 0, .rc = -1};
+    pthread_create(&thr, NULL, erase_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_ERASE_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_erase_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-33: erase suspend OK");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_ERR_BUSY, "SM-33: prog_resume on suspended erase returns BUSY");
+
+    ret = media_nand_erase_resume(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-33: correct resume type OK");
+    pthread_join(thr, NULL);
+
+    /* SM-34: status_byte during DIE_SUSPENDED_PROG */
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 10, .page = 0, .rc = -1};
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-34: suspend OK");
+
+    u8 sr34 = 0;
+    ret = media_nand_read_status_byte(&ctx, 0, 0, 0, &sr34);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-34: status_byte during suspend OK");
+    TEST_ASSERT((sr34 & NAND_STATUS_RDY) != 0, "SM-34: RDY set during suspend");
+    TEST_ASSERT((sr34 & NAND_STATUS_ARDY) == 0, "SM-34: ARDY clear during suspend");
+    TEST_ASSERT((sr34 & NAND_STATUS_FAIL) == 0, "SM-34: FAIL clear during suspend");
+
+    ret = media_nand_read_status_enhanced(&ctx, 0, 0, 0, &enh);
+    TEST_ASSERT(enh.suspended_program == true, "SM-34: suspended_program flag set");
+    TEST_ASSERT(enh.suspended_erase == false, "SM-34: suspended_erase flag clear");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    pthread_join(thr, NULL);
+
+    media_cleanup(&ctx);
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
 /* Main */
 int main(void)
 {
@@ -858,6 +1145,7 @@ int main(void)
     test_persistence();
     test_cmd_state_machine();
     test_cmd_phase2_commands();
+    test_cmd_phase3_suspend_resume();
 
     printf("\n========================================\n");
     printf("Test Summary\n");


### PR DESCRIPTION
## Summary

- Implement program suspend/resume and erase suspend/resume per design spec §8
- Release channel lock during array-busy spin, enabling concurrent suspend/reset via atomic interrupt flags
- Read-during-suspend conflict gate: same-page/block returns BUSY, non-conflicting reads preserve all suspension context
- Reset force-cleans state under die_lock without worker-wait, worker skips final block on abort
- Add tSSBSY/tRSBSY timing constants per cell family, charged to both EAT and wall-clock
- Fix ARDY status byte to report 0 during suspended states (ONFI 4.2 compliance)
- 67 new test assertions (SM-25..SM-34) using pthread worker pattern for real concurrent suspend/resume

## Review fixes applied pre-merge

| ID | Severity | Fix |
|----|----------|-----|
| R4 | CRITICAL | Recheck abort_request inside die_lock window before writing suspended state |
| R5 | MEDIUM | Charge tSSBSY to EAT via eat_update_stage in suspend arm |
| R6 | MEDIUM | Added SM-32 (erase reset-abort symmetric test) |
| R3 | HIGH | Documented u64 alignment assumption for x86-64/AArch64 targets |

## Regression results

| Suite | Result |
|-------|--------|
| test_media | 310/310 |
| test_hal | 61/61 |
| test_reliability | 76/76 |
| test_ftl_reliability | 31/31 |
| test_mt_ftl | 10/10 |

## Test plan

- [ ] CI clang-format check
- [ ] CI ASan / TSan / UBSan
- [ ] CI system tests (systest_data_integrity, systest_wear_gc)
- [ ] Verify SM-25..SM-34 pass with TSan enabled
- [ ] Review conflict gate for future multi-plane extension (deferred to Phase 4)