### PR TITLE
[codex] add authoritative repo agent guide

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,142 @@
+# AGENT.md
+
+This file is the authoritative instruction set for agents working in the
+`hfsss-simulator` repository. If another agent guidance file exists, follow this
+file unless the user gives a more specific instruction in the current session.
+
+## Repository Scope
+
+HFSSS is a full-stack SSD simulator written in C. The codebase spans:
+
+- NVMe and PCIe user-space interfaces
+- SSD controller logic
+- FTL, mapping, GC, wear leveling, ECC, and recovery
+- HAL and NAND media simulation
+- Stress, system, and unit tests
+- Investigation tooling under `scripts/`, `tools/`, and `docs/superpowers/`
+
+The layering matters. Keep changes localized and preserve interface boundaries
+between `include/`, `src/`, `tests/`, and `docs/`.
+
+## Operating Principles
+
+- Explain the intended approach before implementing meaningful changes.
+- If a request is ambiguous, high-risk, or high-impact, clarify the constraint
+  or approval boundary before writing code.
+- In plan-only workflows, write proposals only and do not write code.
+- Prefer spec-driven work for multi-step, high-risk, or architecture-affecting
+  changes. For small, well-scoped fixes, proceed directly once the scope is
+  clear.
+- Keep changes independently verifiable. Break large work into loosely coupled
+  slices when possible.
+- If the same manual process repeats several times, turn it into a script,
+  helper, or explicit repository rule.
+- Separate implementation from review. Finish the change first, then review it
+  with fresh eyes.
+- When fixing bugs, reproduce first when practical, then fix, then verify.
+
+## Language And Communication
+
+- Use English only in agent outputs for this repository.
+- Use English only in PR comments and review comments.
+- Use English only in newly added code comments, documentation edits, and test
+  descriptions unless the user explicitly requests otherwise.
+- Do not use AI tool names in code comments, commit messages, or PR bodies.
+
+## Coding Style
+
+- Use C11 and follow Google-style C/C++ formatting conventions where they fit
+  this codebase.
+- Keep comments conceptual and technical. Do not write process-oriented comments
+  such as "step 1", "fixed", "phase", or progress markers.
+- Specs and design docs must not rely on line numbers to locate code. Use
+  conceptual locations instead.
+- Favor narrow, explicit interfaces over cross-layer shortcuts.
+
+## Build And Test Workflow
+
+Use the repository's Makefile first. Default entry points:
+
+- `make all` builds libraries, binaries, and standard test targets
+- `make test` builds and runs the unit and integration suite wired into the
+  default test target
+- `make clean` removes build output
+
+When working on specific areas, prefer targeted verification in addition to the
+broad suite:
+
+- `build/bin/test_*` for focused module validation
+- `build/bin/stress_*` for sustained-path validation when relevant
+- `build/bin/hfsss-nbd-server` for NBD-path work
+
+Trace-specific work must use the trace build variant:
+
+- `TRACE=1 make all`
+- `TRACE=1 make test`
+
+Expect trace-enabled binaries in `build-trace/` when the Makefile routes them
+there.
+
+## High-Risk Areas
+
+Treat these as high-risk even when the diff is small:
+
+- `src/ftl/` multi-threaded write path, TAA interaction, GC, and recovery
+- `src/vhost/hfsss_nbd_server.c` request lifecycle, cleanup ordering, and
+  buffer sizing
+- Any lifecycle that combines worker threads, HAL ownership, device cleanup,
+  and trace teardown
+- Any change that claims to be "tooling only" while also changing runtime
+  behavior
+
+For these areas, verify shutdown symmetry, ownership, and cleanup order
+explicitly.
+
+## Tooling And Diagnostic Changes
+
+If you add or modify diagnostics, tracing, harnesses, or scripts:
+
+- Ensure the runtime seam actually exists, not just the instrumentation points.
+- Ensure the artifact consumer has a real producer path.
+- Verify the error taxonomy is strict enough to avoid silent PASS conditions.
+- Add or extend focused tests for the diagnostic behavior itself.
+- Do not claim an end-to-end diagnostic pipeline works unless a real artifact
+  was produced and consumed.
+
+If you add runtime fixes alongside tooling, describe the PR as mixed-scope
+instead of "tooling only".
+
+## Review Expectations
+
+When asked to review:
+
+- Lead with findings, ordered by severity.
+- Prioritize correctness, lifecycle safety, cleanup symmetry, data integrity,
+  and testability over style-only comments.
+- Cite files and functions precisely.
+- Distinguish clearly between:
+  - runtime behavior changes
+  - test-only changes
+  - tooling or docs changes
+
+If no material findings remain, say so explicitly and note residual risk.
+
+## Documentation Conventions
+
+Use the existing documentation structure instead of inventing new top-level
+patterns:
+
+- `docs/superpowers/specs/` for design specs
+- `docs/superpowers/plans/` for implementation plans and closeout notes
+- `docs/superpowers/artifacts/` only for curated, review-relevant artifacts
+
+Do not commit incidental runtime output unless the artifact is intentionally part
+of the review record.
+
+## Repository Guardrails
+
+- Do not replace project-specific guidance with a generic template.
+- Do not weaken repository instructions by splitting authority across multiple
+  guidance files.
+- Keep `AGENT.md` authoritative and keep compatibility files such as
+  `CLAUDE.md` as pointers only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,75 +1,12 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This repository uses [AGENT.md](./AGENT.md) as the single source of truth for
+agent instructions.
 
-## Project Overview
-HFSSS (High Fidelity Full-Stack SSD Simulator) is a complete SSD simulation project that includes full-stack simulation from PCIe/NVMe interface to NAND Flash media.
+If you are an agent working in this repo:
 
-## Working Method
-- Explain the approach before implementing.
-- If requirements are ambiguous, high-risk, or high-impact, clarify and wait for approval before writing any code.
-- In Plan mode, write proposals only — no code.
-- Stick to Spec Coding; no Vibe Coding.
-- Prioritize iteration using /loop.
-- Run /simplify when done.
-
-## Coding Style
-- C style with Google Coding Style:https://google.github.io/styleguide/cppguide.html
-
-## Coding Rules
-
-- Only English is allowed in code.
-- Specs must not rely on line numbers to locate code.
-- Do not write process-oriented explanations in comments.
-- Prefer conceptual descriptions to locate code; avoid "file path + line number."
-
-## Decomposition & Scope Control
-
-- Break tasks into loosely coupled, independently verifiable subtasks; use /batch when necessary.
-- Any process that repeats 3 times should be formalized as a Skill.
-
-## Quality Requirements
-
-- In the early stages of a project, keep only the minimum necessary quality standards: runnable, verifiable, and rollback-able.
-- Prioritize making critical paths and high-risk changes verifiable.
-- When handling bugs: reproduce first, then fix and verify.
-
-## Error Correction & Collaboration
-
-- When corrected, identify the root cause and improve your approach; for recurring issues, formalize them into explicit rules.
-- Separate implementation from review: complete the proposal or code first, then review it independently.
-
-## Prohibited
-
-- Never use /init.
-- CLAUDE.md should be written based on the project's actual needs — do not copy generic templates.
-- Avoid terms that describe development progress (FIXED, Step, Week, Section, Phase, AC-x, etc.) in code comments, commit messages, or PR bodies.
-- Avoid AI tool names (e.g. Codex, Claude, Grok, Gemini, …) in code comments, git commit messages (including authorship), or PR bodies.
-
-## Build Commands
-- `make all` - Build all libraries and test programs
-- `make test` - Build and run all tests
-- `make clean` - Clean build directory
-
-## CI/CD
-GitHub Actions is set up to automatically build and test on every push and pull request.
-
-## Project Structure
-```
-.
-├── include/           # Header files
-│   ├── common/       # Common service headers
-│   ├── media/        # Media simulation headers
-│   ├── hal/          # HAL headers
-│   ├── ftl/          # FTL headers
-│   ├── controller/   # Controller headers
-│   ├── pcie/         # PCIe/NVMe headers
-│   └── sssim.h       # Top-level interface
-├── src/              # Source code
-├── tests/            # Test files
-├── docs/             # Design documents
-└── Makefile          # Build system
-```
-
-## Test Status
-All 1,750+ test assertions pass as of the latest build (1,150+ unit tests + 616 system tests).
+- Read `AGENT.md` first.
+- Treat `AGENT.md` as authoritative for workflow, coding, review, and output
+  conventions.
+- Use this file only as a compatibility pointer for tools that still look for
+  `CLAUDE.md`.


### PR DESCRIPTION
## Summary

This PR adds a repository-local `AGENT.md` as the authoritative instruction file
for agents working in `hfsss-simulator`, and converts `CLAUDE.md` into a
compatibility pointer.

## Why

The repository already had meaningful project-specific guidance in
`CLAUDE.md`, but agent behavior is more reliable when there is a single source
of truth instead of multiple partially overlapping instruction files.

Adding `AGENT.md` makes the intended workflow explicit for tools that look for
that filename, while preserving compatibility for tools that still discover
`CLAUDE.md` first.

## What Changed

- Added `AGENT.md` as the primary guide for repository scope, operating
  principles, communication rules, build and test workflow, review expectations,
  and documentation conventions.
- Preserved the English-only output rule for agent messages, PR comments, and
  newly added code comments.
- Converted `CLAUDE.md` into a short pointer that directs agents to `AGENT.md`
  instead of maintaining two competing instruction sets.

## Validation

This is a documentation-only change. I verified the branch diff is limited to
`AGENT.md` and `CLAUDE.md`, and `git diff --check origin/master...HEAD` returns
cleanly.
