### PR TITLE
feat: profile-driven NAND command engine (Phase 6)

### DIFF
--- a/include/media/cmd_engine.h
+++ b/include/media/cmd_engine.h
@@ -8,6 +8,7 @@
 struct nand_device;
 struct eat_ctx;
 struct timing_model;
+struct nand_profile;
 
 /*
  * Per-phase commit callbacks. Any field may be NULL; a NULL slot is treated
@@ -20,7 +21,8 @@ struct nand_cmd_ops {
     int (*on_data_xfer_commit)(void *ctx);
 };
 
-int nand_cmd_engine_init(struct nand_device *dev, struct eat_ctx *eat, struct timing_model *timing);
+int nand_cmd_engine_init(struct nand_device *dev, struct eat_ctx *eat, struct timing_model *timing,
+                         const struct nand_profile *profile);
 void nand_cmd_engine_cleanup(struct nand_device *dev);
 
 int nand_cmd_engine_submit_read(struct nand_device *dev, const struct nand_cmd_target *target,

--- a/include/media/cmd_legality.h
+++ b/include/media/cmd_legality.h
@@ -4,7 +4,18 @@
 #include "common/common.h"
 #include "media/cmd_state.h"
 
+struct nand_profile;
+
 bool nand_cmd_is_legal_in_state(enum nand_die_state state, enum nand_cmd_opcode op);
+
+/*
+ * Profile-aware legality gate. Rejects any op outside the profile's supported
+ * bitmap regardless of state, then delegates to the state-machine matrix. A
+ * NULL profile is treated as "no profile gating" and falls through to the
+ * pure state check, so transitional callers keep working.
+ */
+bool nand_cmd_is_legal_for_profile_state(const struct nand_profile *profile, enum nand_die_state state,
+                                         enum nand_cmd_opcode op);
 
 enum nand_die_state nand_cmd_next_state_on_accept(enum nand_die_state state, enum nand_cmd_opcode op);
 

--- a/include/media/media.h
+++ b/include/media/media.h
@@ -5,6 +5,7 @@
 #include "common/mutex.h"
 #include "media/nand.h"
 #include "media/nand_identity.h"
+#include "media/nand_profile.h"
 #include "media/timing.h"
 #include "media/eat.h"
 #include "media/reliability.h"
@@ -25,6 +26,17 @@ struct media_config {
     enum nand_type nand_type;
     bool enable_multi_plane;
     bool enable_die_interleaving;
+
+    /*
+     * Optional Phase 6 profile selection. When profile_explicit is false
+     * (zero-init default) the profile is derived from nand_type via
+     * nand_profile_get_default_for_type; existing callers therefore observe
+     * zero behavior change. profile_explicit=true with a valid profile_id
+     * routes timing, identity, capability and reset policy through that
+     * profile end-to-end.
+     */
+    enum nand_profile_id profile_id;
+    bool profile_explicit;
 };
 
 /* Media Statistics */
@@ -47,6 +59,7 @@ struct media_ctx {
     struct eat_ctx *eat;
     struct reliability_model *reliability;
     struct bbt *bbt;
+    const struct nand_profile *profile;
     struct media_stats stats;
     struct mutex lock;
     bool initialized;

--- a/include/media/nand.h
+++ b/include/media/nand.h
@@ -97,12 +97,15 @@ struct nand_channel {
     struct mutex lock;
 };
 
+struct nand_profile;
+
 /* NAND Device */
 struct nand_device {
     struct nand_channel channels[MAX_CHANNELS];
     u32 channel_count;
     struct timing_model *timing;
     struct eat_ctx *eat;
+    const struct nand_profile *profile;
     struct nand_id nand_id;
     struct nand_parameter_page param_page;
 };

--- a/include/media/nand_identity.h
+++ b/include/media/nand_identity.h
@@ -131,11 +131,25 @@ struct nand_status_enhanced {
     u8 classic_status;
 };
 
+struct nand_profile;
+
 /*
  * Build the device-level identity and parameter page from the active config.
- * Pure function; performs no locking, no allocation, no I/O.
+ * Pure function; performs no locking, no allocation, no I/O. When dev->profile
+ * is non-NULL the identity bytes (manufacturer, model, supported_cmd_bitmap,
+ * bits_per_cell, ECC contract) come from the profile; geometry fields always
+ * come from cfg. Existing zero-initialized callers without a profile fall
+ * back to the legacy nand_type-derived defaults.
  */
 void nand_identity_build_from_config(struct nand_device *dev, const struct media_config *cfg);
+
+/*
+ * Profile-aware variant exposed for callers that hold an explicit profile
+ * pointer. The shim above is preserved for back-compat and routes through
+ * dev->profile when set.
+ */
+void nand_identity_build_from_profile(struct nand_device *dev, const struct nand_profile *profile,
+                                      const struct media_config *cfg);
 
 /*
  * Decode helpers over a previously taken snapshot. Safe to call without locks.

--- a/include/media/nand_profile.h
+++ b/include/media/nand_profile.h
@@ -1,0 +1,88 @@
+#ifndef __HFSSS_NAND_PROFILE_H
+#define __HFSSS_NAND_PROFILE_H
+
+#include "common/common.h"
+#include "media/cmd_state.h"
+#include "media/nand_identity.h"
+#include "media/timing.h"
+
+/*
+ * Profile-driven NAND capability model (Phase 6 of the NAND command-coverage
+ * design). A profile is the authoritative source for identity, capability,
+ * timing, multi-plane rules and reset policy. Geometry and topology live in
+ * struct media_config and are NOT duplicated here.
+ *
+ * Phase 6 delivers four compile-time generic profiles that differ only in
+ * interface_family and identity strings; Toggle vs ONFI do not diverge in
+ * supported_ops_bitmap yet — that expansion is scheduled for Phase 7.
+ */
+
+enum nand_interface_family {
+    NAND_IF_ONFI = 0,
+    NAND_IF_TOGGLE_EQ,
+};
+
+enum nand_class {
+    NAND_CLASS_ENTERPRISE_TLC = 0,
+    NAND_CLASS_ENTERPRISE_QLC,
+};
+
+enum nand_profile_id {
+    NAND_PROFILE_GENERIC_ONFI_TLC = 0,
+    NAND_PROFILE_GENERIC_ONFI_QLC,
+    NAND_PROFILE_GENERIC_TOGGLE_TLC,
+    NAND_PROFILE_GENERIC_TOGGLE_QLC,
+    NAND_PROFILE_COUNT,
+};
+
+struct nand_profile_identity {
+    u8 manufacturer_id;
+    u8 device_id;
+    char manufacturer_name[NAND_PARAMETER_PAGE_MFR_NAME_LEN];
+    char device_model[NAND_PARAMETER_PAGE_MODEL_LEN];
+};
+
+struct nand_profile_capability {
+    u32 supported_ops_bitmap;
+    u8 bits_per_cell;
+    u16 ecc_bits_required;
+    u16 ecc_codeword_size;
+};
+
+struct nand_profile_timing {
+    struct timing_params slc_params;
+    struct timing_params mlc_params;
+    struct timing_params qlc_params;
+    struct tlc_timing tlc_timing;
+};
+
+struct nand_profile_mp_rules {
+    bool allow_cross_block;
+    u32 plane_addr_mask;
+    u8 max_planes_per_cmd;
+};
+
+struct nand_profile_reset_policy {
+    bool abort_inflight_on_reset;
+    bool preserve_partial_program;
+};
+
+struct nand_profile {
+    const char *id_string;
+    enum nand_profile_id id;
+    enum nand_interface_family interface_family;
+    enum nand_class nand_class;
+    struct nand_profile_identity identity;
+    struct nand_profile_capability capability;
+    struct nand_profile_timing timing;
+    struct nand_profile_mp_rules mp_rules;
+    struct nand_profile_reset_policy reset_policy;
+};
+
+#define NAND_PROFILE_OP_BIT(op) (1u << (u32)(op))
+
+const struct nand_profile *nand_profile_get(enum nand_profile_id id);
+const struct nand_profile *nand_profile_get_default_for_type(enum nand_type type);
+bool nand_profile_supports_op(const struct nand_profile *profile, enum nand_cmd_opcode op);
+
+#endif /* __HFSSS_NAND_PROFILE_H */

--- a/include/media/timing.h
+++ b/include/media/timing.h
@@ -3,6 +3,8 @@
 
 #include "common/common.h"
 
+struct nand_profile;
+
 /* NAND Type */
 enum nand_type {
     NAND_TYPE_SLC = 0,
@@ -54,6 +56,7 @@ struct timing_model {
 
 /* Function Prototypes */
 int timing_model_init(struct timing_model *model, enum nand_type type);
+int timing_model_init_from_profile(struct timing_model *model, const struct nand_profile *profile);
 void timing_model_cleanup(struct timing_model *model);
 u64 timing_get_read_latency(struct timing_model *model, u32 page_idx);
 u64 timing_get_prog_latency(struct timing_model *model, u32 page_idx);

--- a/src/media/cmd_engine.c
+++ b/src/media/cmd_engine.c
@@ -8,6 +8,7 @@
 #include "media/cmd_state.h"
 #include "media/eat.h"
 #include "media/nand.h"
+#include "media/nand_profile.h"
 #include "media/timing.h"
 
 static struct nand_die *engine_get_die(struct nand_device *dev, u32 ch, u32 chip, u32 die)
@@ -313,7 +314,7 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
         die->cmd_state.in_flight = false;
     }
 
-    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, op)) {
+    if (!nand_cmd_is_legal_for_profile_state(dev->profile, die->cmd_state.state, op)) {
         mutex_unlock(&die->die_lock);
         mutex_unlock(&channel->lock);
         return HFSSS_ERR_BUSY;
@@ -547,7 +548,8 @@ static int engine_submit(struct nand_device *dev, enum nand_cmd_opcode op, const
     return stage_rc;
 }
 
-int nand_cmd_engine_init(struct nand_device *dev, struct eat_ctx *eat, struct timing_model *timing)
+int nand_cmd_engine_init(struct nand_device *dev, struct eat_ctx *eat, struct timing_model *timing,
+                         const struct nand_profile *profile)
 {
     if (!dev) {
         return HFSSS_ERR_INVAL;
@@ -557,6 +559,9 @@ int nand_cmd_engine_init(struct nand_device *dev, struct eat_ctx *eat, struct ti
     }
     if (timing) {
         dev->timing = timing;
+    }
+    if (profile) {
+        dev->profile = profile;
     }
     return HFSSS_OK;
 }
@@ -606,9 +611,20 @@ int nand_cmd_engine_submit_reset(struct nand_device *dev, const struct nand_cmd_
      */
     mutex_lock(&die->die_lock, 0);
 
-    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, NAND_OP_RESET)) {
+    if (!nand_cmd_is_legal_for_profile_state(dev->profile, die->cmd_state.state, NAND_OP_RESET)) {
         mutex_unlock(&die->die_lock);
         return HFSSS_ERR_BUSY;
+    }
+
+    /* Profile reset policy: when abort_inflight_on_reset is false the engine
+     * refuses to interrupt an in-flight or suspended command — the caller
+     * must wait for natural completion (or use a profile that allows abort).
+     * Default profiles all set this to true, preserving legacy behavior. */
+    if (dev->profile && !dev->profile->reset_policy.abort_inflight_on_reset) {
+        if (die->cmd_state.state != DIE_IDLE && die->cmd_state.state != DIE_RESETTING) {
+            mutex_unlock(&die->die_lock);
+            return HFSSS_ERR_BUSY;
+        }
     }
 
     /* Increment the abort epoch so any running worker (past or present)
@@ -652,7 +668,7 @@ static int engine_submit_suspend(struct nand_device *dev, enum nand_cmd_opcode o
     }
 
     mutex_lock(&die->die_lock, 0);
-    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, op)) {
+    if (!nand_cmd_is_legal_for_profile_state(dev->profile, die->cmd_state.state, op)) {
         mutex_unlock(&die->die_lock);
         return HFSSS_ERR_BUSY;
     }
@@ -701,7 +717,7 @@ static int engine_submit_resume(struct nand_device *dev, enum nand_cmd_opcode op
     }
 
     mutex_lock(&die->die_lock, 0);
-    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, op)) {
+    if (!nand_cmd_is_legal_for_profile_state(dev->profile, die->cmd_state.state, op)) {
         mutex_unlock(&die->die_lock);
         return HFSSS_ERR_BUSY;
     }
@@ -796,7 +812,7 @@ static int engine_submit_status_byte(struct nand_device *dev, const struct nand_
 
     struct nand_die_cmd_state snap;
     mutex_lock(&die->die_lock, 0);
-    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, NAND_OP_READ_STATUS)) {
+    if (!nand_cmd_is_legal_for_profile_state(dev->profile, die->cmd_state.state, NAND_OP_READ_STATUS)) {
         mutex_unlock(&die->die_lock);
         return HFSSS_ERR_BUSY;
     }
@@ -820,7 +836,7 @@ static int engine_submit_status_enhanced(struct nand_device *dev, const struct n
 
     struct nand_die_cmd_state snap;
     mutex_lock(&die->die_lock, 0);
-    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, NAND_OP_READ_STATUS_ENHANCED)) {
+    if (!nand_cmd_is_legal_for_profile_state(dev->profile, die->cmd_state.state, NAND_OP_READ_STATUS_ENHANCED)) {
         mutex_unlock(&die->die_lock);
         return HFSSS_ERR_BUSY;
     }
@@ -866,7 +882,7 @@ static int engine_submit_identity(struct nand_device *dev, enum nand_cmd_opcode 
     mutex_lock(&channel->lock, 0);
     mutex_lock(&die->die_lock, 0);
 
-    if (!nand_cmd_is_legal_in_state(die->cmd_state.state, op)) {
+    if (!nand_cmd_is_legal_for_profile_state(dev->profile, die->cmd_state.state, op)) {
         mutex_unlock(&die->die_lock);
         mutex_unlock(&channel->lock);
         return HFSSS_ERR_BUSY;

--- a/src/media/cmd_legality.c
+++ b/src/media/cmd_legality.c
@@ -1,4 +1,5 @@
 #include "media/cmd_legality.h"
+#include "media/nand_profile.h"
 
 /*
  * Legality matrix — rows are current die state, columns are incoming opcode.
@@ -110,6 +111,15 @@ bool nand_cmd_is_legal_in_state(enum nand_die_state state, enum nand_cmd_opcode 
         return false;
     }
     return k_legal[state][op];
+}
+
+bool nand_cmd_is_legal_for_profile_state(const struct nand_profile *profile, enum nand_die_state state,
+                                         enum nand_cmd_opcode op)
+{
+    if (profile && !nand_profile_supports_op(profile, op)) {
+        return false;
+    }
+    return nand_cmd_is_legal_in_state(state, op);
 }
 
 enum nand_die_state nand_cmd_next_state_on_accept(enum nand_die_state state, enum nand_cmd_opcode op)

--- a/src/media/media.c
+++ b/src/media/media.c
@@ -57,6 +57,17 @@ int media_init(struct media_ctx *ctx, struct media_config *config)
         return ret;
     }
 
+    /* Resolve the active profile. Explicit profile_id wins; otherwise fall
+     * back to the default for nand_type so existing zero-initialized callers
+     * keep working unchanged. */
+    if (config->profile_explicit) {
+        ctx->profile = nand_profile_get(config->profile_id);
+    }
+    if (!ctx->profile) {
+        ctx->profile = nand_profile_get_default_for_type(config->nand_type);
+    }
+    ctx->nand->profile = ctx->profile;
+
     /* Allocate and initialize timing model */
     ctx->timing = (struct timing_model *)malloc(sizeof(struct timing_model));
     if (!ctx->timing) {
@@ -64,11 +75,15 @@ int media_init(struct media_ctx *ctx, struct media_config *config)
         return HFSSS_ERR_NOMEM;
     }
 
-    ret = timing_model_init(ctx->timing, config->nand_type);
+    ret = timing_model_init_from_profile(ctx->timing, ctx->profile);
     if (ret != HFSSS_OK) {
         media_cleanup(ctx);
         return ret;
     }
+    /* Preserve the caller-requested nand_type so timing_get_*_latency lane
+     * selection still works for SLC/MLC fallbacks where the profile is a
+     * TLC default. */
+    ctx->timing->type = config->nand_type;
 
     /* Associate timing model with NAND device */
     ctx->nand->timing = ctx->timing;

--- a/src/media/nand_identity.c
+++ b/src/media/nand_identity.c
@@ -4,8 +4,10 @@
 #include "media/cmd_state.h"
 #include "media/media.h"
 #include "media/nand.h"
+#include "media/nand_profile.h"
 #include "media/timing.h"
 
+#include <stddef.h>
 #include <string.h>
 
 /*
@@ -108,15 +110,21 @@ static u8 encode_field_log2(u32 value, u8 base_log2, u8 max_code)
  * Pack the 8-byte ID per ONFI 4.2 Table 37. The simulator supports enterprise
  * TLC/QLC geometries whose page/block sizes commonly exceed the 2-bit encoded
  * values defined by ONFI 4.2. Where that happens we clamp to the maximum legal
- * code and mirror the true value in the parameter page.
+ * code and mirror the true value in the parameter page. When a profile is
+ * provided, manufacturer_id and device_id come from the profile so two
+ * profiles sharing the same nand_type still expose distinct identities.
  */
-static void build_nand_id(struct nand_id *id, const struct media_config *cfg)
+static void build_nand_id(struct nand_id *id, const struct media_config *cfg, const struct nand_profile *profile)
 {
     memset(id, 0, sizeof(*id));
-    id->bytes[0] = NAND_ID_MFR_SIMULATOR;
+    if (profile) {
+        id->bytes[0] = profile->identity.manufacturer_id;
+    } else {
+        id->bytes[0] = NAND_ID_MFR_SIMULATOR;
+    }
 
     u8 cell_type = cell_type_from_nand_type(cfg->nand_type);
-    u8 device_code = (u8)(0x10 | (cell_type & 0x03));
+    u8 device_code = profile ? profile->identity.device_id : (u8)(0x10 | (cell_type & 0x03));
     id->bytes[1] = device_code;
 
     u32 dies_per_ce = cfg->chips_per_channel * cfg->dies_per_chip;
@@ -150,7 +158,8 @@ static void build_nand_id(struct nand_id *id, const struct media_config *cfg)
 }
 
 static void build_parameter_page(struct nand_parameter_page *pp, const struct media_config *cfg,
-                                 const struct nand_id *id, struct timing_model *timing)
+                                 const struct nand_id *id, struct timing_model *timing,
+                                 const struct nand_profile *profile)
 {
     memset(pp, 0, sizeof(*pp));
 
@@ -159,26 +168,31 @@ static void build_parameter_page(struct nand_parameter_page *pp, const struct me
 
     pp->manufacturer_id = id->bytes[0];
     pp->device_id = id->bytes[1];
-    memcpy(pp->manufacturer_name, "HFSSS-SIM   ", NAND_PARAMETER_PAGE_MFR_NAME_LEN);
 
-    const char *model = "GENERIC-NAND-0001   ";
-    switch (cfg->nand_type) {
-    case NAND_TYPE_SLC:
-        model = "GENERIC-SLC-0001    ";
-        break;
-    case NAND_TYPE_MLC:
-        model = "GENERIC-MLC-0001    ";
-        break;
-    case NAND_TYPE_TLC:
-        model = "GENERIC-TLC-0001    ";
-        break;
-    case NAND_TYPE_QLC:
-        model = "GENERIC-QLC-0001    ";
-        break;
-    default:
-        break;
+    if (profile) {
+        memcpy(pp->manufacturer_name, profile->identity.manufacturer_name, NAND_PARAMETER_PAGE_MFR_NAME_LEN);
+        memcpy(pp->device_model, profile->identity.device_model, NAND_PARAMETER_PAGE_MODEL_LEN);
+    } else {
+        memcpy(pp->manufacturer_name, "HFSSS-SIM   ", NAND_PARAMETER_PAGE_MFR_NAME_LEN);
+        const char *model = "GENERIC-NAND-0001   ";
+        switch (cfg->nand_type) {
+        case NAND_TYPE_SLC:
+            model = "GENERIC-SLC-0001    ";
+            break;
+        case NAND_TYPE_MLC:
+            model = "GENERIC-MLC-0001    ";
+            break;
+        case NAND_TYPE_TLC:
+            model = "GENERIC-TLC-0001    ";
+            break;
+        case NAND_TYPE_QLC:
+            model = "GENERIC-QLC-0001    ";
+            break;
+        default:
+            break;
+        }
+        memcpy(pp->device_model, model, NAND_PARAMETER_PAGE_MODEL_LEN);
     }
-    memcpy(pp->device_model, model, NAND_PARAMETER_PAGE_MODEL_LEN);
 
     pp->bytes_per_page = cfg->page_size;
     pp->spare_bytes_per_page = (u16)cfg->spare_size;
@@ -186,7 +200,8 @@ static void build_parameter_page(struct nand_parameter_page *pp, const struct me
     pp->blocks_per_lun = cfg->blocks_per_plane * cfg->planes_per_die;
     pp->luns_per_ce = (u8)(cfg->dies_per_chip);
     pp->planes_per_die = (u8)cfg->planes_per_die;
-    pp->bits_per_cell = bits_per_cell_from_nand_type(cfg->nand_type);
+    pp->bits_per_cell =
+        profile ? profile->capability.bits_per_cell : bits_per_cell_from_nand_type(cfg->nand_type);
 
     /* Row address space spans pages × blocks × LUNs so the advertised cycle
      * count can address every page in the CE. Use u64 to avoid overflow on
@@ -211,15 +226,20 @@ static void build_parameter_page(struct nand_parameter_page *pp, const struct me
         pp->addr_cycles_col = 1;
     }
 
-    pp->ecc_bits_required = ecc_bits_from_nand_type(cfg->nand_type);
-    pp->ecc_codeword_size = 1024;
-
-    pp->supported_cmd_bitmap =
-        (1u << NAND_OP_READ) | (1u << NAND_OP_PROG) | (1u << NAND_OP_ERASE) | (1u << NAND_OP_RESET) |
-        (1u << NAND_OP_READ_STATUS) | (1u << NAND_OP_READ_STATUS_ENHANCED) | (1u << NAND_OP_READ_ID) |
-        (1u << NAND_OP_READ_PARAM_PAGE) | (1u << NAND_OP_PROG_SUSPEND) | (1u << NAND_OP_PROG_RESUME) |
-        (1u << NAND_OP_ERASE_SUSPEND) | (1u << NAND_OP_ERASE_RESUME) | (1u << NAND_OP_CACHE_READ) |
-        (1u << NAND_OP_CACHE_READ_END) | (1u << NAND_OP_CACHE_PROG);
+    if (profile) {
+        pp->ecc_bits_required = profile->capability.ecc_bits_required;
+        pp->ecc_codeword_size = profile->capability.ecc_codeword_size;
+        pp->supported_cmd_bitmap = profile->capability.supported_ops_bitmap;
+    } else {
+        pp->ecc_bits_required = ecc_bits_from_nand_type(cfg->nand_type);
+        pp->ecc_codeword_size = 1024;
+        pp->supported_cmd_bitmap =
+            (1u << NAND_OP_READ) | (1u << NAND_OP_PROG) | (1u << NAND_OP_ERASE) | (1u << NAND_OP_RESET) |
+            (1u << NAND_OP_READ_STATUS) | (1u << NAND_OP_READ_STATUS_ENHANCED) | (1u << NAND_OP_READ_ID) |
+            (1u << NAND_OP_READ_PARAM_PAGE) | (1u << NAND_OP_PROG_SUSPEND) | (1u << NAND_OP_PROG_RESUME) |
+            (1u << NAND_OP_ERASE_SUSPEND) | (1u << NAND_OP_ERASE_RESUME) | (1u << NAND_OP_CACHE_READ) |
+            (1u << NAND_OP_CACHE_READ_END) | (1u << NAND_OP_CACHE_PROG);
+    }
 
     if (timing) {
         pp->tR_ns = timing_get_read_latency(timing, 0);
@@ -230,13 +250,22 @@ static void build_parameter_page(struct nand_parameter_page *pp, const struct me
     pp->crc = crc16_ccitt(pp, offsetof(struct nand_parameter_page, crc));
 }
 
+void nand_identity_build_from_profile(struct nand_device *dev, const struct nand_profile *profile,
+                                      const struct media_config *cfg)
+{
+    if (!dev || !cfg) {
+        return;
+    }
+    build_nand_id(&dev->nand_id, cfg, profile);
+    build_parameter_page(&dev->param_page, cfg, &dev->nand_id, dev->timing, profile);
+}
+
 void nand_identity_build_from_config(struct nand_device *dev, const struct media_config *cfg)
 {
     if (!dev || !cfg) {
         return;
     }
-    build_nand_id(&dev->nand_id, cfg);
-    build_parameter_page(&dev->param_page, cfg, &dev->nand_id, dev->timing);
+    nand_identity_build_from_profile(dev, dev->profile, cfg);
 }
 
 void nand_status_byte_from_cmd_state(const struct nand_die_cmd_state *s, u8 *out)

--- a/src/media/nand_profile.c
+++ b/src/media/nand_profile.c
@@ -1,0 +1,271 @@
+#include "media/nand_profile.h"
+#include <string.h>
+
+/*
+ * Phase 6 generic profile table. Timing constants mirror the legacy tables in
+ * timing.c so that legacy callers (nand_type-keyed init path) observe zero
+ * drift when routed through a profile. Identity strings give each profile a
+ * distinct on-the-wire persona so upper layers can tell them apart via
+ * Read ID and Read Parameter Page.
+ */
+
+static const u32 k_default_supported_ops =
+    NAND_PROFILE_OP_BIT(NAND_OP_READ) | NAND_PROFILE_OP_BIT(NAND_OP_PROG) | NAND_PROFILE_OP_BIT(NAND_OP_ERASE)
+    | NAND_PROFILE_OP_BIT(NAND_OP_RESET) | NAND_PROFILE_OP_BIT(NAND_OP_READ_STATUS)
+    | NAND_PROFILE_OP_BIT(NAND_OP_READ_STATUS_ENHANCED) | NAND_PROFILE_OP_BIT(NAND_OP_READ_ID)
+    | NAND_PROFILE_OP_BIT(NAND_OP_READ_PARAM_PAGE) | NAND_PROFILE_OP_BIT(NAND_OP_PROG_SUSPEND)
+    | NAND_PROFILE_OP_BIT(NAND_OP_PROG_RESUME) | NAND_PROFILE_OP_BIT(NAND_OP_ERASE_SUSPEND)
+    | NAND_PROFILE_OP_BIT(NAND_OP_ERASE_RESUME) | NAND_PROFILE_OP_BIT(NAND_OP_CACHE_READ)
+    | NAND_PROFILE_OP_BIT(NAND_OP_CACHE_READ_END) | NAND_PROFILE_OP_BIT(NAND_OP_CACHE_PROG);
+
+static const struct timing_params k_slc_timing = {
+    .tCCS = 100,
+    .tR = 25000,
+    .tPROG = 200000,
+    .tERS = 1500000,
+    .tWC = 30,
+    .tRC = 30,
+    .tADL = 100,
+    .tWB = 100,
+    .tWHR = 60,
+    .tRHW = 60,
+    .tSSBSY = 5000,
+    .tRSBSY = 5000,
+    .tCBSY = 100000,
+    .tDCBSYR1 = 15000,
+};
+
+static const struct timing_params k_mlc_timing = {
+    .tCCS = 150,
+    .tR = 50000,
+    .tPROG = 600000,
+    .tERS = 3000000,
+    .tWC = 40,
+    .tRC = 40,
+    .tADL = 150,
+    .tWB = 150,
+    .tWHR = 80,
+    .tRHW = 80,
+    .tSSBSY = 10000,
+    .tRSBSY = 10000,
+    .tCBSY = 300000,
+    .tDCBSYR1 = 30000,
+};
+
+static const struct tlc_timing k_tlc_timing = {
+    .tR_LSB = 60000,
+    .tR_CSB = 70000,
+    .tR_MSB = 80000,
+    .tPROG_LSB = 900000,
+    .tPROG_CSB = 1100000,
+    .tPROG_MSB = 1300000,
+    .tSSBSY = 25000,
+    .tRSBSY = 25000,
+    .tCBSY = 500000,
+    .tDCBSYR1 = 40000,
+};
+
+static const struct timing_params k_qlc_timing = {
+    .tCCS = 200,
+    .tR = 120000,
+    .tPROG = 2000000,
+    .tERS = 4500000,
+    .tWC = 50,
+    .tRC = 50,
+    .tADL = 200,
+    .tWB = 200,
+    .tWHR = 100,
+    .tRHW = 100,
+    .tSSBSY = 50000,
+    .tRSBSY = 50000,
+    .tCBSY = 1000000,
+    .tDCBSYR1 = 80000,
+};
+
+static const struct nand_profile k_profiles[NAND_PROFILE_COUNT] = {
+    [NAND_PROFILE_GENERIC_ONFI_TLC] =
+        {
+            .id_string = "generic_onfi_enterprise_tlc",
+            .id = NAND_PROFILE_GENERIC_ONFI_TLC,
+            .interface_family = NAND_IF_ONFI,
+            .nand_class = NAND_CLASS_ENTERPRISE_TLC,
+            .identity =
+                {
+                    .manufacturer_id = NAND_ID_MFR_SIMULATOR,
+                    .device_id = 0x30,
+                    .manufacturer_name = "HFSSS ONFI ",
+                    .device_model = "HFSSS-ONFI-TLC-ENT ",
+                },
+            .capability =
+                {
+                    .supported_ops_bitmap = k_default_supported_ops,
+                    .bits_per_cell = 3,
+                    .ecc_bits_required = 40,
+                    .ecc_codeword_size = 1024,
+                },
+            .timing =
+                {
+                    .slc_params = k_slc_timing,
+                    .mlc_params = k_mlc_timing,
+                    .qlc_params = k_qlc_timing,
+                    .tlc_timing = k_tlc_timing,
+                },
+            .mp_rules =
+                {
+                    .allow_cross_block = false,
+                    .plane_addr_mask = 0x01,
+                    .max_planes_per_cmd = 4,
+                },
+            .reset_policy =
+                {
+                    .abort_inflight_on_reset = true,
+                    .preserve_partial_program = false,
+                },
+        },
+    [NAND_PROFILE_GENERIC_ONFI_QLC] =
+        {
+            .id_string = "generic_onfi_enterprise_qlc",
+            .id = NAND_PROFILE_GENERIC_ONFI_QLC,
+            .interface_family = NAND_IF_ONFI,
+            .nand_class = NAND_CLASS_ENTERPRISE_QLC,
+            .identity =
+                {
+                    .manufacturer_id = NAND_ID_MFR_SIMULATOR,
+                    .device_id = 0x40,
+                    .manufacturer_name = "HFSSS ONFI ",
+                    .device_model = "HFSSS-ONFI-QLC-ENT ",
+                },
+            .capability =
+                {
+                    .supported_ops_bitmap = k_default_supported_ops,
+                    .bits_per_cell = 4,
+                    .ecc_bits_required = 72,
+                    .ecc_codeword_size = 1024,
+                },
+            .timing =
+                {
+                    .slc_params = k_slc_timing,
+                    .mlc_params = k_mlc_timing,
+                    .qlc_params = k_qlc_timing,
+                    .tlc_timing = k_tlc_timing,
+                },
+            .mp_rules =
+                {
+                    .allow_cross_block = false,
+                    .plane_addr_mask = 0x01,
+                    .max_planes_per_cmd = 4,
+                },
+            .reset_policy =
+                {
+                    .abort_inflight_on_reset = true,
+                    .preserve_partial_program = false,
+                },
+        },
+    [NAND_PROFILE_GENERIC_TOGGLE_TLC] =
+        {
+            .id_string = "generic_toggle_enterprise_tlc",
+            .id = NAND_PROFILE_GENERIC_TOGGLE_TLC,
+            .interface_family = NAND_IF_TOGGLE_EQ,
+            .nand_class = NAND_CLASS_ENTERPRISE_TLC,
+            .identity =
+                {
+                    .manufacturer_id = NAND_ID_MFR_SIMULATOR,
+                    .device_id = 0x31,
+                    .manufacturer_name = "HFSSS TGL  ",
+                    .device_model = "HFSSS-TGL-TLC-ENT  ",
+                },
+            .capability =
+                {
+                    .supported_ops_bitmap = k_default_supported_ops,
+                    .bits_per_cell = 3,
+                    .ecc_bits_required = 40,
+                    .ecc_codeword_size = 1024,
+                },
+            .timing =
+                {
+                    .slc_params = k_slc_timing,
+                    .mlc_params = k_mlc_timing,
+                    .qlc_params = k_qlc_timing,
+                    .tlc_timing = k_tlc_timing,
+                },
+            .mp_rules =
+                {
+                    .allow_cross_block = false,
+                    .plane_addr_mask = 0x01,
+                    .max_planes_per_cmd = 4,
+                },
+            .reset_policy =
+                {
+                    .abort_inflight_on_reset = true,
+                    .preserve_partial_program = false,
+                },
+        },
+    [NAND_PROFILE_GENERIC_TOGGLE_QLC] =
+        {
+            .id_string = "generic_toggle_enterprise_qlc",
+            .id = NAND_PROFILE_GENERIC_TOGGLE_QLC,
+            .interface_family = NAND_IF_TOGGLE_EQ,
+            .nand_class = NAND_CLASS_ENTERPRISE_QLC,
+            .identity =
+                {
+                    .manufacturer_id = NAND_ID_MFR_SIMULATOR,
+                    .device_id = 0x41,
+                    .manufacturer_name = "HFSSS TGL  ",
+                    .device_model = "HFSSS-TGL-QLC-ENT  ",
+                },
+            .capability =
+                {
+                    .supported_ops_bitmap = k_default_supported_ops,
+                    .bits_per_cell = 4,
+                    .ecc_bits_required = 72,
+                    .ecc_codeword_size = 1024,
+                },
+            .timing =
+                {
+                    .slc_params = k_slc_timing,
+                    .mlc_params = k_mlc_timing,
+                    .qlc_params = k_qlc_timing,
+                    .tlc_timing = k_tlc_timing,
+                },
+            .mp_rules =
+                {
+                    .allow_cross_block = false,
+                    .plane_addr_mask = 0x01,
+                    .max_planes_per_cmd = 4,
+                },
+            .reset_policy =
+                {
+                    .abort_inflight_on_reset = true,
+                    .preserve_partial_program = false,
+                },
+        },
+};
+
+const struct nand_profile *nand_profile_get(enum nand_profile_id id)
+{
+    if ((unsigned)id >= (unsigned)NAND_PROFILE_COUNT) {
+        return NULL;
+    }
+    return &k_profiles[id];
+}
+
+const struct nand_profile *nand_profile_get_default_for_type(enum nand_type type)
+{
+    switch (type) {
+    case NAND_TYPE_QLC:
+        return &k_profiles[NAND_PROFILE_GENERIC_ONFI_QLC];
+    case NAND_TYPE_TLC:
+    case NAND_TYPE_SLC:
+    case NAND_TYPE_MLC:
+    default:
+        return &k_profiles[NAND_PROFILE_GENERIC_ONFI_TLC];
+    }
+}
+
+bool nand_profile_supports_op(const struct nand_profile *profile, enum nand_cmd_opcode op)
+{
+    if (!profile || (unsigned)op >= (unsigned)NAND_OP_COUNT) {
+        return false;
+    }
+    return (profile->capability.supported_ops_bitmap & NAND_PROFILE_OP_BIT(op)) != 0;
+}

--- a/src/media/timing.c
+++ b/src/media/timing.c
@@ -1,73 +1,38 @@
 #include "media/timing.h"
+#include "media/nand_profile.h"
 #include <string.h>
 
-/* Default timing parameters for SLC (ns) */
-static const struct timing_params default_slc_timing = {
-    .tCCS = 100,
-    .tR = 25000,
-    .tPROG = 200000,
-    .tERS = 1500000,
-    .tWC = 30,
-    .tRC = 30,
-    .tADL = 100,
-    .tWB = 100,
-    .tWHR = 60,
-    .tRHW = 60,
-    .tSSBSY = 5000,
-    .tRSBSY = 5000,
-    .tCBSY = 100000,
-    .tDCBSYR1 = 15000,
-};
+int timing_model_init_from_profile(struct timing_model *model, const struct nand_profile *profile)
+{
+    if (!model || !profile) {
+        return HFSSS_ERR_INVAL;
+    }
 
-/* Default timing parameters for MLC (ns) */
-static const struct timing_params default_mlc_timing = {
-    .tCCS = 150,
-    .tR = 50000,
-    .tPROG = 600000,
-    .tERS = 3000000,
-    .tWC = 40,
-    .tRC = 40,
-    .tADL = 150,
-    .tWB = 150,
-    .tWHR = 80,
-    .tRHW = 80,
-    .tSSBSY = 10000,
-    .tRSBSY = 10000,
-    .tCBSY = 300000,
-    .tDCBSYR1 = 30000,
-};
+    memset(model, 0, sizeof(*model));
 
-/* Default timing parameters for TLC (ns) */
-static const struct tlc_timing default_tlc_timing = {
-    .tR_LSB = 60000,
-    .tR_CSB = 70000,
-    .tR_MSB = 80000,
-    .tPROG_LSB = 900000,
-    .tPROG_CSB = 1100000,
-    .tPROG_MSB = 1300000,
-    .tSSBSY = 25000,
-    .tRSBSY = 25000,
-    .tCBSY = 500000,
-    .tDCBSYR1 = 40000,
-};
+    /*
+     * Profile carries timing for every cell variant; copying all four lanes
+     * keeps the legacy timing_get_* switches working unchanged. The model's
+     * type field is derived from the profile's nand_class so the read/program
+     * latency lookups still pick the right lane.
+     */
+    memcpy(&model->slc, &profile->timing.slc_params, sizeof(model->slc));
+    memcpy(&model->mlc, &profile->timing.mlc_params, sizeof(model->mlc));
+    memcpy(&model->tlc, &profile->timing.tlc_timing, sizeof(model->tlc));
+    memcpy(&model->qlc, &profile->timing.qlc_params, sizeof(model->qlc));
 
-/* Default timing parameters for QLC (ns) */
-static const struct timing_params default_qlc_timing = {
-    .tCCS = 200,
-    .tR = 120000,
-    .tPROG = 2000000,
-    .tERS = 4500000,
-    .tWC = 50,
-    .tRC = 50,
-    .tADL = 200,
-    .tWB = 200,
-    .tWHR = 100,
-    .tRHW = 100,
-    .tSSBSY = 50000,
-    .tRSBSY = 50000,
-    .tCBSY = 1000000,
-    .tDCBSYR1 = 80000,
-};
+    switch (profile->nand_class) {
+    case NAND_CLASS_ENTERPRISE_QLC:
+        model->type = NAND_TYPE_QLC;
+        break;
+    case NAND_CLASS_ENTERPRISE_TLC:
+    default:
+        model->type = NAND_TYPE_TLC;
+        break;
+    }
+
+    return HFSSS_OK;
+}
 
 int timing_model_init(struct timing_model *model, enum nand_type type)
 {
@@ -75,15 +40,15 @@ int timing_model_init(struct timing_model *model, enum nand_type type)
         return HFSSS_ERR_INVAL;
     }
 
-    memset(model, 0, sizeof(*model));
+    const struct nand_profile *profile = nand_profile_get_default_for_type(type);
+    int ret = timing_model_init_from_profile(model, profile);
+    if (ret != HFSSS_OK) {
+        return ret;
+    }
+    /* Preserve caller-provided type so SLC/MLC stays observable through
+     * timing_get_*_latency lane selection even though the default profile is
+     * a TLC one. */
     model->type = type;
-
-    /* Initialize with default timings */
-    memcpy(&model->slc, &default_slc_timing, sizeof(model->slc));
-    memcpy(&model->mlc, &default_mlc_timing, sizeof(model->mlc));
-    memcpy(&model->tlc, &default_tlc_timing, sizeof(model->tlc));
-    memcpy(&model->qlc, &default_qlc_timing, sizeof(model->qlc));
-
     return HFSSS_OK;
 }
 

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -8,6 +8,7 @@
 #include "media/cmd_legality.h"
 #include "media/cmd_state.h"
 #include "media/media.h"
+#include "media/nand_profile.h"
 
 #define TEST_PASS 0
 #define TEST_FAIL 1
@@ -1596,6 +1597,188 @@ static int test_cmd_phase5_cache(void)
     return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
 }
 
+static int test_nand_profile_phase6(void)
+{
+    printf("\n=== Phase6 nand_profile table ===\n");
+
+    const struct nand_profile *onfi_tlc = nand_profile_get(NAND_PROFILE_GENERIC_ONFI_TLC);
+    const struct nand_profile *onfi_qlc = nand_profile_get(NAND_PROFILE_GENERIC_ONFI_QLC);
+    const struct nand_profile *tgl_tlc = nand_profile_get(NAND_PROFILE_GENERIC_TOGGLE_TLC);
+    const struct nand_profile *tgl_qlc = nand_profile_get(NAND_PROFILE_GENERIC_TOGGLE_QLC);
+
+    /* PR-01: lookup returns non-NULL for every defined id, NULL for invalid */
+    TEST_ASSERT(onfi_tlc != NULL, "PR-01: ONFI TLC profile present");
+    TEST_ASSERT(onfi_qlc != NULL, "PR-01: ONFI QLC profile present");
+    TEST_ASSERT(tgl_tlc != NULL, "PR-01: Toggle TLC profile present");
+    TEST_ASSERT(tgl_qlc != NULL, "PR-01: Toggle QLC profile present");
+    TEST_ASSERT(nand_profile_get((enum nand_profile_id)NAND_PROFILE_COUNT) == NULL,
+                "PR-01: out-of-range id returns NULL");
+
+    /* PR-02: identity dimensions */
+    TEST_ASSERT(onfi_tlc->interface_family == NAND_IF_ONFI, "PR-02: ONFI TLC interface_family ONFI");
+    TEST_ASSERT(tgl_tlc->interface_family == NAND_IF_TOGGLE_EQ, "PR-02: Toggle TLC interface_family TOGGLE_EQ");
+    TEST_ASSERT(onfi_tlc->nand_class == NAND_CLASS_ENTERPRISE_TLC, "PR-02: ONFI TLC class enterprise_tlc");
+    TEST_ASSERT(onfi_qlc->nand_class == NAND_CLASS_ENTERPRISE_QLC, "PR-02: ONFI QLC class enterprise_qlc");
+    TEST_ASSERT(onfi_tlc->capability.bits_per_cell == 3, "PR-02: ONFI TLC bits_per_cell 3");
+    TEST_ASSERT(onfi_qlc->capability.bits_per_cell == 4, "PR-02: ONFI QLC bits_per_cell 4");
+
+    /* PR-02b: identity strings differ between ONFI and Toggle even when class matches */
+    TEST_ASSERT(onfi_tlc->identity.device_id != tgl_tlc->identity.device_id,
+                "PR-02: ONFI vs Toggle TLC device_id differ");
+    TEST_ASSERT(strncmp(onfi_tlc->identity.manufacturer_name, tgl_tlc->identity.manufacturer_name,
+                        NAND_PARAMETER_PAGE_MFR_NAME_LEN)
+                    != 0,
+                "PR-02: ONFI vs Toggle TLC manufacturer_name differ");
+
+    /* PR-03: default_for_type maps nand_type to expected default profile */
+    TEST_ASSERT(nand_profile_get_default_for_type(NAND_TYPE_TLC) == onfi_tlc, "PR-03: TLC default = ONFI TLC");
+    TEST_ASSERT(nand_profile_get_default_for_type(NAND_TYPE_QLC) == onfi_qlc, "PR-03: QLC default = ONFI QLC");
+    TEST_ASSERT(nand_profile_get_default_for_type(NAND_TYPE_SLC) == onfi_tlc, "PR-03: SLC fallback to ONFI TLC");
+    TEST_ASSERT(nand_profile_get_default_for_type(NAND_TYPE_MLC) == onfi_tlc, "PR-03: MLC fallback to ONFI TLC");
+
+    /* PR-04: supports_op covers all current opcodes for default profiles
+     * and rejects out-of-range/null inputs. */
+    for (int op = 0; op < NAND_OP_COUNT; op++) {
+        TEST_ASSERT(nand_profile_supports_op(onfi_tlc, (enum nand_cmd_opcode)op),
+                    "PR-04: ONFI TLC supports every defined op");
+    }
+    TEST_ASSERT(nand_profile_supports_op(NULL, NAND_OP_READ) == false, "PR-04: NULL profile rejected");
+    TEST_ASSERT(nand_profile_supports_op(onfi_tlc, (enum nand_cmd_opcode)NAND_OP_COUNT) == false,
+                "PR-04: out-of-range op rejected");
+
+    /* PR-05: profile-aware legality gate masks unsupported ops. Build a
+     * synthetic profile that drops CACHE_READ from the bitmap and verify
+     * the gate rejects it even from DIE_IDLE where the state matrix would
+     * normally accept. NULL profile falls through to the pure state check. */
+    struct nand_profile masked = *onfi_tlc;
+    masked.capability.supported_ops_bitmap &= ~NAND_PROFILE_OP_BIT(NAND_OP_CACHE_READ);
+    TEST_ASSERT(nand_cmd_is_legal_in_state(DIE_IDLE, NAND_OP_CACHE_READ) == true,
+                "PR-05: state matrix still allows CACHE_READ in IDLE");
+    TEST_ASSERT(nand_cmd_is_legal_for_profile_state(&masked, DIE_IDLE, NAND_OP_CACHE_READ) == false,
+                "PR-05: masked profile blocks CACHE_READ");
+    TEST_ASSERT(nand_cmd_is_legal_for_profile_state(onfi_tlc, DIE_IDLE, NAND_OP_CACHE_READ) == true,
+                "PR-05: default profile allows CACHE_READ");
+    TEST_ASSERT(nand_cmd_is_legal_for_profile_state(NULL, DIE_IDLE, NAND_OP_CACHE_READ) == true,
+                "PR-05: NULL profile delegates to state matrix");
+    TEST_ASSERT(nand_cmd_is_legal_for_profile_state(&masked, DIE_PROG_ARRAY_BUSY, NAND_OP_READ_STATUS) == true,
+                "PR-05: state-legal supported op still legal under masked profile");
+
+    /* PR-06: media_init resolves profile from config and exposes it on
+     * media_ctx and dev. Default (zero-init) maps via nand_type; explicit
+     * profile_id wins. */
+    struct media_config cfg_default = {
+        .channel_count = 1,
+        .chips_per_channel = 1,
+        .dies_per_chip = 1,
+        .planes_per_die = 1,
+        .blocks_per_plane = 4,
+        .pages_per_block = 16,
+        .page_size = 4096,
+        .spare_size = 256,
+        .nand_type = NAND_TYPE_TLC,
+    };
+    struct media_ctx ctx_default;
+    int ret = media_init(&ctx_default, &cfg_default);
+    TEST_ASSERT(ret == HFSSS_OK, "PR-06: media_init default succeeds");
+    TEST_ASSERT(ctx_default.profile == onfi_tlc, "PR-06: default profile is generic ONFI TLC");
+    TEST_ASSERT(ctx_default.nand->profile == ctx_default.profile, "PR-06: dev profile mirrors ctx profile");
+    media_cleanup(&ctx_default);
+
+    struct media_config cfg_explicit = cfg_default;
+    cfg_explicit.profile_explicit = true;
+    cfg_explicit.profile_id = NAND_PROFILE_GENERIC_ONFI_QLC;
+    struct media_ctx ctx_explicit;
+    ret = media_init(&ctx_explicit, &cfg_explicit);
+    TEST_ASSERT(ret == HFSSS_OK, "PR-06: media_init explicit profile succeeds");
+    TEST_ASSERT(ctx_explicit.profile == onfi_qlc, "PR-06: explicit profile_id wins over nand_type");
+    TEST_ASSERT(ctx_explicit.nand->profile == onfi_qlc, "PR-06: dev profile follows explicit selection");
+
+    /* PR-07: read_id and parameter page reflect the active profile. The
+     * Toggle TLC profile shares geometry and nand_type with ONFI TLC, so
+     * any per-byte difference must come from the profile-driven serializer. */
+    struct nand_id id_qlc;
+    struct nand_parameter_page pp_qlc;
+    TEST_ASSERT(media_nand_read_id(&ctx_explicit, 0, 0, 0, &id_qlc) == HFSSS_OK, "PR-07: read_id ONFI QLC OK");
+    TEST_ASSERT(id_qlc.bytes[0] == onfi_qlc->identity.manufacturer_id, "PR-07: read_id mfr from profile");
+    TEST_ASSERT(id_qlc.bytes[1] == onfi_qlc->identity.device_id, "PR-07: read_id device_id from profile");
+    TEST_ASSERT(media_nand_read_parameter_page(&ctx_explicit, 0, 0, 0, &pp_qlc) == HFSSS_OK,
+                "PR-07: read_parameter_page ONFI QLC OK");
+    TEST_ASSERT(memcmp(pp_qlc.manufacturer_name, onfi_qlc->identity.manufacturer_name,
+                       NAND_PARAMETER_PAGE_MFR_NAME_LEN)
+                    == 0,
+                "PR-07: parameter page mfr_name from profile");
+    TEST_ASSERT(memcmp(pp_qlc.device_model, onfi_qlc->identity.device_model, NAND_PARAMETER_PAGE_MODEL_LEN) == 0,
+                "PR-07: parameter page device_model from profile");
+    TEST_ASSERT(pp_qlc.bits_per_cell == onfi_qlc->capability.bits_per_cell,
+                "PR-07: bits_per_cell from profile capability");
+    TEST_ASSERT(pp_qlc.ecc_bits_required == onfi_qlc->capability.ecc_bits_required,
+                "PR-07: ecc_bits_required from profile capability");
+    TEST_ASSERT(pp_qlc.supported_cmd_bitmap == onfi_qlc->capability.supported_ops_bitmap,
+                "PR-07: supported_cmd_bitmap from profile capability");
+    media_cleanup(&ctx_explicit);
+
+    /* Toggle TLC vs ONFI TLC over identical geometry — profile is the only
+     * differentiator, so identity bytes must differ. */
+    struct media_config cfg_toggle = cfg_default;
+    cfg_toggle.profile_explicit = true;
+    cfg_toggle.profile_id = NAND_PROFILE_GENERIC_TOGGLE_TLC;
+    struct media_ctx ctx_toggle;
+    TEST_ASSERT(media_init(&ctx_toggle, &cfg_toggle) == HFSSS_OK, "PR-07: media_init Toggle TLC OK");
+    struct nand_id id_tgl;
+    struct nand_parameter_page pp_tgl;
+    TEST_ASSERT(media_nand_read_id(&ctx_toggle, 0, 0, 0, &id_tgl) == HFSSS_OK, "PR-07: read_id Toggle TLC OK");
+    TEST_ASSERT(media_nand_read_parameter_page(&ctx_toggle, 0, 0, 0, &pp_tgl) == HFSSS_OK,
+                "PR-07: read_parameter_page Toggle TLC OK");
+    TEST_ASSERT(id_tgl.bytes[1] == tgl_tlc->identity.device_id, "PR-07: Toggle TLC device_id from profile");
+    TEST_ASSERT(memcmp(pp_tgl.manufacturer_name, tgl_tlc->identity.manufacturer_name,
+                       NAND_PARAMETER_PAGE_MFR_NAME_LEN)
+                    == 0,
+                "PR-07: Toggle TLC mfr_name from profile");
+    TEST_ASSERT(memcmp(pp_tgl.device_model, tgl_tlc->identity.device_model, NAND_PARAMETER_PAGE_MODEL_LEN) == 0,
+                "PR-07: Toggle TLC device_model from profile");
+    media_cleanup(&ctx_toggle);
+
+    /* PR-08: reset policy from profile.
+     *
+     * Default profile (abort_inflight_on_reset=true) accepts reset even
+     * mid-op. A custom no-abort profile rejects reset while the die is in a
+     * busy state and only succeeds once the die returns to IDLE. The custom
+     * profile is injected post-init by overwriting ctx->profile and
+     * ctx->nand->profile — this is allowed at test scope because the field is
+     * a const pointer to caller-owned profile storage. */
+    struct media_ctx ctx_policy;
+    TEST_ASSERT(media_init(&ctx_policy, &cfg_default) == HFSSS_OK, "PR-08: media_init for policy test OK");
+
+    static struct nand_profile no_abort_profile;
+    no_abort_profile = *onfi_tlc;
+    no_abort_profile.reset_policy.abort_inflight_on_reset = false;
+    ctx_policy.profile = &no_abort_profile;
+    ctx_policy.nand->profile = &no_abort_profile;
+
+    /* Force the die into a busy state under die_lock so the policy check
+     * triggers without racing a real worker. */
+    struct nand_die *die0 = &ctx_policy.nand->channels[0].chips[0].dies[0];
+    die0->cmd_state.state = DIE_PROG_ARRAY_BUSY;
+    int reset_busy_rc = media_nand_reset(&ctx_policy, 0, 0, 0);
+    TEST_ASSERT(reset_busy_rc != HFSSS_OK, "PR-08: no-abort profile rejects reset while busy");
+
+    /* Restore IDLE and reset should now succeed. */
+    die0->cmd_state.state = DIE_IDLE;
+    int reset_idle_rc = media_nand_reset(&ctx_policy, 0, 0, 0);
+    TEST_ASSERT(reset_idle_rc == HFSSS_OK, "PR-08: no-abort profile allows reset from IDLE");
+
+    /* Switch back to abort-allowing profile and confirm reset still works
+     * when the die is busy. */
+    ctx_policy.profile = onfi_tlc;
+    ctx_policy.nand->profile = onfi_tlc;
+    die0->cmd_state.state = DIE_PROG_ARRAY_BUSY;
+    int reset_force_rc = media_nand_reset(&ctx_policy, 0, 0, 0);
+    TEST_ASSERT(reset_force_rc == HFSSS_OK, "PR-08: abort profile resets even while busy");
+    media_cleanup(&ctx_policy);
+
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
 /* Main */
 int main(void)
 {
@@ -1620,6 +1803,7 @@ int main(void)
     test_cmd_phase4_multi_plane();
     test_pr75_review_fixes();
     test_cmd_phase5_cache();
+    test_nand_profile_phase6();
 
     printf("\n========================================\n");
     printf("Test Summary\n");


### PR DESCRIPTION
## Summary
Implements Phase 6 of the NAND command-coverage design (\`docs/superpowers/specs/2026-04-10-nand-media-command-coverage-design.md\`). The command engine now selects timing, identity, capability, and reset behavior from a \`struct nand_profile\` instead of hard-coded \`nand_type\` switches. Geometry and topology stay in \`struct media_config\`.

## Profile model
Authority split:
- **profile owns**: \`manufacturer\`, \`device_model\`, \`supported_ops_bitmap\`, \`bits_per_cell\`, ECC contract, full timing tables, multi-plane rules, reset policy
- **media_config owns**: channels/chips/dies/planes/blocks/pages, page_size/spare, nand_type, multi_plane and interleaving toggles
- **parameter page**: unchanged ABI; \`nand_identity_build_from_profile\` is the new serializer that pulls identity from profile and geometry from cfg

Four compile-time generic profiles ship in \`src/media/nand_profile.c\`:
- \`generic_onfi_enterprise_tlc\`
- \`generic_onfi_enterprise_qlc\`
- \`generic_toggle_enterprise_tlc\`
- \`generic_toggle_enterprise_qlc\`

ONFI and Toggle profiles share \`supported_ops_bitmap\` in this phase by design — they differ in identity bytes (manufacturer_id, device_id, names). Toggle-specific opcode divergence is scheduled for Phase 7.

## Wiring changes
| Module | Change |
|---|---|
| \`timing.c\` | new \`timing_model_init_from_profile\`; legacy \`timing_model_init(type)\` becomes a shim — zero numerical drift |
| \`cmd_legality.c\` | new \`nand_cmd_is_legal_for_profile_state\` gates supported_ops first; engine submission paths use it |
| \`media.c\` | resolves profile from \`config.profile_explicit\`/\`profile_id\` or default-for-type; stores on \`ctx->profile\` and \`ctx->nand->profile\` |
| \`nand_identity.c\` | profile-aware serializer; \`build_from_config\` becomes a delegating shim |
| \`cmd_engine.c\` | reset honors \`profile->reset_policy.abort_inflight_on_reset\` |

\`media_config\` adds two optional fields: \`profile_id\` and \`profile_explicit\`. Existing zero-initialized callers keep working unchanged via the default-for-type fallback.

## Tests (PR-01..PR-08 in \`tests/test_media.c\`)
- PR-01: profile lookup non-NULL for every defined id, NULL out-of-range
- PR-02: identity dimensions and per-profile field divergence
- PR-03: \`default_for_type\` mapping including SLC/MLC fallback
- PR-04: \`supports_op\` covers all defined opcodes; rejects NULL/out-of-range
- PR-05: profile-aware legality gate masks unsupported ops while preserving NULL fallthrough
- PR-06: \`media_init\` resolves default and explicit profile selections; dev profile mirrors ctx
- PR-07: \`read_id\` and \`read_parameter_page\` reflect profile identity for ONFI QLC and Toggle TLC over identical geometry
- PR-08: \`abort_inflight_on_reset=false\` profile rejects reset while busy; default profile still allows abort

## Test plan
- [x] \`make test\` full regression — 473/473 media tests, all subsystem tests pass locally
- [x] Build clean on macOS (Apple Silicon)
- [ ] CI build job (ubuntu-latest + macos-latest) passes