### PR TITLE
feat: multi-plane read/program/erase simulation

### DIFF
--- a/include/media/cmd_engine.h
+++ b/include/media/cmd_engine.h
@@ -60,6 +60,19 @@ int nand_cmd_engine_submit_read_param_page(struct nand_device *dev, const struct
                                            struct nand_parameter_page *out);
 
 /*
+ * Suspend/resume submission paths. All four take only the die-level lock
+ * so the submitting thread can reach the running worker without blocking
+ * on the channel lock that the worker released across its array-busy
+ * spin. The suspend entry points only use (ch, chip, die) from target;
+ * block/page/plane_mask fields are ignored because these commands act on
+ * the currently in-flight op of the addressed die.
+ */
+int nand_cmd_engine_submit_prog_suspend(struct nand_device *dev, const struct nand_cmd_target *target);
+int nand_cmd_engine_submit_prog_resume(struct nand_device *dev, const struct nand_cmd_target *target);
+int nand_cmd_engine_submit_erase_suspend(struct nand_device *dev, const struct nand_cmd_target *target);
+int nand_cmd_engine_submit_erase_resume(struct nand_device *dev, const struct nand_cmd_target *target);
+
+/*
  * Stage-budget split. Kept in its own translation unit so the partition
  * can be refined later without touching the engine.
  */

--- a/include/media/cmd_state.h
+++ b/include/media/cmd_state.h
@@ -1,6 +1,8 @@
 #ifndef __HFSSS_NAND_CMD_STATE_H
 #define __HFSSS_NAND_CMD_STATE_H
 
+#include <stdatomic.h>
+
 #include "common/common.h"
 #include "common/mutex.h"
 
@@ -41,6 +43,10 @@ enum nand_cmd_opcode {
     NAND_OP_READ_STATUS_ENHANCED,
     NAND_OP_READ_ID,
     NAND_OP_READ_PARAM_PAGE,
+    NAND_OP_PROG_SUSPEND,
+    NAND_OP_PROG_RESUME,
+    NAND_OP_ERASE_SUSPEND,
+    NAND_OP_ERASE_RESUME,
     NAND_OP_COUNT
 };
 
@@ -73,6 +79,30 @@ struct nand_die_cmd_state {
      * operations must not disturb it.
      */
     bool latched_fail;
+    /*
+     * Suspend/resume bookkeeping (Phase 3). array_started_ns anchors the
+     * current array-busy segment so the engine can compute how much of
+     * remaining_ns has drained when a suspend preempts it. suspended_target
+     * snapshots the target of the op that is under suspension so a
+     * concurrent read can be matched against it for conflict gating;
+     * relying on target here is unsafe because a non-conflicting read
+     * legitimately rewrites it. suspend_request is the atomic interrupt
+     * flag polled by the array-busy spin loop in engine_submit. abort_request
+     * is set by reset-during-suspend to wake the spin, have it skip the
+     * commit hook, and let it drive the die to IDLE cleanly.
+     */
+    /*
+     * array_started_ns, array_budget_ns, and remaining_ns are read by the
+     * tight spin in engine_run_array_busy without holding die_lock. On
+     * x86-64 and AArch64 (the project's target platforms) aligned u64
+     * loads are naturally atomic. If the simulator is ever ported to a
+     * 32-bit target these should become _Atomic u64.
+     */
+    u64 array_started_ns;
+    u64 array_budget_ns;
+    struct nand_cmd_target suspended_target;
+    _Atomic int suspend_request;
+    _Atomic int abort_request;
 };
 
 void nand_cmd_state_init(struct nand_die_cmd_state *s);

--- a/include/media/cmd_state.h
+++ b/include/media/cmd_state.h
@@ -102,7 +102,14 @@ struct nand_die_cmd_state {
     u64 array_budget_ns;
     struct nand_cmd_target suspended_target;
     _Atomic int suspend_request;
-    _Atomic int abort_request;
+    /*
+     * abort_epoch: incremented by RESET to signal abort. Workers snapshot
+     * the epoch at submit time; if the current epoch differs from the
+     * snapshot the worker knows a reset occurred. This avoids the race
+     * where a new command's begin() clears a boolean abort_request
+     * before the old worker observes it.
+     */
+    _Atomic u32 abort_epoch;
 };
 
 void nand_cmd_state_init(struct nand_die_cmd_state *s);

--- a/include/media/media.h
+++ b/include/media/media.h
@@ -65,6 +65,11 @@ int media_nand_read_status_byte(struct media_ctx *ctx, u32 ch, u32 chip, u32 die
 int media_nand_read_status_enhanced(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_status_enhanced *out);
 int media_nand_read_id(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_id *out);
 int media_nand_read_parameter_page(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_parameter_page *out);
+int media_nand_multi_plane_read(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane_mask, u32 block, u32 page,
+                                void **data_array, void **spare_array);
+int media_nand_multi_plane_program(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane_mask, u32 block,
+                                   u32 page, const void **data_array, const void **spare_array);
+int media_nand_multi_plane_erase(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane_mask, u32 block);
 int media_nand_program_suspend(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);
 int media_nand_program_resume(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);
 int media_nand_erase_suspend(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);

--- a/include/media/media.h
+++ b/include/media/media.h
@@ -65,6 +65,11 @@ int media_nand_read_status_byte(struct media_ctx *ctx, u32 ch, u32 chip, u32 die
 int media_nand_read_status_enhanced(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_status_enhanced *out);
 int media_nand_read_id(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_id *out);
 int media_nand_read_parameter_page(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_parameter_page *out);
+int media_nand_program_suspend(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);
+int media_nand_program_resume(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);
+int media_nand_erase_suspend(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);
+int media_nand_erase_resume(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);
+int media_nand_reset(struct media_ctx *ctx, u32 ch, u32 chip, u32 die);
 int media_nand_is_bad_block(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block);
 int media_nand_mark_bad_block(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block);
 u32 media_nand_get_erase_count(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block);

--- a/include/media/timing.h
+++ b/include/media/timing.h
@@ -13,16 +13,18 @@ enum nand_type {
 
 /* Timing Parameters (ns) */
 struct timing_params {
-    u64 tCCS;    /* Change Column Setup */
-    u64 tR;      /* Read */
-    u64 tPROG;   /* Program */
-    u64 tERS;    /* Erase */
-    u64 tWC;     /* Write Cycle */
-    u64 tRC;     /* Read Cycle */
-    u64 tADL;    /* Address Load */
-    u64 tWB;     /* Write Busy */
-    u64 tWHR;    /* Write Hold */
-    u64 tRHW;    /* Read Hold */
+    u64 tCCS;   /* Change Column Setup */
+    u64 tR;     /* Read */
+    u64 tPROG;  /* Program */
+    u64 tERS;   /* Erase */
+    u64 tWC;    /* Write Cycle */
+    u64 tRC;    /* Read Cycle */
+    u64 tADL;   /* Address Load */
+    u64 tWB;    /* Write Busy */
+    u64 tWHR;   /* Write Hold */
+    u64 tRHW;   /* Read Hold */
+    u64 tSSBSY; /* Suspend Setup Busy — cost of entering a suspended state */
+    u64 tRSBSY; /* Resume Setup Busy — cost of returning to array busy */
 };
 
 /* TLC Timing Model */
@@ -33,6 +35,8 @@ struct tlc_timing {
     u64 tPROG_LSB;
     u64 tPROG_CSB;
     u64 tPROG_MSB;
+    u64 tSSBSY;
+    u64 tRSBSY;
 };
 
 /* Timing Model */
@@ -50,5 +54,7 @@ void timing_model_cleanup(struct timing_model *model);
 u64 timing_get_read_latency(struct timing_model *model, u32 page_idx);
 u64 timing_get_prog_latency(struct timing_model *model, u32 page_idx);
 u64 timing_get_erase_latency(struct timing_model *model);
+u64 timing_get_suspend_overhead_ns(struct timing_model *model);
+u64 timing_get_resume_overhead_ns(struct timing_model *model);
 
 #endif /* __HFSSS_TIMING_H */

--- a/src/media/cmd_engine.c
+++ b/src/media/cmd_engine.c
@@ -1,5 +1,8 @@
 #include "media/cmd_engine.h"
 
+#include <sched.h>
+#include <stdatomic.h>
+
 #include "common/mutex.h"
 #include "media/cmd_legality.h"
 #include "media/cmd_state.h"
@@ -84,6 +87,126 @@ static void engine_wait_until_available(struct eat_ctx *eat, enum op_type op, u3
     }
 }
 
+/*
+ * Phase 3 array-busy wait. Returns a completion code describing why the wait
+ * ended:
+ *   ENGINE_WAIT_DONE     — remaining_ns drained normally, commit can run
+ *   ENGINE_WAIT_SUSPEND  — suspend_request observed; remaining_ns has been
+ *                          updated to reflect the unconsumed portion, the die
+ *                          state has been flipped to DIE_SUSPENDED_*, and the
+ *                          loop has already drained the subsequent suspended
+ *                          window by waiting for resume (or abort). On return
+ *                          the die is back to *_ARRAY_BUSY with a refreshed
+ *                          array_started_ns. Caller resumes counting down.
+ *   ENGINE_WAIT_ABORT    — abort_request observed (reset-during-suspend, or
+ *                          reset-while-spinning). Caller MUST skip the
+ *                          commit hook and drive the die to IDLE. remaining_ns
+ *                          is zeroed.
+ *
+ * The loop runs with no locks held except for the brief die_lock windows it
+ * opens to inspect/mutate cmd_state. That matches the Phase 2 lock discipline.
+ */
+enum engine_wait_result {
+    ENGINE_WAIT_DONE = 0,
+    ENGINE_WAIT_SUSPEND,
+    ENGINE_WAIT_ABORT,
+};
+
+static enum engine_wait_result engine_run_array_busy(struct nand_device *dev, struct nand_die *die,
+                                                     enum nand_cmd_opcode op, const struct nand_cmd_target *target,
+                                                     u32 plane)
+{
+    for (;;) {
+        if (atomic_load(&die->cmd_state.abort_request)) {
+            /* Reset already forced state to DIE_IDLE + in_flight=false
+             * under die_lock. We return immediately without touching
+             * cmd_state — any mutation here would race with whatever op
+             * (if any) the die owner starts next. The caller skips its
+             * final cleanup block entirely. */
+            return ENGINE_WAIT_ABORT;
+        }
+
+        if (atomic_load(&die->cmd_state.suspend_request)) {
+            /* Account the drained portion of this array-busy segment and
+             * flip to the suspended state under die_lock. Recheck abort
+             * inside the lock window to avoid overwriting a concurrent
+             * reset's clean state with DIE_SUSPENDED_*. */
+            mutex_lock(&die->die_lock, 0);
+            if (atomic_load(&die->cmd_state.abort_request)) {
+                mutex_unlock(&die->die_lock);
+                return ENGINE_WAIT_ABORT;
+            }
+            u64 now = get_time_ns();
+            u64 elapsed = now - die->cmd_state.array_started_ns;
+            if (elapsed > die->cmd_state.remaining_ns) {
+                elapsed = die->cmd_state.remaining_ns;
+            }
+            die->cmd_state.remaining_ns -= elapsed;
+            if (op == NAND_OP_PROG) {
+                die->cmd_state.state = DIE_SUSPENDED_PROG;
+            } else {
+                die->cmd_state.state = DIE_SUSPENDED_ERASE;
+            }
+            die->cmd_state.last_suspend_ts_ns = now;
+            die->cmd_state.suspend_count++;
+            atomic_store(&die->cmd_state.suspend_request, 0);
+            mutex_unlock(&die->die_lock);
+
+            /* Charge tSSBSY to EAT and drain the matching wall-clock so
+             * the overhead is reflected in both statistics and observable
+             * latency. */
+            u64 sus_ov = timing_get_suspend_overhead_ns(dev->timing);
+            enum op_type sus_eat_op = (op == NAND_OP_PROG) ? OP_PROGRAM : OP_ERASE;
+            if (sus_ov > 0) {
+                eat_update_stage(dev->eat, sus_eat_op, target->ch, target->chip, target->die, plane, sus_ov);
+            }
+            u64 sus_deadline = get_time_ns() + sus_ov;
+            while (get_time_ns() < sus_deadline) {
+                /* busy spin */
+            }
+
+            /* Wait for resume or abort. While suspended the die state is
+             * DIE_SUSPENDED_*; resume flips it back to *_ARRAY_BUSY. The
+             * spin-and-yield pattern bounds CPU cost during test-driven
+             * suspend windows. */
+            for (;;) {
+                if (atomic_load(&die->cmd_state.abort_request)) {
+                    return ENGINE_WAIT_ABORT;
+                }
+                enum nand_die_state s;
+                mutex_lock(&die->die_lock, 0);
+                s = die->cmd_state.state;
+                mutex_unlock(&die->die_lock);
+                if (s == DIE_PROG_ARRAY_BUSY || s == DIE_ERASE_ARRAY_BUSY) {
+                    break;
+                }
+                sched_yield();
+            }
+
+            /* Resumed: reset the segment anchor so the next iteration
+             * measures elapsed time from the resume point, not the original
+             * submit. Resume overhead was already accounted for by the
+             * resume submit path. */
+            mutex_lock(&die->die_lock, 0);
+            die->cmd_state.array_started_ns = get_time_ns();
+            mutex_unlock(&die->die_lock);
+            continue;
+        }
+
+        u64 now = get_time_ns();
+        u64 elapsed = now - die->cmd_state.array_started_ns;
+        if (elapsed >= die->cmd_state.remaining_ns) {
+            mutex_lock(&die->die_lock, 0);
+            die->cmd_state.remaining_ns = 0;
+            mutex_unlock(&die->die_lock);
+            return ENGINE_WAIT_DONE;
+        }
+        /* Tight spin preserves existing wall-clock semantics for timing
+         * tests. The suspend/abort checks above make this bounded even
+         * during a long tPROG. */
+    }
+}
+
 static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const struct nand_cmd_target *target,
                          const struct nand_cmd_ops *ops, void *cb_ctx)
 {
@@ -115,6 +238,12 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
      * busy-waiting or running its commit hook — satisfying the
      * "status observable concurrently with in-flight command" contract
      * in the design spec concurrency section.
+     *
+     * Phase 3: for PROG/ERASE submissions the channel lock is released
+     * across the array-busy wait so a suspend submitted by another thread
+     * can acquire it and set the interrupt flag. The die state machine
+     * still prevents a second PROG/ERASE from sneaking in because the
+     * legality matrix rejects non-suspend ops in DIE_*_ARRAY_BUSY.
      */
     mutex_lock(&channel->lock, 0);
     mutex_lock(&die->die_lock, 0);
@@ -125,19 +254,79 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         return HFSSS_ERR_BUSY;
     }
 
+    /*
+     * Read-during-suspend conflict gate. A read against the same physical
+     * page as the suspended program (or the same block as the suspended
+     * erase) returns BUSY without touching cmd_state. Non-conflicting reads
+     * fall through to the normal begin() path below and preserve the
+     * suspension context because non-conflict read state transitions are
+     * engine-managed around the existing fields — see the DIE_SUSPENDED_*
+     * arm in nand_cmd_next_state_on_accept.
+     */
+    if (op == NAND_OP_READ &&
+        (die->cmd_state.state == DIE_SUSPENDED_PROG || die->cmd_state.state == DIE_SUSPENDED_ERASE)) {
+        const struct nand_cmd_target *s = &die->cmd_state.suspended_target;
+        bool conflict = false;
+        if (die->cmd_state.state == DIE_SUSPENDED_PROG) {
+            conflict = (target->block == s->block && target->page == s->page);
+        } else {
+            conflict = (target->block == s->block);
+        }
+        if (conflict) {
+            mutex_unlock(&die->die_lock);
+            mutex_unlock(&channel->lock);
+            return HFSSS_ERR_BUSY;
+        }
+    }
+
+    /*
+     * Non-conflicting read during a suspended PROG/ERASE takes a fast path
+     * that runs the read entirely on the caller's stack: the suspension
+     * context (state/phase/opcode/target/remaining_ns/suspend_count/
+     * in_flight) must not be disturbed, and the lightweight path matches
+     * the Phase 2 identity/status discipline for mid-flight observability.
+     */
+    const bool is_read_during_suspend = (op == NAND_OP_READ) && (die->cmd_state.state == DIE_SUSPENDED_PROG ||
+                                                                 die->cmd_state.state == DIE_SUSPENDED_ERASE);
+
     u64 total_ns = engine_total_budget(dev->timing, op, target->page);
-    nand_cmd_state_begin(&die->cmd_state, op, target, total_ns);
-    mutex_unlock(&die->die_lock);
-
     enum op_type eat_op = op_to_eat_op(op);
-    engine_wait_until_available(dev->eat, eat_op, target->ch, target->chip, target->die, plane);
-
     u64 setup_ns = 0;
     u64 array_ns = 0;
     u64 xfer_ns = 0;
     nand_cmd_stage_budget(op, total_ns, &setup_ns, &array_ns, &xfer_ns);
-
     int stage_rc = HFSSS_OK;
+
+    if (is_read_during_suspend) {
+        mutex_unlock(&die->die_lock);
+
+        engine_wait_until_available(dev->eat, eat_op, target->ch, target->chip, target->die, plane);
+
+        if (ops && ops->on_setup_commit) {
+            stage_rc = ops->on_setup_commit(cb_ctx);
+        }
+        if (stage_rc == HFSSS_OK) {
+            eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, setup_ns);
+            eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, array_ns);
+            if (ops && ops->on_array_commit) {
+                stage_rc = ops->on_array_commit(cb_ctx);
+            }
+        }
+        if (stage_rc == HFSSS_OK) {
+            eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, xfer_ns);
+            if (ops && ops->on_data_xfer_commit) {
+                stage_rc = ops->on_data_xfer_commit(cb_ctx);
+            }
+        }
+
+        mutex_unlock(&channel->lock);
+        return stage_rc;
+    }
+
+    nand_cmd_state_begin(&die->cmd_state, op, target, total_ns);
+    mutex_unlock(&die->die_lock);
+
+    engine_wait_until_available(dev->eat, eat_op, target->ch, target->chip, target->die, plane);
 
     /* Setup stage runs the setup hook first so address/target validation can
      * reject the command without burning any array/xfer time, matching the
@@ -150,6 +339,8 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, setup_ns);
     }
 
+    enum engine_wait_result wait_rc = ENGINE_WAIT_DONE;
+
     /* Array-busy stage: EAT is committed before the commit hook so the
      * caller-visible completion boundary is reached at the start of the
      * array mutation, matching the legacy eat-before-memcpy ordering. */
@@ -157,9 +348,25 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         mutex_lock(&die->die_lock, 0);
         enum nand_die_state next_array_state = nand_cmd_next_state_on_complete(die->cmd_state.state, op);
         nand_cmd_state_advance_phase(&die->cmd_state, CMD_PHASE_ARRAY_BUSY, next_array_state);
+        die->cmd_state.array_budget_ns = array_ns;
+        die->cmd_state.remaining_ns = array_ns;
+        die->cmd_state.array_started_ns = get_time_ns();
         mutex_unlock(&die->die_lock);
+
         eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, array_ns);
-        if (ops && ops->on_array_commit) {
+
+        if (op == NAND_OP_PROG || op == NAND_OP_ERASE) {
+            /* Drop the channel lock so a concurrent suspend/reset submit
+             * can reach the die. The die state machine guards against any
+             * other submit type sneaking in during the window. */
+            mutex_unlock(&channel->lock);
+            wait_rc = engine_run_array_busy(dev, die, op, target, plane);
+            mutex_lock(&channel->lock, 0);
+        }
+
+        if (wait_rc == ENGINE_WAIT_ABORT) {
+            stage_rc = HFSSS_ERR_BUSY;
+        } else if (ops && ops->on_array_commit) {
             stage_rc = ops->on_array_commit(cb_ctx);
         }
     }
@@ -178,6 +385,15 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         }
     }
 
+    /* On abort the reset path already force-cleaned cmd_state. Touching
+     * it again would race with any new op the die owner starts after the
+     * reset. Skip the final cleanup entirely — just release the channel
+     * lock (re-acquired above) and return the abort error code. */
+    if (wait_rc == ENGINE_WAIT_ABORT) {
+        mutex_unlock(&channel->lock);
+        return HFSSS_ERR_BUSY;
+    }
+
     /* Drive the die back to IDLE regardless of commit status so a failed
      * hook does not strand the die. PROG/ERASE completions update the
      * ONFI sticky FAIL latch: a successful completion clears the latch,
@@ -189,6 +405,10 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
     die->cmd_state.phase = CMD_PHASE_COMPLETE;
     die->cmd_state.state = DIE_IDLE;
     die->cmd_state.remaining_ns = 0;
+    die->cmd_state.array_budget_ns = 0;
+    die->cmd_state.array_started_ns = 0;
+    atomic_store(&die->cmd_state.suspend_request, 0);
+    atomic_store(&die->cmd_state.abort_request, 0);
     if (op == NAND_OP_PROG || op == NAND_OP_ERASE) {
         die->cmd_state.latched_fail = (stage_rc != HFSSS_OK);
     }
@@ -240,42 +460,158 @@ int nand_cmd_engine_submit_reset(struct nand_device *dev, const struct nand_cmd_
         return HFSSS_ERR_INVAL;
     }
 
-    struct nand_channel *channel = engine_get_channel(dev, target->ch);
-    if (!channel) {
-        return HFSSS_ERR_INVAL;
-    }
     struct nand_die *die = engine_get_die(dev, target->ch, target->chip, target->die);
     if (!die) {
         return HFSSS_ERR_INVAL;
     }
 
     /*
-     * The synchronous submission model means any concurrent reset caller is
-     * serialized behind the active command via the channel and die locks, so
-     * reset always observes an idle die. True mid-flight abort is deferred to
-     * the async execution model in a later phase.
+     * Reset takes only the die lock so it can abort an in-flight PROG/ERASE
+     * whose worker is spinning in engine_run_array_busy with the channel
+     * lock released. The force-reset writes a clean state and sets
+     * abort_request so the worker — if one exists — will observe the flag
+     * on its next iteration and return ENGINE_WAIT_ABORT. The worker's
+     * engine_submit final block is skipped on abort so it cannot overwrite
+     * the clean state written here.
      */
-    mutex_lock(&channel->lock, 0);
     mutex_lock(&die->die_lock, 0);
 
     if (!nand_cmd_is_legal_in_state(die->cmd_state.state, NAND_OP_RESET)) {
         mutex_unlock(&die->die_lock);
-        mutex_unlock(&channel->lock);
         return HFSSS_ERR_BUSY;
     }
 
-    nand_cmd_state_begin(&die->cmd_state, NAND_OP_RESET, target, 0);
+    /* Signal any running worker to bail. Harmless if no worker exists
+     * (synthetic test state, or die is already IDLE). */
+    atomic_store(&die->cmd_state.abort_request, 1);
+    atomic_store(&die->cmd_state.suspend_request, 0);
+
     die->cmd_state.state = DIE_IDLE;
     die->cmd_state.phase = CMD_PHASE_COMPLETE;
     die->cmd_state.in_flight = false;
     die->cmd_state.remaining_ns = 0;
     die->cmd_state.result_status = HFSSS_OK;
+    die->cmd_state.array_budget_ns = 0;
+    die->cmd_state.array_started_ns = 0;
     /* ONFI 4.2: RESET clears the sticky FAIL latch. */
     die->cmd_state.latched_fail = false;
 
     mutex_unlock(&die->die_lock);
-    mutex_unlock(&channel->lock);
     return HFSSS_OK;
+}
+
+/*
+ * Suspend/resume submission path. Suspend sets an atomic interrupt flag
+ * that the array-busy spin observes; it then waits (briefly) for the spin
+ * to acknowledge the transition by flipping state to DIE_SUSPENDED_*, so
+ * the caller can immediately issue a conflict-checked read afterward with
+ * deterministic ordering. Resume does the opposite: it flips state back to
+ * DIE_*_ARRAY_BUSY and charges tRSBSY against EAT so timing stats reflect
+ * the overhead.
+ */
+static int engine_submit_suspend(struct nand_device *dev, enum nand_cmd_opcode op, const struct nand_cmd_target *target)
+{
+    if (!dev || !target) {
+        return HFSSS_ERR_INVAL;
+    }
+    if (op != NAND_OP_PROG_SUSPEND && op != NAND_OP_ERASE_SUSPEND) {
+        return HFSSS_ERR_INVAL;
+    }
+
+    struct nand_die *die = engine_get_die(dev, target->ch, target->chip, target->die);
+    if (!die) {
+        return HFSSS_ERR_INVAL;
+    }
+
+    mutex_lock(&die->die_lock, 0);
+    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, op)) {
+        mutex_unlock(&die->die_lock);
+        return HFSSS_ERR_BUSY;
+    }
+    /* Snapshot the running op's target before the spin can rewrite
+     * cmd_state.target. The conflict check in engine_submit reads this
+     * field under die_lock. */
+    die->cmd_state.suspended_target = die->cmd_state.target;
+    atomic_store(&die->cmd_state.suspend_request, 1);
+    mutex_unlock(&die->die_lock);
+
+    /* Spin briefly waiting for the running worker to acknowledge the
+     * suspend by flipping state. Bounded by the spin interval inside
+     * engine_run_array_busy plus tSSBSY. */
+    enum nand_die_state want = (op == NAND_OP_PROG_SUSPEND) ? DIE_SUSPENDED_PROG : DIE_SUSPENDED_ERASE;
+    for (;;) {
+        enum nand_die_state s;
+        mutex_lock(&die->die_lock, 0);
+        s = die->cmd_state.state;
+        mutex_unlock(&die->die_lock);
+        if (s == want) {
+            return HFSSS_OK;
+        }
+        if (s == DIE_IDLE) {
+            /* The running op raced us to completion. The suspend submit
+             * lost the race but the caller-visible contract is
+             * unchanged: the die is idle, no op is suspended. Report
+             * BUSY so the caller knows the suspend was not honored. */
+            return HFSSS_ERR_BUSY;
+        }
+        sched_yield();
+    }
+}
+
+static int engine_submit_resume(struct nand_device *dev, enum nand_cmd_opcode op, const struct nand_cmd_target *target)
+{
+    if (!dev || !target) {
+        return HFSSS_ERR_INVAL;
+    }
+    if (op != NAND_OP_PROG_RESUME && op != NAND_OP_ERASE_RESUME) {
+        return HFSSS_ERR_INVAL;
+    }
+
+    struct nand_die *die = engine_get_die(dev, target->ch, target->chip, target->die);
+    if (!die) {
+        return HFSSS_ERR_INVAL;
+    }
+
+    u32 plane = 0;
+    /* Resume updates EAT on the same plane as the suspended op. */
+    mutex_lock(&die->die_lock, 0);
+    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, op)) {
+        mutex_unlock(&die->die_lock);
+        return HFSSS_ERR_BUSY;
+    }
+    int rc = plane_index_from_mask(die->cmd_state.suspended_target.plane_mask, &plane);
+    if (rc != HFSSS_OK) {
+        plane = 0;
+    }
+    die->cmd_state.state = (op == NAND_OP_PROG_RESUME) ? DIE_PROG_ARRAY_BUSY : DIE_ERASE_ARRAY_BUSY;
+    mutex_unlock(&die->die_lock);
+
+    enum op_type eat_op = (op == NAND_OP_PROG_RESUME) ? OP_PROGRAM : OP_ERASE;
+    u64 resume_ov = timing_get_resume_overhead_ns(dev->timing);
+    if (resume_ov > 0) {
+        eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, resume_ov);
+    }
+    return HFSSS_OK;
+}
+
+int nand_cmd_engine_submit_prog_suspend(struct nand_device *dev, const struct nand_cmd_target *target)
+{
+    return engine_submit_suspend(dev, NAND_OP_PROG_SUSPEND, target);
+}
+
+int nand_cmd_engine_submit_prog_resume(struct nand_device *dev, const struct nand_cmd_target *target)
+{
+    return engine_submit_resume(dev, NAND_OP_PROG_RESUME, target);
+}
+
+int nand_cmd_engine_submit_erase_suspend(struct nand_device *dev, const struct nand_cmd_target *target)
+{
+    return engine_submit_suspend(dev, NAND_OP_ERASE_SUSPEND, target);
+}
+
+int nand_cmd_engine_submit_erase_resume(struct nand_device *dev, const struct nand_cmd_target *target)
+{
+    return engine_submit_resume(dev, NAND_OP_ERASE_RESUME, target);
 }
 
 int nand_cmd_engine_snapshot(struct nand_device *dev, const struct nand_cmd_target *target,

--- a/src/media/cmd_engine.c
+++ b/src/media/cmd_engine.c
@@ -351,7 +351,13 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
     if (is_read_during_suspend) {
         mutex_unlock(&die->die_lock);
 
-        engine_wait_until_available_mask(dev->eat, eat_op, target->ch, target->chip, target->die, target->plane_mask);
+        /* Skip the EAT wait: the suspended PROG/ERASE already booked its
+         * full array_ns into EAT, so eat_get_max would return a deadline
+         * in the future that blocks until the PROG/ERASE would have
+         * completed. The ONFI contract says a legal read during suspend
+         * runs in the suspended window, not after the suspended op. The
+         * read's own EAT stages are still committed below so subsequent
+         * operations see the correct timeline. */
 
         if (ops && ops->on_setup_commit) {
             stage_rc = ops->on_setup_commit(cb_ctx);
@@ -381,23 +387,31 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
 
     engine_wait_until_available_mask(dev->eat, eat_op, target->ch, target->chip, target->die, target->plane_mask);
 
+    enum engine_wait_result wait_rc = ENGINE_WAIT_DONE;
+
+    /* Check for abort before each stage so a reset that lands between
+     * nand_cmd_state_begin and the array-busy loop is caught here
+     * instead of allowing the setup/commit hooks to execute on a die
+     * that reset already force-cleaned. */
+    if (atomic_load(&die->cmd_state.abort_request)) {
+        wait_rc = ENGINE_WAIT_ABORT;
+    }
+
     /* Setup stage runs the setup hook first so address/target validation can
      * reject the command without burning any array/xfer time, matching the
      * legacy short-circuit where a failed read of an unwritten page consumed
      * no EAT. */
-    if (ops && ops->on_setup_commit) {
+    if (wait_rc != ENGINE_WAIT_ABORT && ops && ops->on_setup_commit) {
         stage_rc = ops->on_setup_commit(cb_ctx);
     }
-    if (stage_rc == HFSSS_OK) {
+    if (wait_rc != ENGINE_WAIT_ABORT && stage_rc == HFSSS_OK) {
         eat_update_stage_mask(dev->eat, eat_op, target->ch, target->chip, target->die, target->plane_mask, setup_ns);
     }
-
-    enum engine_wait_result wait_rc = ENGINE_WAIT_DONE;
 
     /* Array-busy stage: EAT is committed before the commit hook so the
      * caller-visible completion boundary is reached at the start of the
      * array mutation, matching the legacy eat-before-memcpy ordering. */
-    if (stage_rc == HFSSS_OK) {
+    if (wait_rc != ENGINE_WAIT_ABORT && stage_rc == HFSSS_OK) {
         mutex_lock(&die->die_lock, 0);
         enum nand_die_state next_array_state = nand_cmd_next_state_on_complete(die->cmd_state.state, op);
         nand_cmd_state_advance_phase(&die->cmd_state, CMD_PHASE_ARRAY_BUSY, next_array_state);
@@ -417,6 +431,12 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
             mutex_lock(&channel->lock, 0);
         }
 
+        /* Recheck abort after the spin returns DONE: a reset could land
+         * between the spin exit and this point (the channel lock was just
+         * re-acquired, but die_lock was not held across the gap). */
+        if (wait_rc == ENGINE_WAIT_DONE && atomic_load(&die->cmd_state.abort_request)) {
+            wait_rc = ENGINE_WAIT_ABORT;
+        }
         if (wait_rc == ENGINE_WAIT_ABORT) {
             stage_rc = HFSSS_ERR_BUSY;
         } else if (ops && ops->on_array_commit) {
@@ -537,17 +557,16 @@ int nand_cmd_engine_submit_reset(struct nand_device *dev, const struct nand_cmd_
     /* Signal any running worker to bail. Harmless if no worker exists
      * (synthetic test state, or die is already IDLE). */
     atomic_store(&die->cmd_state.abort_request, 1);
-    atomic_store(&die->cmd_state.suspend_request, 0);
 
-    die->cmd_state.state = DIE_IDLE;
+    /* Full state reset: zero every field to canonical post-reset baseline
+     * so enhanced status never leaks stale opcode, target, timestamps,
+     * or suspend counters from the prior operation. nand_cmd_state_init
+     * does a memset(0) + sets state=DIE_IDLE, phase=CMD_PHASE_NONE.
+     * We override phase to COMPLETE to match the "just finished reset"
+     * observable behavior, then re-arm abort_request for the worker. */
+    nand_cmd_state_init(&die->cmd_state);
     die->cmd_state.phase = CMD_PHASE_COMPLETE;
-    die->cmd_state.in_flight = false;
-    die->cmd_state.remaining_ns = 0;
-    die->cmd_state.result_status = HFSSS_OK;
-    die->cmd_state.array_budget_ns = 0;
-    die->cmd_state.array_started_ns = 0;
-    /* ONFI 4.2: RESET clears the sticky FAIL latch. */
-    die->cmd_state.latched_fail = false;
+    atomic_store(&die->cmd_state.abort_request, 1);
 
     mutex_unlock(&die->die_lock);
     return HFSSS_OK;
@@ -638,6 +657,12 @@ static int engine_submit_resume(struct nand_device *dev, enum nand_cmd_opcode op
     u64 resume_ov = timing_get_resume_overhead_ns(dev->timing);
     if (resume_ov > 0) {
         eat_update_stage_mask(dev->eat, eat_op, target->ch, target->chip, target->die, suspended_mask, resume_ov);
+        /* Drain wall-clock for tRSBSY, symmetric with the tSSBSY
+         * wall-clock spin in the suspend arm of engine_run_array_busy. */
+        u64 res_deadline = get_time_ns() + resume_ov;
+        while (get_time_ns() < res_deadline) {
+            /* busy spin */
+        }
     }
     return HFSSS_OK;
 }

--- a/src/media/cmd_engine.c
+++ b/src/media/cmd_engine.c
@@ -120,7 +120,7 @@ static void engine_wait_until_available_mask(struct eat_ctx *eat, enum op_type o
         }
     }
     while (get_time_ns() < deadline) {
-        /* Busy spin preserves wait semantics observed by timing-sensitive tests. */
+        sched_yield();
     }
 }
 
@@ -145,7 +145,7 @@ static void eat_update_stage_mask(struct eat_ctx *eat, enum op_type op, u32 ch, 
  *                          window by waiting for resume (or abort). On return
  *                          the die is back to *_ARRAY_BUSY with a refreshed
  *                          array_started_ns. Caller resumes counting down.
- *   ENGINE_WAIT_ABORT    — abort_request observed (reset-during-suspend, or
+ *   ENGINE_WAIT_ABORT    — abort_epoch changed (reset-during-suspend, or
  *                          reset-while-spinning). Caller MUST skip the
  *                          commit hook and drive the die to IDLE. remaining_ns
  *                          is zeroed.
@@ -160,10 +160,11 @@ enum engine_wait_result {
 };
 
 static enum engine_wait_result engine_run_array_busy(struct nand_device *dev, struct nand_die *die,
-                                                     enum nand_cmd_opcode op, const struct nand_cmd_target *target)
+                                                     enum nand_cmd_opcode op, const struct nand_cmd_target *target,
+                                                     u32 epoch_at_submit)
 {
     for (;;) {
-        if (atomic_load(&die->cmd_state.abort_request)) {
+        if (atomic_load(&die->cmd_state.abort_epoch) != epoch_at_submit) {
             /* Reset already forced state to DIE_IDLE + in_flight=false
              * under die_lock. We return immediately without touching
              * cmd_state — any mutation here would race with whatever op
@@ -178,7 +179,7 @@ static enum engine_wait_result engine_run_array_busy(struct nand_device *dev, st
              * inside the lock window to avoid overwriting a concurrent
              * reset's clean state with DIE_SUSPENDED_*. */
             mutex_lock(&die->die_lock, 0);
-            if (atomic_load(&die->cmd_state.abort_request)) {
+            if (atomic_load(&die->cmd_state.abort_epoch) != epoch_at_submit) {
                 mutex_unlock(&die->die_lock);
                 return ENGINE_WAIT_ABORT;
             }
@@ -209,7 +210,7 @@ static enum engine_wait_result engine_run_array_busy(struct nand_device *dev, st
             }
             u64 sus_deadline = get_time_ns() + sus_ov;
             while (get_time_ns() < sus_deadline) {
-                /* busy spin */
+                sched_yield();
             }
 
             /* Wait for resume or abort. While suspended the die state is
@@ -217,7 +218,7 @@ static enum engine_wait_result engine_run_array_busy(struct nand_device *dev, st
              * spin-and-yield pattern bounds CPU cost during test-driven
              * suspend windows. */
             for (;;) {
-                if (atomic_load(&die->cmd_state.abort_request)) {
+                if (atomic_load(&die->cmd_state.abort_epoch) != epoch_at_submit) {
                     return ENGINE_WAIT_ABORT;
                 }
                 enum nand_die_state s;
@@ -248,9 +249,7 @@ static enum engine_wait_result engine_run_array_busy(struct nand_device *dev, st
             mutex_unlock(&die->die_lock);
             return ENGINE_WAIT_DONE;
         }
-        /* Tight spin preserves existing wall-clock semantics for timing
-         * tests. The suspend/abort checks above make this bounded even
-         * during a long tPROG. */
+        sched_yield();
     }
 }
 
@@ -383,17 +382,17 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
     }
 
     nand_cmd_state_begin(&die->cmd_state, op, target, total_ns);
+    u32 epoch_at_submit = atomic_load(&die->cmd_state.abort_epoch);
     mutex_unlock(&die->die_lock);
 
     engine_wait_until_available_mask(dev->eat, eat_op, target->ch, target->chip, target->die, target->plane_mask);
 
     enum engine_wait_result wait_rc = ENGINE_WAIT_DONE;
 
-    /* Check for abort before each stage so a reset that lands between
-     * nand_cmd_state_begin and the array-busy loop is caught here
-     * instead of allowing the setup/commit hooks to execute on a die
-     * that reset already force-cleaned. */
-    if (atomic_load(&die->cmd_state.abort_request)) {
+    /* Check for abort before each stage. The epoch comparison detects
+     * resets even if a new command was submitted after the reset (which
+     * would have left abort_epoch at the incremented value). */
+    if (atomic_load(&die->cmd_state.abort_epoch) != epoch_at_submit) {
         wait_rc = ENGINE_WAIT_ABORT;
     }
 
@@ -427,14 +426,14 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
              * can reach the die. The die state machine guards against any
              * other submit type sneaking in during the window. */
             mutex_unlock(&channel->lock);
-            wait_rc = engine_run_array_busy(dev, die, op, target);
+            wait_rc = engine_run_array_busy(dev, die, op, target, epoch_at_submit);
             mutex_lock(&channel->lock, 0);
         }
 
         /* Recheck abort after the spin returns DONE: a reset could land
          * between the spin exit and this point (the channel lock was just
          * re-acquired, but die_lock was not held across the gap). */
-        if (wait_rc == ENGINE_WAIT_DONE && atomic_load(&die->cmd_state.abort_request)) {
+        if (wait_rc == ENGINE_WAIT_DONE && atomic_load(&die->cmd_state.abort_epoch) != epoch_at_submit) {
             wait_rc = ENGINE_WAIT_ABORT;
         }
         if (wait_rc == ENGINE_WAIT_ABORT) {
@@ -481,7 +480,8 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
     die->cmd_state.array_budget_ns = 0;
     die->cmd_state.array_started_ns = 0;
     atomic_store(&die->cmd_state.suspend_request, 0);
-    atomic_store(&die->cmd_state.abort_request, 0);
+    /* abort_epoch is not cleared here — it is a monotonic counter.
+     * The next command will snapshot whatever value it has. */
     if (op == NAND_OP_PROG || op == NAND_OP_ERASE) {
         die->cmd_state.latched_fail = (stage_rc != HFSSS_OK);
     }
@@ -542,7 +542,7 @@ int nand_cmd_engine_submit_reset(struct nand_device *dev, const struct nand_cmd_
      * Reset takes only the die lock so it can abort an in-flight PROG/ERASE
      * whose worker is spinning in engine_run_array_busy with the channel
      * lock released. The force-reset writes a clean state and sets
-     * abort_request so the worker — if one exists — will observe the flag
+     * abort_epoch so the worker — if one exists — will observe the change
      * on its next iteration and return ENGINE_WAIT_ABORT. The worker's
      * engine_submit final block is skipped on abort so it cannot overwrite
      * the clean state written here.
@@ -554,19 +554,18 @@ int nand_cmd_engine_submit_reset(struct nand_device *dev, const struct nand_cmd_
         return HFSSS_ERR_BUSY;
     }
 
-    /* Signal any running worker to bail. Harmless if no worker exists
-     * (synthetic test state, or die is already IDLE). */
-    atomic_store(&die->cmd_state.abort_request, 1);
+    /* Increment the abort epoch so any running worker (past or present)
+     * detects the reset via its saved epoch snapshot. Save the new epoch
+     * before zeroing the rest of cmd_state so the memset in
+     * nand_cmd_state_init does not revert it to zero. */
+    u32 new_epoch = atomic_load(&die->cmd_state.abort_epoch) + 1;
 
     /* Full state reset: zero every field to canonical post-reset baseline
      * so enhanced status never leaks stale opcode, target, timestamps,
-     * or suspend counters from the prior operation. nand_cmd_state_init
-     * does a memset(0) + sets state=DIE_IDLE, phase=CMD_PHASE_NONE.
-     * We override phase to COMPLETE to match the "just finished reset"
-     * observable behavior, then re-arm abort_request for the worker. */
+     * or suspend counters from the prior operation. */
     nand_cmd_state_init(&die->cmd_state);
     die->cmd_state.phase = CMD_PHASE_COMPLETE;
-    atomic_store(&die->cmd_state.abort_request, 1);
+    atomic_store(&die->cmd_state.abort_epoch, new_epoch);
 
     mutex_unlock(&die->die_lock);
     return HFSSS_OK;

--- a/src/media/cmd_engine.c
+++ b/src/media/cmd_engine.c
@@ -37,18 +37,46 @@ static struct nand_channel *engine_get_channel(struct nand_device *dev, u32 ch)
     return &dev->channels[ch];
 }
 
-static int plane_index_from_mask(u32 plane_mask, u32 *out)
+/*
+ * Validate that every set bit in plane_mask refers to a plane that
+ * exists in the die geometry. Returns HFSSS_OK and writes the popcount
+ * to *out_count. For single-bit masks the first (and only) plane index
+ * is written to *out_first for backward compat; for multi-bit masks
+ * *out_first receives the lowest set bit.
+ */
+static int engine_validate_planes(u32 plane_mask, u32 plane_count, u32 *out_count, u32 *out_first)
 {
     if (plane_mask == 0) {
         return HFSSS_ERR_INVAL;
     }
-    if ((plane_mask & (plane_mask - 1)) != 0) {
-        /* The engine currently supports a single plane per command. */
-        return HFSSS_ERR_NOTSUPP;
+    u32 remaining = plane_mask;
+    u32 count = 0;
+    u32 first = (u32)__builtin_ctz(remaining);
+    while (remaining) {
+        u32 idx = (u32)__builtin_ctz(remaining);
+        if (idx >= plane_count) {
+            return HFSSS_ERR_INVAL;
+        }
+        count++;
+        remaining &= remaining - 1;
     }
-    *out = (u32)__builtin_ctz(plane_mask);
+    if (out_count) {
+        *out_count = count;
+    }
+    if (out_first) {
+        *out_first = first;
+    }
     return HFSSS_OK;
 }
+
+/*
+ * Helper to iterate set bits in a plane mask. Usage:
+ *   u32 mask = target->plane_mask;
+ *   u32 p;
+ *   FOR_EACH_PLANE(p, mask) { ... use p ... }
+ */
+#define FOR_EACH_PLANE(var, mask_copy)                                                                                 \
+    for (u32 _m = (mask_copy); _m && ((var) = (u32)__builtin_ctz(_m), 1); _m &= _m - 1)
 
 static enum op_type op_to_eat_op(enum nand_cmd_opcode op)
 {
@@ -79,11 +107,30 @@ static u64 engine_total_budget(struct timing_model *timing, enum nand_cmd_opcode
     }
 }
 
-static void engine_wait_until_available(struct eat_ctx *eat, enum op_type op, u32 ch, u32 chip, u32 die, u32 plane)
+static void engine_wait_until_available_mask(struct eat_ctx *eat, enum op_type op, u32 ch, u32 chip, u32 die,
+                                             u32 plane_mask)
 {
-    u64 deadline = eat_get_max(eat, op, ch, chip, die, plane);
+    u64 deadline = 0;
+    u32 p;
+    FOR_EACH_PLANE(p, plane_mask)
+    {
+        u64 d = eat_get_max(eat, op, ch, chip, die, p);
+        if (d > deadline) {
+            deadline = d;
+        }
+    }
     while (get_time_ns() < deadline) {
         /* Busy spin preserves wait semantics observed by timing-sensitive tests. */
+    }
+}
+
+static void eat_update_stage_mask(struct eat_ctx *eat, enum op_type op, u32 ch, u32 chip, u32 die, u32 plane_mask,
+                                  u64 stage_ns)
+{
+    u32 p;
+    FOR_EACH_PLANE(p, plane_mask)
+    {
+        eat_update_stage(eat, op, ch, chip, die, p, stage_ns);
     }
 }
 
@@ -113,8 +160,7 @@ enum engine_wait_result {
 };
 
 static enum engine_wait_result engine_run_array_busy(struct nand_device *dev, struct nand_die *die,
-                                                     enum nand_cmd_opcode op, const struct nand_cmd_target *target,
-                                                     u32 plane)
+                                                     enum nand_cmd_opcode op, const struct nand_cmd_target *target)
 {
     for (;;) {
         if (atomic_load(&die->cmd_state.abort_request)) {
@@ -158,7 +204,8 @@ static enum engine_wait_result engine_run_array_busy(struct nand_device *dev, st
             u64 sus_ov = timing_get_suspend_overhead_ns(dev->timing);
             enum op_type sus_eat_op = (op == NAND_OP_PROG) ? OP_PROGRAM : OP_ERASE;
             if (sus_ov > 0) {
-                eat_update_stage(dev->eat, sus_eat_op, target->ch, target->chip, target->die, plane, sus_ov);
+                eat_update_stage_mask(dev->eat, sus_eat_op, target->ch, target->chip, target->die, target->plane_mask,
+                                      sus_ov);
             }
             u64 sus_deadline = get_time_ns() + sus_ov;
             while (get_time_ns() < sus_deadline) {
@@ -214,18 +261,19 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         return HFSSS_ERR_INVAL;
     }
 
-    u32 plane = 0;
-    int rc = plane_index_from_mask(target->plane_mask, &plane);
+    u32 plane_count = 0;
+    u32 plane_first = 0;
+    struct nand_die *die = engine_get_die(dev, target->ch, target->chip, target->die);
+    if (!die) {
+        return HFSSS_ERR_INVAL;
+    }
+    int rc = engine_validate_planes(target->plane_mask, die->plane_count, &plane_count, &plane_first);
     if (rc != HFSSS_OK) {
         return rc;
     }
 
     struct nand_channel *channel = engine_get_channel(dev, target->ch);
     if (!channel) {
-        return HFSSS_ERR_INVAL;
-    }
-    struct nand_die *die = engine_get_die(dev, target->ch, target->chip, target->die);
-    if (!die) {
         return HFSSS_ERR_INVAL;
     }
 
@@ -266,11 +314,14 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
     if (op == NAND_OP_READ &&
         (die->cmd_state.state == DIE_SUSPENDED_PROG || die->cmd_state.state == DIE_SUSPENDED_ERASE)) {
         const struct nand_cmd_target *s = &die->cmd_state.suspended_target;
+        bool planes_overlap = (target->plane_mask & s->plane_mask) != 0;
         bool conflict = false;
-        if (die->cmd_state.state == DIE_SUSPENDED_PROG) {
-            conflict = (target->block == s->block && target->page == s->page);
-        } else {
-            conflict = (target->block == s->block);
+        if (planes_overlap) {
+            if (die->cmd_state.state == DIE_SUSPENDED_PROG) {
+                conflict = (target->block == s->block && target->page == s->page);
+            } else {
+                conflict = (target->block == s->block);
+            }
         }
         if (conflict) {
             mutex_unlock(&die->die_lock);
@@ -300,20 +351,22 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
     if (is_read_during_suspend) {
         mutex_unlock(&die->die_lock);
 
-        engine_wait_until_available(dev->eat, eat_op, target->ch, target->chip, target->die, plane);
+        engine_wait_until_available_mask(dev->eat, eat_op, target->ch, target->chip, target->die, target->plane_mask);
 
         if (ops && ops->on_setup_commit) {
             stage_rc = ops->on_setup_commit(cb_ctx);
         }
         if (stage_rc == HFSSS_OK) {
-            eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, setup_ns);
-            eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, array_ns);
+            eat_update_stage_mask(dev->eat, eat_op, target->ch, target->chip, target->die, target->plane_mask,
+                                  setup_ns);
+            eat_update_stage_mask(dev->eat, eat_op, target->ch, target->chip, target->die, target->plane_mask,
+                                  array_ns);
             if (ops && ops->on_array_commit) {
                 stage_rc = ops->on_array_commit(cb_ctx);
             }
         }
         if (stage_rc == HFSSS_OK) {
-            eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, xfer_ns);
+            eat_update_stage_mask(dev->eat, eat_op, target->ch, target->chip, target->die, target->plane_mask, xfer_ns);
             if (ops && ops->on_data_xfer_commit) {
                 stage_rc = ops->on_data_xfer_commit(cb_ctx);
             }
@@ -326,7 +379,7 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
     nand_cmd_state_begin(&die->cmd_state, op, target, total_ns);
     mutex_unlock(&die->die_lock);
 
-    engine_wait_until_available(dev->eat, eat_op, target->ch, target->chip, target->die, plane);
+    engine_wait_until_available_mask(dev->eat, eat_op, target->ch, target->chip, target->die, target->plane_mask);
 
     /* Setup stage runs the setup hook first so address/target validation can
      * reject the command without burning any array/xfer time, matching the
@@ -336,7 +389,7 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         stage_rc = ops->on_setup_commit(cb_ctx);
     }
     if (stage_rc == HFSSS_OK) {
-        eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, setup_ns);
+        eat_update_stage_mask(dev->eat, eat_op, target->ch, target->chip, target->die, target->plane_mask, setup_ns);
     }
 
     enum engine_wait_result wait_rc = ENGINE_WAIT_DONE;
@@ -353,14 +406,14 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         die->cmd_state.array_started_ns = get_time_ns();
         mutex_unlock(&die->die_lock);
 
-        eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, array_ns);
+        eat_update_stage_mask(dev->eat, eat_op, target->ch, target->chip, target->die, target->plane_mask, array_ns);
 
         if (op == NAND_OP_PROG || op == NAND_OP_ERASE) {
             /* Drop the channel lock so a concurrent suspend/reset submit
              * can reach the die. The die state machine guards against any
              * other submit type sneaking in during the window. */
             mutex_unlock(&channel->lock);
-            wait_rc = engine_run_array_busy(dev, die, op, target, plane);
+            wait_rc = engine_run_array_busy(dev, die, op, target);
             mutex_lock(&channel->lock, 0);
         }
 
@@ -379,7 +432,7 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         enum nand_die_state next_xfer_state = nand_cmd_next_state_on_complete(die->cmd_state.state, op);
         nand_cmd_state_advance_phase(&die->cmd_state, CMD_PHASE_DATA_XFER, next_xfer_state);
         mutex_unlock(&die->die_lock);
-        eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, xfer_ns);
+        eat_update_stage_mask(dev->eat, eat_op, target->ch, target->chip, target->die, target->plane_mask, xfer_ns);
         if (ops && ops->on_data_xfer_commit) {
             stage_rc = ops->on_data_xfer_commit(cb_ctx);
         }
@@ -572,24 +625,19 @@ static int engine_submit_resume(struct nand_device *dev, enum nand_cmd_opcode op
         return HFSSS_ERR_INVAL;
     }
 
-    u32 plane = 0;
-    /* Resume updates EAT on the same plane as the suspended op. */
     mutex_lock(&die->die_lock, 0);
     if (!nand_cmd_is_legal_in_state(die->cmd_state.state, op)) {
         mutex_unlock(&die->die_lock);
         return HFSSS_ERR_BUSY;
     }
-    int rc = plane_index_from_mask(die->cmd_state.suspended_target.plane_mask, &plane);
-    if (rc != HFSSS_OK) {
-        plane = 0;
-    }
+    u32 suspended_mask = die->cmd_state.suspended_target.plane_mask;
     die->cmd_state.state = (op == NAND_OP_PROG_RESUME) ? DIE_PROG_ARRAY_BUSY : DIE_ERASE_ARRAY_BUSY;
     mutex_unlock(&die->die_lock);
 
     enum op_type eat_op = (op == NAND_OP_PROG_RESUME) ? OP_PROGRAM : OP_ERASE;
     u64 resume_ov = timing_get_resume_overhead_ns(dev->timing);
     if (resume_ov > 0) {
-        eat_update_stage(dev->eat, eat_op, target->ch, target->chip, target->die, plane, resume_ov);
+        eat_update_stage_mask(dev->eat, eat_op, target->ch, target->chip, target->die, suspended_mask, resume_ov);
     }
     return HFSSS_OK;
 }

--- a/src/media/cmd_legality.c
+++ b/src/media/cmd_legality.c
@@ -57,6 +57,7 @@ static const bool k_legal[DIE_STATE_COUNT][NAND_OP_COUNT] = {
             [NAND_OP_RESET] = true,
             [NAND_OP_READ_STATUS] = true,
             [NAND_OP_READ_STATUS_ENHANCED] = true,
+            [NAND_OP_PROG_SUSPEND] = true,
         },
     [DIE_ERASE_SETUP] =
         {
@@ -69,22 +70,27 @@ static const bool k_legal[DIE_STATE_COUNT][NAND_OP_COUNT] = {
             [NAND_OP_RESET] = true,
             [NAND_OP_READ_STATUS] = true,
             [NAND_OP_READ_STATUS_ENHANCED] = true,
+            [NAND_OP_ERASE_SUSPEND] = true,
         },
     [DIE_SUSPENDED_PROG] =
         {
+            [NAND_OP_READ] = true,
             [NAND_OP_RESET] = true,
             [NAND_OP_READ_STATUS] = true,
             [NAND_OP_READ_STATUS_ENHANCED] = true,
             [NAND_OP_READ_ID] = true,
             [NAND_OP_READ_PARAM_PAGE] = true,
+            [NAND_OP_PROG_RESUME] = true,
         },
     [DIE_SUSPENDED_ERASE] =
         {
+            [NAND_OP_READ] = true,
             [NAND_OP_RESET] = true,
             [NAND_OP_READ_STATUS] = true,
             [NAND_OP_READ_STATUS_ENHANCED] = true,
             [NAND_OP_READ_ID] = true,
             [NAND_OP_READ_PARAM_PAGE] = true,
+            [NAND_OP_ERASE_RESUME] = true,
         },
     [DIE_RESETTING] =
         {
@@ -108,6 +114,13 @@ enum nand_die_state nand_cmd_next_state_on_accept(enum nand_die_state state, enu
     }
     switch (op) {
     case NAND_OP_READ:
+        /* Read accepted during a suspended program/erase stays in the
+         * suspend state — the read runs to completion on top of the
+         * preserved suspension context and must not disturb it. The engine
+         * drives its own transitions for the read path in that case. */
+        if (state == DIE_SUSPENDED_PROG || state == DIE_SUSPENDED_ERASE) {
+            return state;
+        }
         return DIE_READ_SETUP;
     case NAND_OP_PROG:
         return DIE_PROG_SETUP;
@@ -115,6 +128,14 @@ enum nand_die_state nand_cmd_next_state_on_accept(enum nand_die_state state, enu
         return DIE_ERASE_SETUP;
     case NAND_OP_RESET:
         return DIE_RESETTING;
+    case NAND_OP_PROG_SUSPEND:
+        return DIE_SUSPENDED_PROG;
+    case NAND_OP_ERASE_SUSPEND:
+        return DIE_SUSPENDED_ERASE;
+    case NAND_OP_PROG_RESUME:
+        return DIE_PROG_ARRAY_BUSY;
+    case NAND_OP_ERASE_RESUME:
+        return DIE_ERASE_ARRAY_BUSY;
     default:
         return state;
     }

--- a/src/media/cmd_state.c
+++ b/src/media/cmd_state.c
@@ -47,7 +47,10 @@ void nand_cmd_state_begin(struct nand_die_cmd_state *s, enum nand_cmd_opcode op,
     s->array_budget_ns = 0;
     memset(&s->suspended_target, 0, sizeof(s->suspended_target));
     atomic_store(&s->suspend_request, 0);
-    atomic_store(&s->abort_request, 0);
+    /* Do NOT touch abort_epoch here — a new command must not clear an
+     * abort signal that the previous worker has not yet observed. The
+     * worker compares its saved epoch snapshot against the current
+     * value to detect resets. */
 }
 
 void nand_cmd_state_advance_phase(struct nand_die_cmd_state *s, enum nand_cmd_phase next_phase,

--- a/src/media/cmd_state.c
+++ b/src/media/cmd_state.c
@@ -43,6 +43,11 @@ void nand_cmd_state_begin(struct nand_die_cmd_state *s, enum nand_cmd_opcode op,
     s->in_flight = true;
     s->phase = CMD_PHASE_SETUP;
     s->state = nand_cmd_next_state_on_accept(s->state, op);
+    s->array_started_ns = 0;
+    s->array_budget_ns = 0;
+    memset(&s->suspended_target, 0, sizeof(s->suspended_target));
+    atomic_store(&s->suspend_request, 0);
+    atomic_store(&s->abort_request, 0);
 }
 
 void nand_cmd_state_advance_phase(struct nand_die_cmd_state *s, enum nand_cmd_phase next_phase,

--- a/src/media/media.c
+++ b/src/media/media.c
@@ -803,12 +803,21 @@ int media_nand_multi_plane_read(struct media_ctx *ctx, u32 ch, u32 chip, u32 die
         return HFSSS_ERR_NOTSUPP;
     }
     u32 remaining = plane_mask;
+    u32 idx = 0;
     while (remaining) {
         u32 p = (u32)__builtin_ctz(remaining);
         remaining &= remaining - 1;
         if (nand_validate_address(ctx->nand, ch, chip, die, p, block, page) != HFSSS_OK) {
             return HFSSS_ERR_INVAL;
         }
+        int is_bad = bbt_is_bad(ctx->bbt, ch, chip, die, p, block);
+        if (is_bad == 1) {
+            return HFSSS_ERR_IO;
+        }
+        if (!data_array[idx]) {
+            return HFSSS_ERR_INVAL;
+        }
+        idx++;
     }
 
     struct mp_read_cb_ctx cbc = {

--- a/src/media/media.c
+++ b/src/media/media.c
@@ -585,6 +585,314 @@ int media_nand_read_parameter_page(struct media_ctx *ctx, u32 ch, u32 chip, u32 
     return nand_cmd_engine_submit_read_param_page(ctx->nand, &target, out);
 }
 
+/*
+ * Multi-plane callback contexts. Each carries an array of per-plane
+ * data/spare pointers indexed by position within the plane_mask (LSB
+ * first). The commit hooks iterate all planes, performing the same
+ * operation that the single-plane hooks do but once per plane.
+ */
+struct mp_prog_cb_ctx {
+    struct media_ctx *ctx;
+    u32 ch;
+    u32 chip;
+    u32 die;
+    u32 plane_mask;
+    u32 block;
+    u32 page;
+    const void **data_array;
+    const void **spare_array;
+    int out_status;
+};
+
+static int mp_prog_on_array_commit(void *raw)
+{
+    struct mp_prog_cb_ctx *c = (struct mp_prog_cb_ctx *)raw;
+    u32 idx = 0;
+    u32 remaining = c->plane_mask;
+    while (remaining) {
+        u32 p = (u32)__builtin_ctz(remaining);
+        remaining &= remaining - 1;
+        struct nand_page *np = nand_get_page(c->ctx->nand, c->ch, c->chip, c->die, p, c->block, c->page);
+        if (!np) {
+            c->out_status = HFSSS_ERR_INVAL;
+            return HFSSS_ERR_INVAL;
+        }
+        memcpy(np->data, c->data_array[idx], c->ctx->config.page_size);
+        if (c->spare_array && c->spare_array[idx]) {
+            memcpy(np->spare, c->spare_array[idx], c->ctx->config.spare_size);
+        }
+        np->state = PAGE_VALID;
+        np->program_ts = get_time_ns();
+        np->erase_count = bbt_get_erase_count(c->ctx->bbt, c->ch, c->chip, c->die, p, c->block);
+        np->read_count = 0;
+        np->dirty = true;
+        struct nand_block *nb = nand_get_block(c->ctx->nand, c->ch, c->chip, c->die, p, c->block);
+        if (nb) {
+            nb->state = BLOCK_OPEN;
+            nb->pages_written++;
+            nb->dirty = true;
+        }
+        idx++;
+    }
+    return HFSSS_OK;
+}
+
+struct mp_read_cb_ctx {
+    struct media_ctx *ctx;
+    u32 ch;
+    u32 chip;
+    u32 die;
+    u32 plane_mask;
+    u32 block;
+    u32 page;
+    void **data_array;
+    void **spare_array;
+    int out_status;
+};
+
+static int mp_read_on_setup_commit(void *raw)
+{
+    struct mp_read_cb_ctx *c = (struct mp_read_cb_ctx *)raw;
+    u32 remaining = c->plane_mask;
+    while (remaining) {
+        u32 p = (u32)__builtin_ctz(remaining);
+        remaining &= remaining - 1;
+        struct nand_page *np = nand_get_page(c->ctx->nand, c->ch, c->chip, c->die, p, c->block, c->page);
+        if (!np || np->state != PAGE_VALID) {
+            c->out_status = HFSSS_ERR_NOENT;
+            return HFSSS_ERR_NOENT;
+        }
+    }
+    return HFSSS_OK;
+}
+
+static int mp_read_on_data_xfer_commit(void *raw)
+{
+    struct mp_read_cb_ctx *c = (struct mp_read_cb_ctx *)raw;
+    u32 idx = 0;
+    u32 remaining = c->plane_mask;
+    while (remaining) {
+        u32 p = (u32)__builtin_ctz(remaining);
+        remaining &= remaining - 1;
+        struct nand_page *np = nand_get_page(c->ctx->nand, c->ch, c->chip, c->die, p, c->block, c->page);
+        if (!np) {
+            return HFSSS_ERR_INVAL;
+        }
+        media_inject_bit_errors(c->ctx, np, c->data_array[idx], (c->spare_array ? c->spare_array[idx] : NULL),
+                                c->ctx->config.page_size, c->ctx->config.spare_size);
+        np->read_count++;
+        idx++;
+    }
+    return HFSSS_OK;
+}
+
+struct mp_erase_cb_ctx {
+    struct media_ctx *ctx;
+    u32 ch;
+    u32 chip;
+    u32 die;
+    u32 plane_mask;
+    u32 block;
+    int out_status;
+};
+
+static int mp_erase_on_array_commit(void *raw)
+{
+    struct mp_erase_cb_ctx *c = (struct mp_erase_cb_ctx *)raw;
+    u32 remaining = c->plane_mask;
+    while (remaining) {
+        u32 p = (u32)__builtin_ctz(remaining);
+        remaining &= remaining - 1;
+        struct nand_block *nb = nand_get_block(c->ctx->nand, c->ch, c->chip, c->die, p, c->block);
+        if (!nb) {
+            c->out_status = HFSSS_ERR_INVAL;
+            return HFSSS_ERR_INVAL;
+        }
+        for (u32 pg = 0; pg < nb->page_count; pg++) {
+            struct nand_page *np = &nb->pages[pg];
+            memset(np->data, 0xFF, c->ctx->config.page_size);
+            memset(np->spare, 0xFF, c->ctx->config.spare_size);
+            np->state = PAGE_FREE;
+            np->program_ts = 0;
+            np->read_count = 0;
+            np->bit_errors = 0;
+            np->dirty = true;
+        }
+        nb->state = BLOCK_FREE;
+        nb->pages_written = 0;
+        nb->dirty = true;
+        bbt_increment_erase_count(c->ctx->bbt, c->ch, c->chip, c->die, p, c->block);
+        u32 ec = bbt_get_erase_count(c->ctx->bbt, c->ch, c->chip, c->die, p, c->block);
+        if (reliability_is_block_bad(c->ctx->reliability, c->ctx->config.nand_type, ec)) {
+            bbt_mark_bad(c->ctx->bbt, c->ch, c->chip, c->die, p, c->block);
+        }
+    }
+    return HFSSS_OK;
+}
+
+static u32 popcount32(u32 x)
+{
+    return (u32)__builtin_popcount(x);
+}
+
+int media_nand_multi_plane_program(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane_mask, u32 block,
+                                   u32 page, const void **data_array, const void **spare_array)
+{
+    if (!ctx || !ctx->initialized || !data_array || plane_mask == 0) {
+        return HFSSS_ERR_INVAL;
+    }
+    if (!ctx->config.enable_multi_plane && popcount32(plane_mask) > 1) {
+        return HFSSS_ERR_NOTSUPP;
+    }
+    u32 remaining = plane_mask;
+    u32 idx = 0;
+    while (remaining) {
+        u32 p = (u32)__builtin_ctz(remaining);
+        remaining &= remaining - 1;
+        if (nand_validate_address(ctx->nand, ch, chip, die, p, block, page) != HFSSS_OK) {
+            return HFSSS_ERR_INVAL;
+        }
+        int is_bad = bbt_is_bad(ctx->bbt, ch, chip, die, p, block);
+        if (is_bad == 1) {
+            return HFSSS_ERR_IO;
+        }
+        if (!data_array[idx]) {
+            return HFSSS_ERR_INVAL;
+        }
+        idx++;
+    }
+
+    struct mp_prog_cb_ctx cbc = {
+        .ctx = ctx,
+        .ch = ch,
+        .chip = chip,
+        .die = die,
+        .plane_mask = plane_mask,
+        .block = block,
+        .page = page,
+        .data_array = data_array,
+        .spare_array = spare_array,
+        .out_status = HFSSS_OK,
+    };
+    struct nand_cmd_target target = {
+        .ch = ch, .chip = chip, .die = die, .plane_mask = plane_mask, .block = block, .page = page};
+    struct nand_cmd_ops ops = {.on_array_commit = mp_prog_on_array_commit};
+
+    u64 start_time = get_time_ns();
+    int rc = nand_cmd_engine_submit_program(ctx->nand, &target, &ops, &cbc);
+    if (rc != HFSSS_OK) {
+        return cbc.out_status != HFSSS_OK ? cbc.out_status : rc;
+    }
+
+    u32 n = popcount32(plane_mask);
+    mutex_lock(&ctx->lock, 0);
+    ctx->stats.write_count += n;
+    ctx->stats.total_write_bytes += (u64)n * ctx->config.page_size;
+    ctx->stats.total_write_ns += get_time_ns() - start_time;
+    mutex_unlock(&ctx->lock);
+    return HFSSS_OK;
+}
+
+int media_nand_multi_plane_read(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane_mask, u32 block, u32 page,
+                                void **data_array, void **spare_array)
+{
+    if (!ctx || !ctx->initialized || !data_array || plane_mask == 0) {
+        return HFSSS_ERR_INVAL;
+    }
+    if (!ctx->config.enable_multi_plane && popcount32(plane_mask) > 1) {
+        return HFSSS_ERR_NOTSUPP;
+    }
+    u32 remaining = plane_mask;
+    while (remaining) {
+        u32 p = (u32)__builtin_ctz(remaining);
+        remaining &= remaining - 1;
+        if (nand_validate_address(ctx->nand, ch, chip, die, p, block, page) != HFSSS_OK) {
+            return HFSSS_ERR_INVAL;
+        }
+    }
+
+    struct mp_read_cb_ctx cbc = {
+        .ctx = ctx,
+        .ch = ch,
+        .chip = chip,
+        .die = die,
+        .plane_mask = plane_mask,
+        .block = block,
+        .page = page,
+        .data_array = data_array,
+        .spare_array = spare_array,
+        .out_status = HFSSS_OK,
+    };
+    struct nand_cmd_target target = {
+        .ch = ch, .chip = chip, .die = die, .plane_mask = plane_mask, .block = block, .page = page};
+    struct nand_cmd_ops ops = {.on_setup_commit = mp_read_on_setup_commit,
+                               .on_data_xfer_commit = mp_read_on_data_xfer_commit};
+
+    u64 start_time = get_time_ns();
+    int rc = nand_cmd_engine_submit_read(ctx->nand, &target, &ops, &cbc);
+    if (rc != HFSSS_OK) {
+        return cbc.out_status != HFSSS_OK ? cbc.out_status : rc;
+    }
+
+    u32 n = popcount32(plane_mask);
+    mutex_lock(&ctx->lock, 0);
+    ctx->stats.read_count += n;
+    ctx->stats.total_read_bytes += (u64)n * ctx->config.page_size;
+    ctx->stats.total_read_ns += get_time_ns() - start_time;
+    mutex_unlock(&ctx->lock);
+    return HFSSS_OK;
+}
+
+int media_nand_multi_plane_erase(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane_mask, u32 block)
+{
+    if (!ctx || !ctx->initialized || plane_mask == 0) {
+        return HFSSS_ERR_INVAL;
+    }
+    if (!ctx->config.enable_multi_plane && popcount32(plane_mask) > 1) {
+        return HFSSS_ERR_NOTSUPP;
+    }
+    u32 remaining = plane_mask;
+    while (remaining) {
+        u32 p = (u32)__builtin_ctz(remaining);
+        remaining &= remaining - 1;
+        if (ch >= ctx->config.channel_count || chip >= ctx->config.chips_per_channel ||
+            die >= ctx->config.dies_per_chip || p >= ctx->config.planes_per_die ||
+            block >= ctx->config.blocks_per_plane) {
+            return HFSSS_ERR_INVAL;
+        }
+        int is_bad = bbt_is_bad(ctx->bbt, ch, chip, die, p, block);
+        if (is_bad == 1) {
+            return HFSSS_ERR_IO;
+        }
+    }
+
+    struct mp_erase_cb_ctx cbc = {
+        .ctx = ctx,
+        .ch = ch,
+        .chip = chip,
+        .die = die,
+        .plane_mask = plane_mask,
+        .block = block,
+        .out_status = HFSSS_OK,
+    };
+    struct nand_cmd_target target = {
+        .ch = ch, .chip = chip, .die = die, .plane_mask = plane_mask, .block = block, .page = 0};
+    struct nand_cmd_ops ops = {.on_array_commit = mp_erase_on_array_commit};
+
+    u64 start_time = get_time_ns();
+    int rc = nand_cmd_engine_submit_erase(ctx->nand, &target, &ops, &cbc);
+    if (rc != HFSSS_OK) {
+        return cbc.out_status != HFSSS_OK ? cbc.out_status : rc;
+    }
+
+    u32 n = popcount32(plane_mask);
+    mutex_lock(&ctx->lock, 0);
+    ctx->stats.erase_count += n;
+    ctx->stats.total_erase_ns += get_time_ns() - start_time;
+    mutex_unlock(&ctx->lock);
+    return HFSSS_OK;
+}
+
 static int media_build_die_target(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_cmd_target *out)
 {
     if (!ctx || !ctx->initialized || !out) {

--- a/src/media/media.c
+++ b/src/media/media.c
@@ -585,6 +585,73 @@ int media_nand_read_parameter_page(struct media_ctx *ctx, u32 ch, u32 chip, u32 
     return nand_cmd_engine_submit_read_param_page(ctx->nand, &target, out);
 }
 
+static int media_build_die_target(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, struct nand_cmd_target *out)
+{
+    if (!ctx || !ctx->initialized || !out) {
+        return HFSSS_ERR_INVAL;
+    }
+    if (ch >= ctx->config.channel_count || chip >= ctx->config.chips_per_channel || die >= ctx->config.dies_per_chip) {
+        return HFSSS_ERR_INVAL;
+    }
+    out->ch = ch;
+    out->chip = chip;
+    out->die = die;
+    out->plane_mask = 1u << 0;
+    out->block = 0;
+    out->page = 0;
+    return HFSSS_OK;
+}
+
+int media_nand_program_suspend(struct media_ctx *ctx, u32 ch, u32 chip, u32 die)
+{
+    struct nand_cmd_target target;
+    int rc = media_build_die_target(ctx, ch, chip, die, &target);
+    if (rc != HFSSS_OK) {
+        return rc;
+    }
+    return nand_cmd_engine_submit_prog_suspend(ctx->nand, &target);
+}
+
+int media_nand_program_resume(struct media_ctx *ctx, u32 ch, u32 chip, u32 die)
+{
+    struct nand_cmd_target target;
+    int rc = media_build_die_target(ctx, ch, chip, die, &target);
+    if (rc != HFSSS_OK) {
+        return rc;
+    }
+    return nand_cmd_engine_submit_prog_resume(ctx->nand, &target);
+}
+
+int media_nand_erase_suspend(struct media_ctx *ctx, u32 ch, u32 chip, u32 die)
+{
+    struct nand_cmd_target target;
+    int rc = media_build_die_target(ctx, ch, chip, die, &target);
+    if (rc != HFSSS_OK) {
+        return rc;
+    }
+    return nand_cmd_engine_submit_erase_suspend(ctx->nand, &target);
+}
+
+int media_nand_erase_resume(struct media_ctx *ctx, u32 ch, u32 chip, u32 die)
+{
+    struct nand_cmd_target target;
+    int rc = media_build_die_target(ctx, ch, chip, die, &target);
+    if (rc != HFSSS_OK) {
+        return rc;
+    }
+    return nand_cmd_engine_submit_erase_resume(ctx->nand, &target);
+}
+
+int media_nand_reset(struct media_ctx *ctx, u32 ch, u32 chip, u32 die)
+{
+    struct nand_cmd_target target;
+    int rc = media_build_die_target(ctx, ch, chip, die, &target);
+    if (rc != HFSSS_OK) {
+        return rc;
+    }
+    return nand_cmd_engine_submit_reset(ctx->nand, &target);
+}
+
 int media_nand_is_bad_block(struct media_ctx *ctx, u32 ch, u32 chip, u32 die, u32 plane, u32 block)
 {
     int is_bad;

--- a/src/media/nand_identity.c
+++ b/src/media/nand_identity.c
@@ -214,10 +214,11 @@ static void build_parameter_page(struct nand_parameter_page *pp, const struct me
     pp->ecc_bits_required = ecc_bits_from_nand_type(cfg->nand_type);
     pp->ecc_codeword_size = 1024;
 
-    pp->supported_cmd_bitmap = (1u << NAND_OP_READ) | (1u << NAND_OP_PROG) | (1u << NAND_OP_ERASE) |
-                               (1u << NAND_OP_RESET) | (1u << NAND_OP_READ_STATUS) |
-                               (1u << NAND_OP_READ_STATUS_ENHANCED) | (1u << NAND_OP_READ_ID) |
-                               (1u << NAND_OP_READ_PARAM_PAGE);
+    pp->supported_cmd_bitmap =
+        (1u << NAND_OP_READ) | (1u << NAND_OP_PROG) | (1u << NAND_OP_ERASE) | (1u << NAND_OP_RESET) |
+        (1u << NAND_OP_READ_STATUS) | (1u << NAND_OP_READ_STATUS_ENHANCED) | (1u << NAND_OP_READ_ID) |
+        (1u << NAND_OP_READ_PARAM_PAGE) | (1u << NAND_OP_PROG_SUSPEND) | (1u << NAND_OP_PROG_RESUME) |
+        (1u << NAND_OP_ERASE_SUSPEND) | (1u << NAND_OP_ERASE_RESUME);
 
     if (timing) {
         pp->tR_ns = timing_get_read_latency(timing, 0);
@@ -270,7 +271,7 @@ void nand_status_byte_from_cmd_state(const struct nand_die_cmd_state *s, u8 *out
         break;
     }
 
-    if (!array_busy) {
+    if (!array_busy && !suspended) {
         value |= NAND_STATUS_ARDY;
     }
     if (!array_busy || suspended) {
@@ -330,8 +331,9 @@ void nand_status_enhanced_from_cmd_state(const struct nand_die_cmd_state *s, str
         array_busy = true;
         break;
     }
-    out->array_ready = !array_busy;
-    out->ready = !array_busy || out->suspended_program || out->suspended_erase;
+    bool suspended = out->suspended_program || out->suspended_erase;
+    out->array_ready = !array_busy && !suspended;
+    out->ready = !array_busy || suspended;
 
     out->last_op_failed = s->latched_fail;
 

--- a/src/media/timing.c
+++ b/src/media/timing.c
@@ -13,6 +13,8 @@ static const struct timing_params default_slc_timing = {
     .tWB = 100,
     .tWHR = 60,
     .tRHW = 60,
+    .tSSBSY = 5000,
+    .tRSBSY = 5000,
 };
 
 /* Default timing parameters for MLC (ns) */
@@ -27,6 +29,8 @@ static const struct timing_params default_mlc_timing = {
     .tWB = 150,
     .tWHR = 80,
     .tRHW = 80,
+    .tSSBSY = 10000,
+    .tRSBSY = 10000,
 };
 
 /* Default timing parameters for TLC (ns) */
@@ -37,6 +41,8 @@ static const struct tlc_timing default_tlc_timing = {
     .tPROG_LSB = 900000,
     .tPROG_CSB = 1100000,
     .tPROG_MSB = 1300000,
+    .tSSBSY = 25000,
+    .tRSBSY = 25000,
 };
 
 /* Default timing parameters for QLC (ns) */
@@ -51,6 +57,8 @@ static const struct timing_params default_qlc_timing = {
     .tWB = 200,
     .tWHR = 100,
     .tRHW = 100,
+    .tSSBSY = 50000,
+    .tRSBSY = 50000,
 };
 
 int timing_model_init(struct timing_model *model, enum nand_type type)
@@ -94,10 +102,14 @@ u64 timing_get_read_latency(struct timing_model *model, u32 page_idx)
     case NAND_TYPE_TLC:
         /* TLC has different read latencies for different page types */
         switch (page_idx % 3) {
-        case 0: return model->tlc.tR_LSB;
-        case 1: return model->tlc.tR_CSB;
-        case 2: return model->tlc.tR_MSB;
-        default: return model->tlc.tR_LSB;
+        case 0:
+            return model->tlc.tR_LSB;
+        case 1:
+            return model->tlc.tR_CSB;
+        case 2:
+            return model->tlc.tR_MSB;
+        default:
+            return model->tlc.tR_LSB;
         }
     case NAND_TYPE_QLC:
         return model->qlc.tR;
@@ -120,10 +132,14 @@ u64 timing_get_prog_latency(struct timing_model *model, u32 page_idx)
     case NAND_TYPE_TLC:
         /* TLC has different program latencies for different page types */
         switch (page_idx % 3) {
-        case 0: return model->tlc.tPROG_LSB;
-        case 1: return model->tlc.tPROG_CSB;
-        case 2: return model->tlc.tPROG_MSB;
-        default: return model->tlc.tPROG_LSB;
+        case 0:
+            return model->tlc.tPROG_LSB;
+        case 1:
+            return model->tlc.tPROG_CSB;
+        case 2:
+            return model->tlc.tPROG_MSB;
+        default:
+            return model->tlc.tPROG_LSB;
         }
     case NAND_TYPE_QLC:
         return model->qlc.tPROG;
@@ -150,5 +166,45 @@ u64 timing_get_erase_latency(struct timing_model *model)
         return model->qlc.tERS;
     default:
         return model->slc.tERS * 2;
+    }
+}
+
+u64 timing_get_suspend_overhead_ns(struct timing_model *model)
+{
+    if (!model) {
+        return 0;
+    }
+
+    switch (model->type) {
+    case NAND_TYPE_SLC:
+        return model->slc.tSSBSY;
+    case NAND_TYPE_MLC:
+        return model->mlc.tSSBSY;
+    case NAND_TYPE_TLC:
+        return model->tlc.tSSBSY;
+    case NAND_TYPE_QLC:
+        return model->qlc.tSSBSY;
+    default:
+        return model->tlc.tSSBSY;
+    }
+}
+
+u64 timing_get_resume_overhead_ns(struct timing_model *model)
+{
+    if (!model) {
+        return 0;
+    }
+
+    switch (model->type) {
+    case NAND_TYPE_SLC:
+        return model->slc.tRSBSY;
+    case NAND_TYPE_MLC:
+        return model->mlc.tRSBSY;
+    case NAND_TYPE_TLC:
+        return model->tlc.tRSBSY;
+    case NAND_TYPE_QLC:
+        return model->qlc.tRSBSY;
+    default:
+        return model->tlc.tRSBSY;
     }
 }

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -1,3 +1,4 @@
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -838,6 +839,292 @@ static int test_cmd_phase2_commands(void)
     return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
 }
 
+/* Phase 3 suspend/resume tests — worker thread helpers */
+struct worker_ctx {
+    struct media_ctx *ctx;
+    u32 block;
+    u32 page;
+    int rc;
+};
+
+static void *prog_worker(void *arg)
+{
+    struct worker_ctx *w = (struct worker_ctx *)arg;
+    u8 buf[4096];
+    memset(buf, 0x5A, sizeof(buf));
+    w->rc = media_nand_program(w->ctx, 0, 0, 0, 0, w->block, w->page, buf, NULL);
+    return NULL;
+}
+
+static void *erase_worker(void *arg)
+{
+    struct worker_ctx *w = (struct worker_ctx *)arg;
+    w->rc = media_nand_erase(w->ctx, 0, 0, 0, 0, w->block);
+    return NULL;
+}
+
+static bool wait_for_state(struct media_ctx *ctx, enum nand_die_state want, u64 timeout_ns)
+{
+    u64 deadline = get_time_ns() + timeout_ns;
+    while (get_time_ns() < deadline) {
+        struct nand_status_enhanced enh;
+        if (media_nand_read_status_enhanced(ctx, 0, 0, 0, &enh) == HFSSS_OK && enh.state == want) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static int test_cmd_phase3_suspend_resume(void)
+{
+    printf("\n=== NAND Phase 3 Suspend/Resume Tests ===\n");
+
+    struct media_config config = {
+        .channel_count = 1,
+        .chips_per_channel = 1,
+        .dies_per_chip = 1,
+        .planes_per_die = 1,
+        .blocks_per_plane = 16,
+        .pages_per_block = 16,
+        .page_size = 4096,
+        .spare_size = 64,
+        .nand_type = NAND_TYPE_TLC,
+    };
+
+    struct media_ctx ctx;
+    int ret = media_init(&ctx, &config);
+    TEST_ASSERT(ret == HFSSS_OK, "Phase3: media_init succeeds");
+    if (ret != HFSSS_OK) {
+        return TEST_FAIL;
+    }
+
+    /* Pre-program a page for read-during-suspend tests. */
+    u8 preprog_buf[4096];
+    memset(preprog_buf, 0xBB, sizeof(preprog_buf));
+    ret = media_nand_program(&ctx, 0, 0, 0, 0, 7, 0, preprog_buf, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "Phase3: pre-program block 7 page 0");
+
+    /* SM-25: prog_suspend legal transition */
+    struct worker_ctx wctx = {.ctx = &ctx, .block = 5, .page = 10, .rc = -1};
+    pthread_t thr;
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    bool saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    TEST_ASSERT(saw_busy, "SM-25: observed DIE_PROG_ARRAY_BUSY");
+
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-25: prog_suspend returns OK");
+    struct nand_status_enhanced enh;
+    ret = media_nand_read_status_enhanced(&ctx, 0, 0, 0, &enh);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-25: status after suspend OK");
+    TEST_ASSERT(enh.state == DIE_SUSPENDED_PROG, "SM-25: state == DIE_SUSPENDED_PROG");
+    TEST_ASSERT(enh.suspend_count == 1, "SM-25: suspend_count == 1");
+    TEST_ASSERT(enh.remaining_ns > 0, "SM-25: remaining_ns > 0");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-25: resume returns OK");
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_OK, "SM-25: worker completed OK");
+
+    u8 readback[4096];
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 5, 10, readback, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-25: read-back after suspend/resume OK");
+    TEST_ASSERT(readback[0] == 0x5A, "SM-25: data correct after suspend/resume");
+
+    /* SM-26: suspend-illegal-state matrix */
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_IDLE, NAND_OP_PROG_SUSPEND) == false,
+                "SM-26: prog_suspend illegal in DIE_IDLE");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_PROG_SETUP, NAND_OP_PROG_SUSPEND) == false,
+                "SM-26: prog_suspend illegal in DIE_PROG_SETUP");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_ERASE_ARRAY_BUSY, NAND_OP_PROG_SUSPEND) == false,
+                "SM-26: prog_suspend illegal in DIE_ERASE_ARRAY_BUSY (type mismatch)");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_PROG_ARRAY_BUSY, NAND_OP_ERASE_SUSPEND) == false,
+                "SM-26: erase_suspend illegal in DIE_PROG_ARRAY_BUSY");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_SUSPENDED_PROG, NAND_OP_PROG_SUSPEND) == false,
+                "SM-26: no nested suspend");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_SUSPENDED_ERASE, NAND_OP_PROG_RESUME) == false,
+                "SM-26: prog_resume illegal on suspended erase (cross-type)");
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_SUSPENDED_PROG, NAND_OP_ERASE_RESUME) == false,
+                "SM-26: erase_resume illegal on suspended prog (cross-type)");
+
+    /* SM-27: read during suspend, same-page conflict → BUSY */
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 5, .page = 11, .rc = -1};
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-27: suspend OK");
+
+    u8 conflict_buf[4096];
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 5, 11, conflict_buf, NULL);
+    TEST_ASSERT(ret == HFSSS_ERR_BUSY, "SM-27: same-page read returns BUSY");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_OK, "SM-27: worker completed OK after conflict rejection");
+
+    /* SM-28: read during suspend, different-page → success */
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 5, .page = 12, .rc = -1};
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-28: suspend OK");
+
+    struct nand_die_cmd_state snap_pre_read;
+    ret = nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                                   &snap_pre_read);
+
+    u8 non_conflict_buf[4096];
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 7, 0, non_conflict_buf, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-28: different-block read OK during suspend");
+    TEST_ASSERT(non_conflict_buf[0] == 0xBB, "SM-28: read data correct");
+
+    struct nand_die_cmd_state snap_post_read;
+    ret = nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                                   &snap_post_read);
+    TEST_ASSERT(snap_post_read.state == DIE_SUSPENDED_PROG, "SM-28: state preserved after non-conflict read");
+    TEST_ASSERT(snap_post_read.suspend_count == snap_pre_read.suspend_count, "SM-28: suspend_count preserved");
+    TEST_ASSERT(snap_post_read.remaining_ns == snap_pre_read.remaining_ns, "SM-28: remaining_ns preserved across read");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_OK, "SM-28: worker completed OK after non-conflict read");
+
+    /* SM-29: resume completes remaining_ns */
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 5, .page = 13, .rc = -1};
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-29: suspend OK");
+
+    struct nand_die_cmd_state snap_29;
+    nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                             &snap_29);
+    u64 remaining_before_resume = snap_29.remaining_ns;
+    TEST_ASSERT(remaining_before_resume > 0, "SM-29: remaining_ns positive before resume");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-29: resume OK");
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_OK, "SM-29: worker completed successfully");
+
+    u8 rb29[4096];
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 5, 13, rb29, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-29: data persisted after suspend/resume");
+    TEST_ASSERT(rb29[0] == 0x5A, "SM-29: data content matches");
+
+    /* SM-30: reset during suspended_prog aborts cleanly */
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 6, .page = 0, .rc = -1};
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-30: suspend OK");
+
+    ret = media_nand_reset(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-30: reset OK");
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_ERR_BUSY, "SM-30: worker returns BUSY (aborted)");
+
+    struct nand_die_cmd_state snap_30;
+    nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                             &snap_30);
+    TEST_ASSERT(snap_30.state == DIE_IDLE, "SM-30: state == DIE_IDLE after reset-abort");
+    TEST_ASSERT(snap_30.in_flight == false, "SM-30: in_flight false after reset-abort");
+    TEST_ASSERT(snap_30.latched_fail == false, "SM-30: FAIL latch cleared by reset");
+
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 6, 0, readback, NULL);
+    TEST_ASSERT(ret != HFSSS_OK, "SM-30: aborted program did not commit page");
+
+    /* SM-31: erase suspend/resume symmetric path */
+    /* Erase block 8 (unused) — need it non-erased first, program then erase */
+    u8 buf31[4096];
+    memset(buf31, 0xDD, sizeof(buf31));
+    ret = media_nand_program(&ctx, 0, 0, 0, 0, 8, 0, buf31, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-31: pre-program block 8 for erase test");
+
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 8, .page = 0, .rc = -1};
+    pthread_create(&thr, NULL, erase_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_ERASE_ARRAY_BUSY, 5000000000ULL);
+    TEST_ASSERT(saw_busy, "SM-31: observed DIE_ERASE_ARRAY_BUSY");
+
+    ret = media_nand_erase_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-31: erase_suspend OK");
+
+    ret = media_nand_read_status_enhanced(&ctx, 0, 0, 0, &enh);
+    TEST_ASSERT(enh.state == DIE_SUSPENDED_ERASE, "SM-31: state == DIE_SUSPENDED_ERASE");
+    TEST_ASSERT(enh.suspend_count == 1, "SM-31: suspend_count == 1");
+
+    ret = media_nand_erase_resume(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-31: erase_resume OK");
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_OK, "SM-31: erase worker completed OK");
+
+    u32 ec = media_nand_get_erase_count(&ctx, 0, 0, 0, 0, 8);
+    TEST_ASSERT(ec >= 1, "SM-31: erase count incremented");
+
+    /* SM-32: reset during erase array-busy aborts cleanly */
+    memset(buf31, 0xFF, sizeof(buf31));
+    ret = media_nand_program(&ctx, 0, 0, 0, 0, 11, 0, buf31, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-32: pre-program block 11");
+
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 11, .page = 0, .rc = -1};
+    pthread_create(&thr, NULL, erase_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_ERASE_ARRAY_BUSY, 5000000000ULL);
+    TEST_ASSERT(saw_busy, "SM-32: observed DIE_ERASE_ARRAY_BUSY");
+
+    ret = media_nand_erase_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-32: erase suspend OK");
+
+    ret = media_nand_reset(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-32: reset OK");
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_ERR_BUSY, "SM-32: erase worker returns BUSY (aborted)");
+
+    struct nand_die_cmd_state snap_32;
+    nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                             &snap_32);
+    TEST_ASSERT(snap_32.state == DIE_IDLE, "SM-32: state == DIE_IDLE after erase reset-abort");
+    TEST_ASSERT(snap_32.in_flight == false, "SM-32: in_flight false");
+
+    /* SM-33: wrong-type resume illegal */
+    memset(buf31, 0xEE, sizeof(buf31));
+    ret = media_nand_program(&ctx, 0, 0, 0, 0, 9, 0, buf31, NULL);
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 9, .page = 0, .rc = -1};
+    pthread_create(&thr, NULL, erase_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_ERASE_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_erase_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-33: erase suspend OK");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_ERR_BUSY, "SM-33: prog_resume on suspended erase returns BUSY");
+
+    ret = media_nand_erase_resume(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-33: correct resume type OK");
+    pthread_join(thr, NULL);
+
+    /* SM-34: status_byte during DIE_SUSPENDED_PROG */
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 10, .page = 0, .rc = -1};
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-34: suspend OK");
+
+    u8 sr34 = 0;
+    ret = media_nand_read_status_byte(&ctx, 0, 0, 0, &sr34);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-34: status_byte during suspend OK");
+    TEST_ASSERT((sr34 & NAND_STATUS_RDY) != 0, "SM-34: RDY set during suspend");
+    TEST_ASSERT((sr34 & NAND_STATUS_ARDY) == 0, "SM-34: ARDY clear during suspend");
+    TEST_ASSERT((sr34 & NAND_STATUS_FAIL) == 0, "SM-34: FAIL clear during suspend");
+
+    ret = media_nand_read_status_enhanced(&ctx, 0, 0, 0, &enh);
+    TEST_ASSERT(enh.suspended_program == true, "SM-34: suspended_program flag set");
+    TEST_ASSERT(enh.suspended_erase == false, "SM-34: suspended_erase flag clear");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    pthread_join(thr, NULL);
+
+    media_cleanup(&ctx);
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
 /* Main */
 int main(void)
 {
@@ -858,6 +1145,7 @@ int main(void)
     test_persistence();
     test_cmd_state_machine();
     test_cmd_phase2_commands();
+    test_cmd_phase3_suspend_resume();
 
     printf("\n========================================\n");
     printf("Test Summary\n");

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -1125,6 +1125,169 @@ static int test_cmd_phase3_suspend_resume(void)
     return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
 }
 
+/* Phase 4 multi-plane tests */
+static int test_cmd_phase4_multi_plane(void)
+{
+    printf("\n=== NAND Phase 4 Multi-Plane Tests ===\n");
+
+    struct media_config config = {
+        .channel_count = 1,
+        .chips_per_channel = 1,
+        .dies_per_chip = 1,
+        .planes_per_die = 2,
+        .blocks_per_plane = 16,
+        .pages_per_block = 16,
+        .page_size = 4096,
+        .spare_size = 64,
+        .nand_type = NAND_TYPE_TLC,
+        .enable_multi_plane = true,
+    };
+
+    struct media_ctx ctx;
+    int ret = media_init(&ctx, &config);
+    TEST_ASSERT(ret == HFSSS_OK, "Phase4: media_init succeeds (2-plane)");
+    if (ret != HFSSS_OK) {
+        return TEST_FAIL;
+    }
+
+    /* SM-35: basic multi-plane program */
+    u8 d0[4096], d1[4096];
+    memset(d0, 0xAA, sizeof(d0));
+    memset(d1, 0xBB, sizeof(d1));
+    const void *wr_arr[2] = {d0, d1};
+    ret = media_nand_multi_plane_program(&ctx, 0, 0, 0, 0x3, 0, 0, wr_arr, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-35: multi-plane program succeeds");
+
+    u8 r0[4096], r1[4096];
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 0, 0, r0, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-35: read plane 0 OK");
+    TEST_ASSERT(r0[0] == 0xAA, "SM-35: plane 0 data correct");
+    ret = media_nand_read(&ctx, 0, 0, 0, 1, 0, 0, r1, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-35: read plane 1 OK");
+    TEST_ASSERT(r1[0] == 0xBB, "SM-35: plane 1 data correct");
+
+    /* SM-36: basic multi-plane read */
+    memset(r0, 0, sizeof(r0));
+    memset(r1, 0, sizeof(r1));
+    void *rd_arr[2] = {r0, r1};
+    ret = media_nand_multi_plane_read(&ctx, 0, 0, 0, 0x3, 0, 0, rd_arr, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-36: multi-plane read succeeds");
+    TEST_ASSERT(r0[0] == 0xAA, "SM-36: multi-plane read plane 0 correct");
+    TEST_ASSERT(r1[0] == 0xBB, "SM-36: multi-plane read plane 1 correct");
+
+    /* SM-37: basic multi-plane erase */
+    ret = media_nand_multi_plane_erase(&ctx, 0, 0, 0, 0x3, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-37: multi-plane erase succeeds");
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 0, 0, r0, NULL);
+    TEST_ASSERT(ret == HFSSS_ERR_NOENT, "SM-37: plane 0 erased (NOENT)");
+    ret = media_nand_read(&ctx, 0, 0, 0, 1, 0, 0, r1, NULL);
+    TEST_ASSERT(ret == HFSSS_ERR_NOENT, "SM-37: plane 1 erased (NOENT)");
+
+    /* SM-38: single-plane regression */
+    memset(d0, 0xCC, sizeof(d0));
+    ret = media_nand_program(&ctx, 0, 0, 0, 0, 1, 0, d0, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-38: single-plane program still works");
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 1, 0, r0, NULL);
+    TEST_ASSERT(ret == HFSSS_OK && r0[0] == 0xCC, "SM-38: single-plane data correct");
+
+    /* SM-39: illegal plane_mask — non-existent plane */
+    ret = media_nand_multi_plane_program(&ctx, 0, 0, 0, 0x4, 0, 0, wr_arr, NULL);
+    TEST_ASSERT(ret == HFSSS_ERR_INVAL, "SM-39: plane_mask with non-existent plane returns INVAL");
+
+    /* SM-40: illegal plane_mask — zero */
+    ret = media_nand_multi_plane_program(&ctx, 0, 0, 0, 0x0, 0, 0, wr_arr, NULL);
+    TEST_ASSERT(ret == HFSSS_ERR_INVAL, "SM-40: zero plane_mask returns INVAL");
+
+    /* SM-41: multi-plane disabled */
+    struct media_config cfg_disabled = config;
+    cfg_disabled.enable_multi_plane = false;
+    struct media_ctx ctx_dis;
+    ret = media_init(&ctx_dis, &cfg_disabled);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-41: disabled ctx init OK");
+    ret = media_nand_multi_plane_program(&ctx_dis, 0, 0, 0, 0x3, 0, 0, wr_arr, NULL);
+    TEST_ASSERT(ret == HFSSS_ERR_NOTSUPP, "SM-41: multi-plane program returns NOTSUPP when disabled");
+    ret = media_nand_multi_plane_program(&ctx_dis, 0, 0, 0, 0x1, 0, 0, wr_arr, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-41: single-bit mask still works when disabled");
+    media_cleanup(&ctx_dis);
+
+    /* SM-42: bad block on one plane fails entire multi-plane op */
+    bbt_mark_bad(ctx.bbt, 0, 0, 0, 1, 2);
+    ret = media_nand_multi_plane_program(&ctx, 0, 0, 0, 0x3, 2, 0, wr_arr, NULL);
+    TEST_ASSERT(ret == HFSSS_ERR_IO, "SM-42: bad block on plane 1 rejects multi-plane");
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 2, 0, r0, NULL);
+    TEST_ASSERT(ret != HFSSS_OK, "SM-42: plane 0 block 2 not programmed (atomicity)");
+
+    /* SM-43: multi-plane EAT updated for all planes */
+    u64 eat_p0_before = eat_get_for_plane(ctx.eat, 0, 0, 0, 0);
+    u64 eat_p1_before = eat_get_for_plane(ctx.eat, 0, 0, 0, 1);
+    memset(d0, 0xDD, sizeof(d0));
+    memset(d1, 0xEE, sizeof(d1));
+    wr_arr[0] = d0;
+    wr_arr[1] = d1;
+    ret = media_nand_multi_plane_program(&ctx, 0, 0, 0, 0x3, 3, 0, wr_arr, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-43: multi-plane program for EAT test");
+    u64 eat_p0_after = eat_get_for_plane(ctx.eat, 0, 0, 0, 0);
+    u64 eat_p1_after = eat_get_for_plane(ctx.eat, 0, 0, 0, 1);
+    TEST_ASSERT(eat_p0_after > eat_p0_before, "SM-43: plane 0 EAT advanced");
+    TEST_ASSERT(eat_p1_after > eat_p1_before, "SM-43: plane 1 EAT advanced");
+
+    /* SM-45: snapshot after multi-plane shows correct plane_mask */
+    struct nand_die_cmd_state snap;
+    nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1}, &snap);
+    TEST_ASSERT(snap.target.plane_mask == 0x3, "SM-45: snapshot target.plane_mask has both planes");
+    TEST_ASSERT(snap.state == DIE_IDLE, "SM-45: die idle after multi-plane");
+
+    /* SM-46: multi-plane suspend/resume */
+    memset(d0, 0x11, sizeof(d0));
+    memset(d1, 0x22, sizeof(d1));
+    wr_arr[0] = d0;
+    wr_arr[1] = d1;
+
+    struct worker_ctx wctx;
+    pthread_t thr;
+    struct nand_status_enhanced enh;
+
+    /* We cannot easily use a lambda in C, so test suspend/resume with
+     * a single-plane worker on this 2-plane die — the engine still
+     * correctly tracks plane_mask=1 for the single-plane case. */
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 4, .page = 1, .rc = -1};
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    bool saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    TEST_ASSERT(saw_busy, "SM-46: observed PROG_ARRAY_BUSY on 2-plane die");
+
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-46: suspend OK on 2-plane die");
+
+    ret = media_nand_read_status_enhanced(&ctx, 0, 0, 0, &enh);
+    TEST_ASSERT(enh.state == DIE_SUSPENDED_PROG, "SM-46: state == DIE_SUSPENDED_PROG");
+
+    /* SM-47: read on non-overlapping plane during suspend succeeds */
+    u8 read47[4096];
+    memset(d0, 0xFF, sizeof(d0));
+    ret = media_nand_program(&ctx, 0, 0, 0, 1, 4, 1, d0, NULL);
+    /* This will fail because die is suspended, read instead from an already-programmed page */
+    /* Actually the plane_mask for the prog worker was 1u<<0 (plane 0). So plane 1 is free. */
+    /* But we need a valid page on plane 1 — we programmed block 3, page 0 on plane 1 in SM-43. */
+    ret = media_nand_read(&ctx, 0, 0, 0, 1, 3, 0, read47, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-47: read on non-overlapping plane during suspend OK");
+    TEST_ASSERT(read47[0] == 0xEE, "SM-47: read data from plane 1 correct");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_OK, "SM-46: worker completed after resume");
+
+    /* SM-50: multi-plane with single bit in mask is equivalent to single-plane */
+    memset(d0, 0x99, sizeof(d0));
+    wr_arr[0] = d0;
+    ret = media_nand_multi_plane_program(&ctx, 0, 0, 0, 0x1, 5, 0, wr_arr, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-50: single-bit mask multi-plane succeeds");
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 5, 0, r0, NULL);
+    TEST_ASSERT(ret == HFSSS_OK && r0[0] == 0x99, "SM-50: data correct with single-bit mask");
+
+    media_cleanup(&ctx);
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
 /* Main */
 int main(void)
 {
@@ -1146,6 +1309,7 @@ int main(void)
     test_cmd_state_machine();
     test_cmd_phase2_commands();
     test_cmd_phase3_suspend_resume();
+    test_cmd_phase4_multi_plane();
 
     printf("\n========================================\n");
     printf("Test Summary\n");

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -1288,6 +1288,111 @@ static int test_cmd_phase4_multi_plane(void)
     return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
 }
 
+/* PR #75 review fix coverage */
+static int test_pr75_review_fixes(void)
+{
+    printf("\n=== PR #75 Review Fix Coverage ===\n");
+
+    struct media_config config = {
+        .channel_count = 1,
+        .chips_per_channel = 1,
+        .dies_per_chip = 1,
+        .planes_per_die = 1,
+        .blocks_per_plane = 16,
+        .pages_per_block = 16,
+        .page_size = 4096,
+        .spare_size = 64,
+        .nand_type = NAND_TYPE_TLC,
+    };
+
+    struct media_ctx ctx;
+    int ret = media_init(&ctx, &config);
+    TEST_ASSERT(ret == HFSSS_OK, "PR75-fix: media_init succeeds");
+    if (ret != HFSSS_OK) {
+        return TEST_FAIL;
+    }
+
+    /* SM-51: reset during live array-busy (NOT after suspend-ack).
+     * This tests the wider abort sampling window: reset fires while
+     * the worker is in engine_run_array_busy before any suspend. */
+    struct worker_ctx wctx = {.ctx = &ctx, .block = 0, .page = 0, .rc = -1};
+    pthread_t thr;
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    bool saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    TEST_ASSERT(saw_busy, "SM-51: observed DIE_PROG_ARRAY_BUSY");
+
+    /* Reset directly without suspending first. */
+    ret = media_nand_reset(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-51: reset during array-busy OK");
+    pthread_join(thr, NULL);
+    TEST_ASSERT(wctx.rc == HFSSS_ERR_BUSY, "SM-51: worker returns BUSY (aborted mid-flight)");
+
+    struct nand_die_cmd_state snap51;
+    nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                             &snap51);
+    TEST_ASSERT(snap51.state == DIE_IDLE, "SM-51: state == DIE_IDLE");
+    TEST_ASSERT(snap51.in_flight == false, "SM-51: in_flight false");
+    /* Verify page was NOT committed (reset prevented the commit hook). */
+    u8 rb51[4096];
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 0, 0, rb51, NULL);
+    TEST_ASSERT(ret != HFSSS_OK, "SM-51: aborted PROG did not commit page");
+
+    /* SM-52: read during suspend completes in the suspended window,
+     * not serialized behind the original PROG EAT deadline.
+     * Approach: program on a worker, suspend, then time a read. If the
+     * read were serialized by the PROG EAT, it would take at least
+     * remaining_ns of the suspended PROG. We verify the read completes
+     * in much less time than that. */
+    u8 preprog[4096];
+    memset(preprog, 0x77, sizeof(preprog));
+    ret = media_nand_program(&ctx, 0, 0, 0, 0, 1, 0, preprog, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-52: pre-program page for read test");
+
+    wctx = (struct worker_ctx){.ctx = &ctx, .block = 2, .page = 0, .rc = -1};
+    pthread_create(&thr, NULL, prog_worker, &wctx);
+    saw_busy = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-52: suspend OK");
+
+    struct nand_die_cmd_state snap_sus;
+    nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                             &snap_sus);
+    u64 remaining_prog = snap_sus.remaining_ns;
+
+    u64 read_start = get_time_ns();
+    u8 rb52[4096];
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 1, 0, rb52, NULL);
+    u64 read_elapsed = get_time_ns() - read_start;
+    TEST_ASSERT(ret == HFSSS_OK, "SM-52: read during suspend succeeds");
+    TEST_ASSERT(rb52[0] == 0x77, "SM-52: read data correct");
+    /* The read must complete MUCH faster than the remaining PROG time.
+     * If it were serialized, read_elapsed >= remaining_prog. We assert
+     * it completes in less than half the remaining PROG budget. */
+    TEST_ASSERT(remaining_prog > 0, "SM-52: remaining_ns positive");
+    TEST_ASSERT(read_elapsed < remaining_prog / 2, "SM-52: read NOT serialized by PROG EAT");
+
+    /* SM-53: reset fully clears enhanced status fields (opcode, target,
+     * timestamps, suspend_count). */
+    struct nand_status_enhanced enh53;
+    ret = media_nand_read_status_enhanced(&ctx, 0, 0, 0, &enh53);
+    /* Die is suspended — status should show suspend state. */
+    TEST_ASSERT(enh53.suspend_count > 0, "SM-53: suspend_count > 0 before reset");
+
+    ret = media_nand_reset(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-53: reset OK");
+    pthread_join(thr, NULL);
+
+    ret = media_nand_read_status_enhanced(&ctx, 0, 0, 0, &enh53);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-53: enhanced status after reset OK");
+    TEST_ASSERT(enh53.state == DIE_IDLE, "SM-53: state == DIE_IDLE");
+    TEST_ASSERT(enh53.suspend_count == 0, "SM-53: suspend_count zeroed by reset");
+    TEST_ASSERT(enh53.start_ts_ns == 0, "SM-53: start_ts_ns zeroed by reset");
+    TEST_ASSERT(enh53.remaining_ns == 0, "SM-53: remaining_ns zeroed by reset");
+
+    media_cleanup(&ctx);
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
 /* Main */
 int main(void)
 {
@@ -1310,6 +1415,7 @@ int main(void)
     test_cmd_phase2_commands();
     test_cmd_phase3_suspend_resume();
     test_cmd_phase4_multi_plane();
+    test_pr75_review_fixes();
 
     printf("\n========================================\n");
     printf("Test Summary\n");

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -856,6 +856,25 @@ static void *prog_worker(void *arg)
     return NULL;
 }
 
+struct mp_worker_ctx {
+    struct media_ctx *ctx;
+    u32 plane_mask;
+    u32 block;
+    u32 page;
+    int rc;
+};
+
+static void *mp_prog_worker(void *arg)
+{
+    struct mp_worker_ctx *w = (struct mp_worker_ctx *)arg;
+    u8 d0[4096], d1[4096];
+    memset(d0, 0x5A, sizeof(d0));
+    memset(d1, 0x5B, sizeof(d1));
+    const void *arr[2] = {d0, d1};
+    w->rc = media_nand_multi_plane_program(w->ctx, 0, 0, 0, w->plane_mask, w->block, w->page, arr, NULL);
+    return NULL;
+}
+
 static void *erase_worker(void *arg)
 {
     struct worker_ctx *w = (struct worker_ctx *)arg;
@@ -1283,6 +1302,55 @@ static int test_cmd_phase4_multi_plane(void)
     TEST_ASSERT(ret == HFSSS_OK, "SM-50: single-bit mask multi-plane succeeds");
     ret = media_nand_read(&ctx, 0, 0, 0, 0, 5, 0, r0, NULL);
     TEST_ASSERT(ret == HFSSS_OK && r0[0] == 0x99, "SM-50: data correct with single-bit mask");
+
+    /* SM-54: real multi-plane in-flight suspend/resume */
+    struct mp_worker_ctx mpw = {.ctx = &ctx, .plane_mask = 0x3, .block = 6, .page = 0, .rc = -1};
+    pthread_t mp_thr;
+    pthread_create(&mp_thr, NULL, mp_prog_worker, &mpw);
+    bool saw = wait_for_state(&ctx, DIE_PROG_ARRAY_BUSY, 5000000000ULL);
+    TEST_ASSERT(saw, "SM-54: observed PROG_ARRAY_BUSY on multi-plane op");
+
+    ret = media_nand_program_suspend(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-54: suspend multi-plane prog OK");
+
+    struct nand_die_cmd_state snap54;
+    nand_cmd_engine_snapshot(ctx.nand, &(struct nand_cmd_target){.ch = 0, .chip = 0, .die = 0, .plane_mask = 1},
+                             &snap54);
+    TEST_ASSERT(snap54.state == DIE_SUSPENDED_PROG, "SM-54: state == DIE_SUSPENDED_PROG");
+    TEST_ASSERT(snap54.suspended_target.plane_mask == 0x3, "SM-54: suspended_target.plane_mask == 0x3");
+    TEST_ASSERT(snap54.remaining_ns > 0, "SM-54: remaining_ns > 0");
+
+    ret = media_nand_program_resume(&ctx, 0, 0, 0);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-54: resume OK");
+    pthread_join(mp_thr, NULL);
+    TEST_ASSERT(mpw.rc == HFSSS_OK, "SM-54: multi-plane worker completed OK");
+
+    ret = media_nand_read(&ctx, 0, 0, 0, 0, 6, 0, r0, NULL);
+    TEST_ASSERT(ret == HFSSS_OK && r0[0] == 0x5A, "SM-54: plane 0 data correct after suspend/resume");
+    ret = media_nand_read(&ctx, 0, 0, 0, 1, 6, 0, r1, NULL);
+    TEST_ASSERT(ret == HFSSS_OK && r1[0] == 0x5B, "SM-54: plane 1 data correct after suspend/resume");
+
+    /* SM-55: multi-plane EAT relative deadline assertion */
+    u64 eat_p0_pre = eat_get_for_plane(ctx.eat, 0, 0, 0, 0);
+    u64 eat_p1_pre = eat_get_for_plane(ctx.eat, 0, 0, 0, 1);
+    memset(d0, 0x11, sizeof(d0));
+    memset(d1, 0x22, sizeof(d1));
+    wr_arr[0] = d0;
+    wr_arr[1] = d1;
+    ret = media_nand_multi_plane_program(&ctx, 0, 0, 0, 0x3, 7, 0, wr_arr, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "SM-55: multi-plane program for EAT test");
+    u64 eat_p0_post = eat_get_for_plane(ctx.eat, 0, 0, 0, 0);
+    u64 eat_p1_post = eat_get_for_plane(ctx.eat, 0, 0, 0, 1);
+    u64 delta_p0 = eat_p0_post - eat_p0_pre;
+    u64 delta_p1 = eat_p1_post - eat_p1_pre;
+    TEST_ASSERT(delta_p0 > 0, "SM-55: plane 0 EAT delta > 0");
+    TEST_ASSERT(delta_p1 > 0, "SM-55: plane 1 EAT delta > 0");
+    /* Both planes should advance by approximately the same amount since
+     * multi-plane executes in parallel. Allow 10% tolerance for clock
+     * drift between the two eat_update_stage calls. */
+    u64 max_delta = delta_p0 > delta_p1 ? delta_p0 : delta_p1;
+    u64 min_delta = delta_p0 < delta_p1 ? delta_p0 : delta_p1;
+    TEST_ASSERT(min_delta * 10 >= max_delta * 9, "SM-55: plane EAT deltas within 10% (parallel execution)");
 
     media_cleanup(&ctx);
     return tests_failed > 0 ? TEST_FAIL : TEST_PASS;


### PR DESCRIPTION
## Summary

- Lift single-plane guard in command engine: `plane_mask` now supports multiple set bits
- Multi-plane EAT charging: wait for max deadline across all planes, charge each stage to all planes simultaneously (ONFI 4.2 die-internal parallelism)
- Three new media-layer multi-plane wrappers with per-plane data/spare arrays and atomic commit hooks
- Plane legality validation: geometry bounds, `enable_multi_plane` config gate, bad-block atomicity across planes
- Read-during-suspend conflict check upgraded to use plane_mask intersection
- Addresses PR #73 reviewer feedback on single-plane target model ABI

## Depends on

- PR #75 (suspend/resume) — this branch is based on Phase 3

## Regression results

| Suite | Result |
|-------|--------|
| test_media | 344/344 |
| test_hal | 61/61 |
| test_reliability | 76/76 |
| test_ftl_reliability | 31/31 |
| test_mt_ftl | 10/10 |

## Test plan

- [ ] CI clang-format check
- [ ] CI ASan / TSan / UBSan
- [ ] CI system tests
- [ ] Verify SM-35..SM-50 pass with TSan enabled
- [ ] Validate multi-plane EAT matches single-plane timing (SM-43)
- [ ] Validate bad-block atomicity (SM-42)