### PR TITLE
fix(nvme): restore Identify Namespace data structure to 4096 bytes

### DIFF
--- a/include/pcie/nvme.h
+++ b/include/pcie/nvme.h
@@ -402,7 +402,12 @@ struct nvme_identify_ns {
     u16 nabspf;       /* 0x2C: Namespace Atomic Boundary Size Power Fail */
     u16 noiob;        /* 0x2E: Namespace Optimal I/O Boundary */
     u64 nvmcap[2];    /* 0x30: NVM Capacity */
-    u8  rsvd1[28];    /* 0x40: Reserved */
+    u16 npwg;         /* 0x40: Namespace Preferred Write Granularity */
+    u16 npwa;         /* 0x42: Namespace Preferred Write Alignment */
+    u16 npdg;         /* 0x44: Namespace Preferred Deallocate Granularity */
+    u16 npda;         /* 0x46: Namespace Preferred Deallocate Alignment */
+    u16 nows;         /* 0x48: Namespace Optimal Write Size */
+    u8  rsvd1[18];    /* 0x4A: Reserved */
     u8  anagrpid[4];  /* 0x5C: ANA Group Identifier */
     u8  rsvd2[3];     /* 0x60: Reserved */
     u8  attr;         /* 0x63: Namespace Attributes */

--- a/include/pcie/nvme.h
+++ b/include/pcie/nvme.h
@@ -402,23 +402,26 @@ struct nvme_identify_ns {
     u16 nabspf;       /* 0x2C: Namespace Atomic Boundary Size Power Fail */
     u16 noiob;        /* 0x2E: Namespace Optimal I/O Boundary */
     u64 nvmcap[2];    /* 0x30: NVM Capacity */
-    u8  rsvd1[40];    /* 0x40: Reserved */
-    u8  anagrpid[4];  /* 0x68: ANA Group Identifier */
-    u8  rsvd2[3];     /* 0x6C: Reserved */
-    u8  attr;         /* 0x6F: Namespace Attributes */
-    u16 nvmsetid;     /* 0x70: NVM Set Identifier */
-    u16 endgid;       /* 0x72: Endurance Group Identifier */
-    u8  nguid[16];    /* 0x74: Namespace Globally Unique Identifier */
-    u64 eui64;        /* 0x84: IEEE Extended Unique Identifier */
+    u8  rsvd1[28];    /* 0x40: Reserved */
+    u8  anagrpid[4];  /* 0x5C: ANA Group Identifier */
+    u8  rsvd2[3];     /* 0x60: Reserved */
+    u8  attr;         /* 0x63: Namespace Attributes */
+    u16 nvmsetid;     /* 0x64: NVM Set Identifier */
+    u16 endgid;       /* 0x66: Endurance Group Identifier */
+    u8  nguid[16];    /* 0x68: Namespace Globally Unique Identifier */
+    u64 eui64;        /* 0x78: IEEE Extended Unique Identifier */
     struct {
         u32 ms : 16;
         u32 lbads : 8;
         u32 rp : 2;
         u32 rsvd : 6;
-    } lbaf[16];        /* 0x88: LBA Format Support */
-    u8  rsvd3[192];   /* 0x108: Reserved */
-    u8  vs[3712];     /* 0x1C0: Vendor Specific */
+    } lbaf[16];        /* 0x80: LBA Format Support */
+    u8  rsvd3[192];   /* 0xC0: Reserved */
+    u8  vs[3712];     /* 0x180: Vendor Specific */
 } __attribute__((packed));
+
+_Static_assert(sizeof(struct nvme_identify_ns) == 4096,
+               "NVMe Identify Namespace data structure must be 4096 bytes per spec");
 
 /* NVMe Controller Context */
 struct nvme_ctrl_ctx {


### PR DESCRIPTION
## Summary

- `struct nvme_identify_ns` was 4108 bytes (NVMe spec requires 4096). `rsvd1[40]` retained the pre-1.4 size after ANAGRPID/NSATTR/NVMSETID/ENDGID were added in-place, double-counting 12 bytes.
- `nvme_build_identify_ns` issues `memset(id, 0, sizeof(*id))` = 4108 bytes into 4096-byte caller buffers (e.g. `calloc(1, 4096)` in `nvme_uspace_exercise_admin_path`), writing 12 bytes past the heap region.
- Fix: shrink `rsvd1` to 28 bytes, restoring NVMe 1.4 field offsets (ANAGRPID at 0x5C, NGUID at 0x68, EUI64 at 0x78, LBAF at 0x80, VS at 0x180). Added `_Static_assert(sizeof == 4096)` as a compile-time regression guard.

## Root Cause Evidence

```
==54712==ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 4108 at 0x621a00060100
    #1 nvme_ctrl_process_identify nvme.c:399
    #2 nvme_uspace_dispatch_admin_cmd nvme_uspace.c:711
    #3 nvme_uspace_exercise_admin_path nvme_uspace.c:923
0 bytes after 4096-byte region
allocated by calloc at nvme_uspace.c:902
```

## Test Plan

- [x] Static assert fails compilation before fix (proves RED): `4108 == 4096` → compile error
- [x] Static assert passes after fix (proves GREEN): `sizeof == 4096` holds
- [x] ASAN build: nbd-server startup clean, Identify Controller + Identify Namespace both `rc=0`, server reaches "Listening" state without overflow report
- [x] `make test` regression: 0 failures across all test tallies
- [x] No callers reference the shifted field offsets in generated data — only `lbaf[0]` is populated (checked by grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)