### PR TITLE
feat(nvme): wire per-NS QoS caps + SLA rollback + hot-reconfigure (REQ-148/149/150/151)

### DIFF
--- a/docs/REQUIREMENT_COVERAGE.md
+++ b/docs/REQUIREMENT_COVERAGE.md
@@ -39,13 +39,13 @@ This document analyzes the coverage of the 178 requirements from the Requirement
 | System Reliability | 4 | 3 | 0 | 1 | 0 | 75.0% | ↑ REQ-088 P99.9 latency anomaly detector |
 | **Core Subtotal** | **138** | **105** | **13** | **20** | **0** | **76.1%** (85.5% partial) | ↑ from 50.0% |
 | Enterprise: UPLP | 8 | 8 | 0 | 0 | 0 | 100% | ↑ implemented |
-| Enterprise: QoS Determinism | 7 | 2 | 5 | 0 | 0 | 28.6% (100% partial) | ↑ DWRR + partial wiring |
+| Enterprise: QoS Determinism | 7 | 6 | 1 | 0 | 0 | 85.7% (100% partial) | ↑ DWRR + per-NS IOPS/BW caps + SLA rollback + hot-reconfig |
 | Enterprise: T10 DIF/PI | 5 | 5 | 0 | 0 | 0 | 100% | ↑ Type 1/2/3 CRC-16 + GC-path PI propagation |
 | Enterprise: Security | 7 | 7 | 0 | 0 | 0 | 100% | ↑ AES-XTS sim, keys, crypto erase, sanitize action modes, secure-boot-verify, NOR-backed dual-copy UPLP-safe key table, TCG-Opal lock/unlock |
 | Enterprise: Multi-Namespace | 5 | 5 | 0 | 0 | 0 | 100% | ↑ implemented |
 | Enterprise: Thermal/Telemetry | 8 | 8 | 0 | 0 | 0 | 100% | ↑ throttle + SMART predict + NVMe Log Page 07h/08h/0xC0 dispatch + AER notifier helpers + REQ-178 runtime producer (smart_monitor) |
-| **Enterprise Subtotal** | **40** | **35** | **5** | **0** | **0** | **87.5%** (100% partial) | ↑ from 0% |
-| **Grand Total** | **178** | **140** | **18** | **20** | **0** | **78.7%** (88.8% partial) | ↑ from 38.8% |
+| **Enterprise Subtotal** | **40** | **39** | **1** | **0** | **0** | **97.5%** (100% partial) | ↑ from 0% |
+| **Grand Total** | **178** | **144** | **14** | **20** | **0** | **80.9%** (88.8% partial) | ↑ from 38.8% |
 
 > **Note**: Figures above count individual requirement rows. Related roadmap group-level coverage tracks the same reality from a different angle. All changes since V2.0 have been verified against current source code; see notes column on each row for file-level evidence.
 
@@ -259,10 +259,10 @@ This document analyzes the coverage of the 178 requirements from the Requirement
 | ID | Requirement Description | Status | Notes |
 |----|------------------------|--------|-------|
 | REQ-147 | DWRR multi-queue scheduler | ✅ | `src/controller/dwrr_scheduler.c` with per-NS queue create/delete + weighted dispatch; `tests/test_qos.c` |
-| REQ-148 | Per-namespace IOPS limits (1K-2M) | ⚠️ | QoS token-bucket tier in `flow_control.c` (REQ-035/113); explicit per-NS rate caps in the 1K–2M range not enforced |
-| REQ-149 | Per-namespace bandwidth limits (50MB/s-14GB/s) | ⚠️ | Same bucket framework; BW-unit tuning not tied to per-NS cap |
-| REQ-150 | Latency SLA enforcement (P99) | ⚠️ | Latency monitor in `src/controller/latency_monitor.c` + deterministic window in `det_window.c`; strict SLA rollback not wired |
-| REQ-151 | QoS policy hot-reconfiguration | ⚠️ | Static at init via config; runtime `config.set` path designed (LLD_18) not fully wired |
+| REQ-148 | Per-namespace IOPS limits (1K-2M) | ✅ | Per-NS `ns_qos_ctx` table embedded in `struct nvme_uspace_dev`; `nvme_uspace_read/write` refill + acquire tokens on every LBA-bearing command, returning `HFSSS_ERR_BUSY` on exhaustion. Dispatcher maps to CQE `SC=NAMESPACE_NOT_READY` so hosts treat it as retryable. Setter `nvme_uspace_dev_set_qos_policy` accepts the full 1K..2M IOPS range. Covered by `tests/test_nvme_uspace.c::test_qos_per_ns_iops_cap_engages` (throttle observation on the read path + CQE status + boundary accept). |
+| REQ-149 | Per-namespace bandwidth limits (50MB/s-14GB/s) | ✅ | Same acquire-tokens path — the BW bucket consumes `count * lba_size` bytes per request. Setter accepts the full 50 MB/s..14 GB/s span (50..14000 MB/s). Covered by `tests/test_nvme_uspace.c::test_qos_per_ns_bw_cap_engages` (100K reads against a 50 MB/s cap drive the bucket into throttle; spec lower + upper bounds accepted cleanly). |
+| REQ-150 | Latency SLA enforcement (P99) | ✅ | `nvme_uspace_dev_set_sla_rollback(nsid, target_us, trigger_count, cb, ctx)` arms a P99 SLA target + rollback callback; `nvme_uspace_dev_check_sla` folds `lat_monitor_check_sla`'s breach detection on top of the trigger count and fires the callback on sustained breaches, then resets consecutive_violations so each window is evaluated independently. Covered by `tests/test_nvme_uspace.c::test_qos_sla_rollback` (healthy P99 silent, 3-in-a-row breaches fire exactly once, disabled trigger stays silent, second window re-arms). |
+| REQ-151 | QoS policy hot-reconfiguration | ✅ | `nvme_uspace_dev_set_qos_policy` rebuilds the token buckets in place and the next `qos_acquire_tokens` call sees the new caps without stopping traffic or draining the I/O path. Works for cap changes AND for `enforced` flag flips. Covered by `tests/test_nvme_uspace.c::test_qos_hot_reconfigure_live` (tight -> unenforced mid-traffic stops throttling immediately; subsequent reconfigure to 2M IOPS still passes all commands). |
 | REQ-152 | GC/WL background priority yield | ✅ | GC bandwidth cap (REQ-036) + QoS-aware dispatcher yields foreground reads |
 | REQ-153 | Deterministic latency window (duty cycle) | ⚠️ | `det_window.c` provides windowed metrics; duty-cycle enforcement partial |
 
@@ -375,9 +375,9 @@ The PRD and HLD/LLD documents describe a Linux **kernel module** (`hfsss_nvme.ko
 Current position: **core + enterprise features largely landed; polish and gap-closure in progress.**
 
 Near-term priorities:
-1. Broaden **QoS coverage** — per-NS IOPS/BW limits (REQ-148/149), P99 SLA enforcement (REQ-150), hot-reconfigure (REQ-151).
-2. Address remaining perf items (REQ-122 scalability / REQ-123 resource) with multi-threaded reference measurements.
-3. Wire **real producers** for `system_monitor` (REQ-087) into the NBD / vhost / exporter mains — defaults are POSIX-backed but callers still need to attach real thread-count sources.
+1. Address remaining perf items (REQ-122 scalability / REQ-123 resource) with multi-threaded reference measurements.
+2. Wire **real producers** for `system_monitor` (REQ-087) and the QoS hot-reconfig entry point into the NBD / vhost / exporter mains — hooks exist, callers still need to attach real sensors + config surfaces.
+3. Core gaps: REQ-010 PRP/SGL full, REQ-025 cmd dispatch FSM, REQ-042 multi-plane concurrency, REQ-044 per-channel thread, REQ-096 Format NVM OP%.
 
 Mid-term:
 4. Broaden QoS coverage — per-NS IOPS/BW limits (REQ-148/149), P99 SLA enforcement (REQ-150), hot-reconfigure (REQ-151).

--- a/docs/TRACEABILITY_MATRIX.md
+++ b/docs/TRACEABILITY_MATRIX.md
@@ -219,10 +219,10 @@ This document maps every requirement to its PRD source, HLD architecture, LLD de
 | REQ-ID | Description (brief) | PRD Section | HLD Reference | LLD Reference | Test Reference | Implementation Status |
 |--------|---------------------|-------------|---------------|---------------|----------------|----------------------|
 | REQ-147 | DWRR multi-queue scheduler | 12.2.2 | HLD_02 | LLD_18 | TEST_LLD_02 | Implemented |
-| REQ-148 | Per-namespace IOPS limits | 12.2.3 | HLD_02 | LLD_18 | TEST_LLD_02 | Partial |
-| REQ-149 | Per-namespace bandwidth limits | 12.2.3 | HLD_02 | LLD_18 | TEST_LLD_02 | Partial |
-| REQ-150 | Latency SLA enforcement (P99) | 12.2.4 | HLD_02 | LLD_18 | TEST_LLD_02 | Partial |
-| REQ-151 | QoS policy hot-reconfiguration | 12.2.6 | HLD_02 | LLD_18 | TEST_LLD_02 | Partial |
+| REQ-148 | Per-namespace IOPS limits | 12.2.3 | HLD_02 | LLD_18 | TEST_LLD_02 | Implemented |
+| REQ-149 | Per-namespace bandwidth limits | 12.2.3 | HLD_02 | LLD_18 | TEST_LLD_02 | Implemented |
+| REQ-150 | Latency SLA enforcement (P99) | 12.2.4 | HLD_02 | LLD_18 | TEST_LLD_02 | Implemented |
+| REQ-151 | QoS policy hot-reconfiguration | 12.2.6 | HLD_02 | LLD_18 | TEST_LLD_02 | Implemented |
 | REQ-152 | GC/WL background priority yield | 12.2.5 | HLD_02 | LLD_18 | TEST_LLD_02 | Implemented |
 | REQ-153 | Deterministic latency window | 12.2.5 | HLD_02 | LLD_18 | TEST_LLD_02 | Partial |
 ### 13. Enterprise Requirements: T10 DIF/PI (REQ-154 through REQ-158)
@@ -283,12 +283,12 @@ This document maps every requirement to its PRD source, HLD architecture, LLD de
 | Fault Injection Framework | 3 | 2 | 1 | 0 | 0 | 66.7% |
 | System Reliability/Stability | 4 | 3 | 0 | 0 | 1 | 75.0% |
 | Enterprise: UPLP | 8 | 8 | 0 | 0 | 0 | 100.0% |
-| Enterprise: QoS Determinism | 7 | 2 | 5 | 0 | 0 | 28.6% |
+| Enterprise: QoS Determinism | 7 | 6 | 1 | 0 | 0 | 85.7% |
 | Enterprise: T10 DIF/PI | 5 | 5 | 0 | 0 | 0 | 100.0% |
 | Enterprise: Security | 7 | 7 | 0 | 0 | 0 | 100.0% |
 | Enterprise: Multi-Namespace | 5 | 5 | 0 | 0 | 0 | 100.0% |
 | Enterprise: Thermal/Telemetry | 8 | 8 | 0 | 0 | 0 | 100.0% |
-| **Total** | **178** | **140** | **18** | **0** | **20** | **78.7%** |
+| **Total** | **178** | **144** | **14** | **0** | **20** | **80.9%** |
 
 > Note: "Coverage %" counts Implemented only. Partial and Stub are not counted as fully covered.
 

--- a/include/pcie/nvme_uspace.h
+++ b/include/pcie/nvme_uspace.h
@@ -7,7 +7,22 @@
 #include "sssim.h"
 #include "common/telemetry.h"
 #include "controller/security.h"
+#include "controller/qos.h"
 #include "hal/hal_aer.h"
+
+/* REQ-150: callback fired when the latency monitor observes
+ * `trigger_count` consecutive P99 SLA violations on a namespace.
+ * Receives the nsid, the current P99 reading (microseconds), and
+ * the caller ctx. Declared here so struct nvme_uspace_dev below
+ * can embed a per-ns slot without a forward-decl dance. */
+typedef void (*sla_rollback_fn)(u32 nsid, u64 p99_us, void *ctx);
+
+struct nvme_sla_slot {
+    sla_rollback_fn cb;
+    void           *cb_ctx;
+    u32             trigger_count;   /* 0 disables the rollback */
+    u32             fire_count;      /* total times cb has fired */
+};
 
 /* Simulator Opal command frame layout used on Security Send / Recv
  * data buffers (REQ-161). 37 bytes total:
@@ -111,6 +126,19 @@ struct nvme_uspace_dev {
      * 100) so the monitor is silent until a real data source is
      * attached via nvme_uspace_dev_set_smart_source(). */
     struct smart_monitor smart_mon;
+
+    /* REQ-148 / REQ-149 / REQ-151: per-namespace QoS. Indexed by
+     * nsid-1 (Identify advertises NN=1 so only slot 0 is used today,
+     * but the table size matches the spec's QOS_MAX_NAMESPACES so
+     * future multi-NS work has room). `qos_by_ns[i].initialized`
+     * gates the acquire-tokens check on the I/O path; an
+     * unenforced policy passes through cleanly. */
+    struct ns_qos_ctx         qos_by_ns[QOS_MAX_NAMESPACES];
+
+    /* REQ-150: latency monitor used for P99 SLA tracking +
+     * rollback callback registered by the caller. */
+    struct ns_latency_monitor lat_by_ns[QOS_MAX_NAMESPACES];
+    struct nvme_sla_slot      sla_by_ns[QOS_MAX_NAMESPACES];
 };
 
 /* User-space NVMe Configuration */
@@ -207,6 +235,43 @@ int nvme_uspace_dev_set_smart_source(struct nvme_uspace_dev *dev,
                                      smart_remaining_life_fn get_remaining_life,
                                      smart_spare_fn          get_spare,
                                      void                   *cb_ctx);
+
+/* REQ-151: hot-reconfigure the per-namespace QoS policy at runtime.
+ * Applies `policy` to `nsid` without stopping or draining the I/O
+ * path; the next qos_acquire_tokens call sees the new caps. Pass
+ * policy->enforced=false to disable throttling without tearing
+ * down the ctx. Returns HFSSS_ERR_INVAL for nsid outside the
+ * advertised range, HFSSS_ERR_NOENT if the slot hasn't been armed
+ * yet. */
+int nvme_uspace_dev_set_qos_policy(struct nvme_uspace_dev *dev,
+                                   u32 nsid,
+                                   const struct ns_qos_policy *policy);
+
+/* REQ-150: install a P99 SLA rollback callback for a namespace.
+ * The existing ns_latency_monitor counts consecutive_violations on
+ * every SLA breach; when that counter reaches `trigger_count`, the
+ * callback fires with the offending nsid + the current P99 reading
+ * so the caller can tighten caps, flip to a stricter deterministic
+ * window, or log a telemetry event. `trigger_count == 0` disables
+ * the rollback without touching the monitor. */
+int nvme_uspace_dev_set_sla_rollback(struct nvme_uspace_dev *dev,
+                                     u32 nsid,
+                                     u32 target_us,
+                                     u32 trigger_count,
+                                     sla_rollback_fn cb,
+                                     void *cb_ctx);
+
+/* Drive the SLA check for `nsid`. Usually called after recording a
+ * batch of latency samples via lat_monitor_record; on the sim test
+ * path it's invoked synchronously. Returns true if the rollback
+ * callback fired on this call. */
+bool nvme_uspace_dev_check_sla(struct nvme_uspace_dev *dev, u32 nsid);
+
+/* Record a single completion latency into the per-ns monitor so the
+ * P99 / P99.9 detectors have data. Used by the dispatch wiring + by
+ * tests. */
+void nvme_uspace_dev_record_latency(struct nvme_uspace_dev *dev,
+                                    u32 nsid, u64 latency_ns);
 int nvme_uspace_get_features(struct nvme_uspace_dev *dev, u8 fid, u32 *value);
 int nvme_uspace_set_features(struct nvme_uspace_dev *dev, u8 fid, u32 value);
 

--- a/include/pcie/nvme_uspace.h
+++ b/include/pcie/nvme_uspace.h
@@ -130,13 +130,16 @@ struct nvme_uspace_dev {
     /* REQ-148 / REQ-149 / REQ-151: per-namespace QoS. Indexed by
      * nsid-1 (Identify advertises NN=1 so only slot 0 is used today,
      * but the table size matches the spec's QOS_MAX_NAMESPACES so
-     * future multi-NS work has room). `qos_by_ns[i].initialized`
-     * gates the acquire-tokens check on the I/O path; an
-     * unenforced policy passes through cleanly. */
+     * future multi-NS work has room). All runtime accesses go under
+     * `qos_lock`; the setter takes the same lock so a hot-reconfigure
+     * can't corrupt an in-flight acquire_tokens call. Leaf lock —
+     * never acquire another lock while holding it. */
     struct ns_qos_ctx         qos_by_ns[QOS_MAX_NAMESPACES];
+    struct mutex              qos_lock;
 
     /* REQ-150: latency monitor used for P99 SLA tracking +
-     * rollback callback registered by the caller. */
+     * rollback callback registered by the caller. Guarded by
+     * `qos_lock` alongside the QoS state. */
     struct ns_latency_monitor lat_by_ns[QOS_MAX_NAMESPACES];
     struct nvme_sla_slot      sla_by_ns[QOS_MAX_NAMESPACES];
 };

--- a/src/pcie/nvme_uspace.c
+++ b/src/pcie/nvme_uspace.c
@@ -75,8 +75,11 @@ int nvme_uspace_dev_init(struct nvme_uspace_dev *dev, struct nvme_uspace_config 
     ret = mutex_init(&dev->keys_lock);
     if (ret != HFSSS_OK) goto fail_error_log_lock;
 
-    ret = mutex_init(&dev->telemetry_lock);
+    ret = mutex_init(&dev->qos_lock);
     if (ret != HFSSS_OK) goto fail_keys_lock;
+
+    ret = mutex_init(&dev->telemetry_lock);
+    if (ret != HFSSS_OK) goto fail_qos_lock;
 
     ret = telemetry_init(&dev->telemetry);
     if (ret != HFSSS_OK) goto fail_telemetry_lock;
@@ -159,6 +162,8 @@ fail_telemetry:
     telemetry_cleanup(&dev->telemetry);
 fail_telemetry_lock:
     mutex_cleanup(&dev->telemetry_lock);
+fail_qos_lock:
+    mutex_cleanup(&dev->qos_lock);
 fail_keys_lock:
     mutex_cleanup(&dev->keys_lock);
 fail_error_log_lock:
@@ -195,6 +200,7 @@ void nvme_uspace_dev_cleanup(struct nvme_uspace_dev *dev)
     hal_aer_cleanup(&dev->aer);
     telemetry_cleanup(&dev->telemetry);
     mutex_cleanup(&dev->telemetry_lock);
+    mutex_cleanup(&dev->qos_lock);
     mutex_cleanup(&dev->keys_lock);
     mutex_cleanup(&dev->error_log_lock);
     mutex_cleanup(&dev->lock);
@@ -646,11 +652,17 @@ int nvme_uspace_read(struct nvme_uspace_dev *dev, u32 nsid, u64 lba, u32 count, 
 
     /* REQ-148 / REQ-149: per-NS QoS gate. An unenforced policy
      * passes through; an enforced one throttles the command with
-     * HFSSS_ERR_BUSY when the token bucket is exhausted. */
+     * HFSSS_ERR_BUSY when the token bucket is exhausted. qos_lock
+     * serializes refill/acquire against a concurrent
+     * nvme_uspace_dev_set_qos_policy so a hot-reconfigure can't
+     * tear the bucket mid-check. */
     struct ns_qos_ctx *qctx = &dev->qos_by_ns[nsid - 1];
-    qos_refill_tokens(qctx, get_time_ns());
     u32 io_bytes = count * (u32)dev->sssim.config.lba_size;
-    if (!qos_acquire_tokens(qctx, /*is_write=*/false, io_bytes)) {
+    mutex_lock(&dev->qos_lock, 0);
+    qos_refill_tokens(qctx, get_time_ns());
+    bool admitted = qos_acquire_tokens(qctx, /*is_write=*/false, io_bytes);
+    mutex_unlock(&dev->qos_lock);
+    if (!admitted) {
         mutex_unlock(&dev->keys_lock);
         return HFSSS_ERR_BUSY;
     }
@@ -685,11 +697,15 @@ int nvme_uspace_write(struct nvme_uspace_dev *dev, u32 nsid, u64 lba, u32 count,
     }
 
     /* REQ-148 / REQ-149: per-NS QoS gate. Write costs 2 IOPS tokens
-     * per the existing qos_acquire_tokens contract. */
+     * per the existing qos_acquire_tokens contract. See the read
+     * path for why qos_lock sits inside keys_lock. */
     struct ns_qos_ctx *qctx = &dev->qos_by_ns[nsid - 1];
-    qos_refill_tokens(qctx, get_time_ns());
     u32 io_bytes = count * (u32)dev->sssim.config.lba_size;
-    if (!qos_acquire_tokens(qctx, /*is_write=*/true, io_bytes)) {
+    mutex_lock(&dev->qos_lock, 0);
+    qos_refill_tokens(qctx, get_time_ns());
+    bool admitted = qos_acquire_tokens(qctx, /*is_write=*/true, io_bytes);
+    mutex_unlock(&dev->qos_lock);
+    if (!admitted) {
         mutex_unlock(&dev->keys_lock);
         return HFSSS_ERR_BUSY;
     }
@@ -699,6 +715,30 @@ int nvme_uspace_write(struct nvme_uspace_dev *dev, u32 nsid, u64 lba, u32 count,
     return rc;
 }
 
+/* Spec-aligned QoS policy validation: REQ-148 advertises 1K..2M
+ * IOPS, REQ-149 advertises 50 MB/s..14 GB/s. A zero value on
+ * either axis means "unlimited" and is always legal. Any non-zero
+ * value outside the advertised range is rejected at the edge so
+ * the bucket math is never asked to represent an unsupported rate. */
+#define QOS_IOPS_MIN   1000u
+#define QOS_IOPS_MAX   2000000u
+#define QOS_BW_MIN_MBPS 50u
+#define QOS_BW_MAX_MBPS 14000u
+
+static bool qos_policy_within_spec(const struct ns_qos_policy *p)
+{
+    if (p->iops_limit != 0 &&
+        (p->iops_limit < QOS_IOPS_MIN || p->iops_limit > QOS_IOPS_MAX)) {
+        return false;
+    }
+    if (p->bw_limit_mbps != 0 &&
+        (p->bw_limit_mbps < QOS_BW_MIN_MBPS ||
+         p->bw_limit_mbps > QOS_BW_MAX_MBPS)) {
+        return false;
+    }
+    return true;
+}
+
 int nvme_uspace_dev_set_qos_policy(struct nvme_uspace_dev *dev,
                                    u32 nsid,
                                    const struct ns_qos_policy *policy)
@@ -706,7 +746,13 @@ int nvme_uspace_dev_set_qos_policy(struct nvme_uspace_dev *dev,
     if (!dev || !dev->initialized || !policy) {
         return HFSSS_ERR_INVAL;
     }
-    if (nsid == 0 || nsid > QOS_MAX_NAMESPACES) {
+    /* Identify Controller advertises NN=1; reject anything else so
+     * the API mirrors what the I/O path accepts and callers can't
+     * successfully arm phantom namespaces. */
+    if (nsid != 1) {
+        return HFSSS_ERR_INVAL;
+    }
+    if (!qos_policy_within_spec(policy)) {
         return HFSSS_ERR_INVAL;
     }
     struct ns_qos_ctx *qctx = &dev->qos_by_ns[nsid - 1];
@@ -714,10 +760,13 @@ int nvme_uspace_dev_set_qos_policy(struct nvme_uspace_dev *dev,
         return HFSSS_ERR_NOENT;
     }
     /* qos_set_policy rebuilds the token buckets with current time
-     * so a hot-reconfig takes effect on the very next acquire —
-     * no need to stop or drain traffic. keys_lock isn't taken
-     * because qos state is independent of the Opal key table. */
-    return qos_set_policy(qctx, policy);
+     * so a hot-reconfig takes effect on the very next acquire.
+     * qos_lock serializes against the in-flight I/O path so a
+     * concurrent read/write can't observe a torn bucket state. */
+    mutex_lock(&dev->qos_lock, 0);
+    int rc = qos_set_policy(qctx, policy);
+    mutex_unlock(&dev->qos_lock);
+    return rc;
 }
 
 int nvme_uspace_dev_set_sla_rollback(struct nvme_uspace_dev *dev,
@@ -728,49 +777,58 @@ int nvme_uspace_dev_set_sla_rollback(struct nvme_uspace_dev *dev,
                                      void *cb_ctx)
 {
     if (!dev || !dev->initialized) return HFSSS_ERR_INVAL;
-    if (nsid == 0 || nsid > QOS_MAX_NAMESPACES) return HFSSS_ERR_INVAL;
+    /* Match the I/O path: only the advertised namespace is valid. */
+    if (nsid != 1) return HFSSS_ERR_INVAL;
 
     struct ns_latency_monitor *mon = &dev->lat_by_ns[nsid - 1];
     struct nvme_sla_slot      *slot = &dev->sla_by_ns[nsid - 1];
 
+    mutex_lock(&dev->qos_lock, 0);
     /* Update the target_us on the underlying monitor so
      * lat_monitor_check_sla knows what to compare against. */
     mon->target_us = target_us;
-
     slot->cb            = cb;
     slot->cb_ctx        = cb_ctx;
     slot->trigger_count = trigger_count;
     slot->fire_count    = 0;
+    mutex_unlock(&dev->qos_lock);
     return HFSSS_OK;
 }
 
 bool nvme_uspace_dev_check_sla(struct nvme_uspace_dev *dev, u32 nsid)
 {
     if (!dev || !dev->initialized) return false;
-    if (nsid == 0 || nsid > QOS_MAX_NAMESPACES) return false;
+    if (nsid != 1) return false;
 
     struct ns_latency_monitor *mon  = &dev->lat_by_ns[nsid - 1];
     struct nvme_sla_slot      *slot = &dev->sla_by_ns[nsid - 1];
 
-    /* check_sla bumps consecutive_violations on breach and clears
-     * it otherwise — we just need to fold the trigger-count
-     * threshold on top. */
+    /* Evaluate + snapshot the slot inside qos_lock so a concurrent
+     * nvme_uspace_dev_set_sla_rollback (e.g. from inside a
+     * running callback) can't tear slot->cb/ctx/trigger. The
+     * callback itself runs outside the lock so it can legally
+     * re-install a rollback without deadlocking. */
+    mutex_lock(&dev->qos_lock, 0);
     bool breached = lat_monitor_check_sla(mon);
-    if (!breached || slot->trigger_count == 0) {
+    if (!breached || slot->trigger_count == 0 ||
+        mon->consecutive_violations < slot->trigger_count) {
+        mutex_unlock(&dev->qos_lock);
         return false;
     }
-    if (mon->consecutive_violations < slot->trigger_count) {
-        return false;
-    }
-    if (slot->cb) {
-        u64 p99_us = lat_monitor_percentile(mon, 990);
-        slot->cb(nsid, p99_us, slot->cb_ctx);
-    }
-    slot->fire_count++;
+    sla_rollback_fn local_cb = slot->cb;
+    void           *local_ctx = slot->cb_ctx;
+    u64             p99_us   = lat_monitor_percentile(mon, 990);
     /* Reset consecutive_violations so the next N breaches are
-     * treated as a fresh window; otherwise a single burst would
-     * fire the callback every check. */
+     * treated as a fresh window; without this a sustained P99
+     * breach would fire every check. Callers wanting a "new
+     * samples required" gate can lat_monitor_reset on fire. */
     mon->consecutive_violations = 0;
+    slot->fire_count++;
+    mutex_unlock(&dev->qos_lock);
+
+    if (local_cb) {
+        local_cb(nsid, p99_us, local_ctx);
+    }
     return true;
 }
 
@@ -778,8 +836,10 @@ void nvme_uspace_dev_record_latency(struct nvme_uspace_dev *dev,
                                     u32 nsid, u64 latency_ns)
 {
     if (!dev || !dev->initialized) return;
-    if (nsid == 0 || nsid > QOS_MAX_NAMESPACES) return;
+    if (nsid != 1) return;
+    mutex_lock(&dev->qos_lock, 0);
     lat_monitor_record(&dev->lat_by_ns[nsid - 1], latency_ns);
+    mutex_unlock(&dev->qos_lock);
 }
 
 int nvme_uspace_flush(struct nvme_uspace_dev *dev, u32 nsid)
@@ -1276,6 +1336,11 @@ int nvme_uspace_dispatch_io_cmd(struct nvme_uspace_dev *dev, struct nvme_sq_entr
     u32 nlb = (cmd->cdw12 & 0xFFFF) + 1;
     int result = HFSSS_OK;
 
+    /* REQ-150: stamp completion latency on every LBA-bearing I/O so
+     * nvme_uspace_dev_check_sla sees real data. Caller-driven polls
+     * (or a future QoS daemon) evaluate the rolled-up P99. */
+    u64 io_start_ns = get_time_ns();
+
     switch (cmd->opcode) {
     case NVME_NVM_READ:
         if (!data || data_len < (u64)nlb * dev->sssim.config.lba_size) {
@@ -1343,9 +1408,16 @@ int nvme_uspace_dispatch_io_cmd(struct nvme_uspace_dev *dev, struct nvme_sq_entr
         if (result == HFSSS_ERR_AUTH) {
             sc = NVME_SC_OP_DENIED;
         } else if (result == HFSSS_ERR_BUSY) {
-            /* REQ-148 / REQ-149: token bucket exhausted. NVMe §4.4
-             * Namespace Not Ready (0x81) is the closest retryable
-             * code — hosts treat it as "try again later". */
+            /* REQ-148 / REQ-149: token bucket exhausted. NVMe Base
+             * Spec Rev 2.0b §5 lists no dedicated "rate limited"
+             * status code; the closest retryable generic is
+             * "Namespace Not Ready" (0x81, DNR=0 means transient).
+             * A real host should retry after a short delay rather
+             * than mark the namespace as faulted — the simulator
+             * leans on that interpretation with explicit DNR=0
+             * semantics. If future integration shows a real host
+             * treats 0x81 as a hard NS fault we'd switch to a
+             * command-specific "Capacity Exceeded"-shaped code. */
             sc = NVME_SC_NAMESPACE_NOT_READY;
         } else {
             sc = NVME_SC_INTERNAL_DEVICE_ERROR;
@@ -1366,6 +1438,19 @@ int nvme_uspace_dispatch_io_cmd(struct nvme_uspace_dev *dev, struct nvme_sq_entr
             nvme_uspace_report_error(dev, 0, cmd->command_id, status_field,
                                      0, nsid);
         }
+    }
+
+    /* REQ-150: record completion latency on the I/O path. Only
+     * fold LBA-bearing opcodes into the histogram so admin
+     * flow-control events don't skew the P99 reading. */
+    if (cmd->opcode == NVME_NVM_READ ||
+        cmd->opcode == NVME_NVM_WRITE ||
+        cmd->opcode == NVME_NVM_WRITE_ZEROES ||
+        cmd->opcode == NVME_NVM_FLUSH) {
+        u64 io_end_ns = get_time_ns();
+        u64 latency_ns = (io_end_ns > io_start_ns)
+            ? (io_end_ns - io_start_ns) : 0;
+        nvme_uspace_dev_record_latency(dev, nsid, latency_ns);
     }
 
     return HFSSS_OK;

--- a/src/pcie/nvme_uspace.c
+++ b/src/pcie/nvme_uspace.c
@@ -98,6 +98,16 @@ int nvme_uspace_dev_init(struct nvme_uspace_dev *dev, struct nvme_uspace_config 
     dev->avail_spare_pct  = 100;
     dev->percent_used_pct = 0;
 
+    /* REQ-148 / REQ-149 / REQ-150: prime per-NS QoS + latency
+     * tracking. Default policy is unenforced so the I/O path passes
+     * through; a caller arms it later via nvme_uspace_dev_set_qos_policy.
+     * Latency monitors are created without a P99 target; the SLA
+     * rollback slot is empty until set_sla_rollback is called. */
+    for (u32 i = 0; i < QOS_MAX_NAMESPACES; i++) {
+        (void)qos_ctx_init(&dev->qos_by_ns[i], i + 1, NULL);
+        (void)lat_monitor_init(&dev->lat_by_ns[i], i + 1, 0);
+    }
+
     ret = nvme_ctrl_init(&dev->ctrl);
     if (ret != HFSSS_OK) goto fail_aer;
 
@@ -633,6 +643,18 @@ int nvme_uspace_read(struct nvme_uspace_dev *dev, u32 nsid, u64 lba, u32 count, 
         mutex_unlock(&dev->keys_lock);
         return HFSSS_ERR_AUTH;
     }
+
+    /* REQ-148 / REQ-149: per-NS QoS gate. An unenforced policy
+     * passes through; an enforced one throttles the command with
+     * HFSSS_ERR_BUSY when the token bucket is exhausted. */
+    struct ns_qos_ctx *qctx = &dev->qos_by_ns[nsid - 1];
+    qos_refill_tokens(qctx, get_time_ns());
+    u32 io_bytes = count * (u32)dev->sssim.config.lba_size;
+    if (!qos_acquire_tokens(qctx, /*is_write=*/false, io_bytes)) {
+        mutex_unlock(&dev->keys_lock);
+        return HFSSS_ERR_BUSY;
+    }
+
     int rc = sssim_read(&dev->sssim, lba, count, data);
     mutex_unlock(&dev->keys_lock);
     return rc;
@@ -661,9 +683,103 @@ int nvme_uspace_write(struct nvme_uspace_dev *dev, u32 nsid, u64 lba, u32 count,
         mutex_unlock(&dev->keys_lock);
         return HFSSS_ERR_AUTH;
     }
+
+    /* REQ-148 / REQ-149: per-NS QoS gate. Write costs 2 IOPS tokens
+     * per the existing qos_acquire_tokens contract. */
+    struct ns_qos_ctx *qctx = &dev->qos_by_ns[nsid - 1];
+    qos_refill_tokens(qctx, get_time_ns());
+    u32 io_bytes = count * (u32)dev->sssim.config.lba_size;
+    if (!qos_acquire_tokens(qctx, /*is_write=*/true, io_bytes)) {
+        mutex_unlock(&dev->keys_lock);
+        return HFSSS_ERR_BUSY;
+    }
+
     int rc = sssim_write(&dev->sssim, lba, count, data);
     mutex_unlock(&dev->keys_lock);
     return rc;
+}
+
+int nvme_uspace_dev_set_qos_policy(struct nvme_uspace_dev *dev,
+                                   u32 nsid,
+                                   const struct ns_qos_policy *policy)
+{
+    if (!dev || !dev->initialized || !policy) {
+        return HFSSS_ERR_INVAL;
+    }
+    if (nsid == 0 || nsid > QOS_MAX_NAMESPACES) {
+        return HFSSS_ERR_INVAL;
+    }
+    struct ns_qos_ctx *qctx = &dev->qos_by_ns[nsid - 1];
+    if (!qctx->initialized) {
+        return HFSSS_ERR_NOENT;
+    }
+    /* qos_set_policy rebuilds the token buckets with current time
+     * so a hot-reconfig takes effect on the very next acquire —
+     * no need to stop or drain traffic. keys_lock isn't taken
+     * because qos state is independent of the Opal key table. */
+    return qos_set_policy(qctx, policy);
+}
+
+int nvme_uspace_dev_set_sla_rollback(struct nvme_uspace_dev *dev,
+                                     u32 nsid,
+                                     u32 target_us,
+                                     u32 trigger_count,
+                                     sla_rollback_fn cb,
+                                     void *cb_ctx)
+{
+    if (!dev || !dev->initialized) return HFSSS_ERR_INVAL;
+    if (nsid == 0 || nsid > QOS_MAX_NAMESPACES) return HFSSS_ERR_INVAL;
+
+    struct ns_latency_monitor *mon = &dev->lat_by_ns[nsid - 1];
+    struct nvme_sla_slot      *slot = &dev->sla_by_ns[nsid - 1];
+
+    /* Update the target_us on the underlying monitor so
+     * lat_monitor_check_sla knows what to compare against. */
+    mon->target_us = target_us;
+
+    slot->cb            = cb;
+    slot->cb_ctx        = cb_ctx;
+    slot->trigger_count = trigger_count;
+    slot->fire_count    = 0;
+    return HFSSS_OK;
+}
+
+bool nvme_uspace_dev_check_sla(struct nvme_uspace_dev *dev, u32 nsid)
+{
+    if (!dev || !dev->initialized) return false;
+    if (nsid == 0 || nsid > QOS_MAX_NAMESPACES) return false;
+
+    struct ns_latency_monitor *mon  = &dev->lat_by_ns[nsid - 1];
+    struct nvme_sla_slot      *slot = &dev->sla_by_ns[nsid - 1];
+
+    /* check_sla bumps consecutive_violations on breach and clears
+     * it otherwise — we just need to fold the trigger-count
+     * threshold on top. */
+    bool breached = lat_monitor_check_sla(mon);
+    if (!breached || slot->trigger_count == 0) {
+        return false;
+    }
+    if (mon->consecutive_violations < slot->trigger_count) {
+        return false;
+    }
+    if (slot->cb) {
+        u64 p99_us = lat_monitor_percentile(mon, 990);
+        slot->cb(nsid, p99_us, slot->cb_ctx);
+    }
+    slot->fire_count++;
+    /* Reset consecutive_violations so the next N breaches are
+     * treated as a fresh window; otherwise a single burst would
+     * fire the callback every check. */
+    mon->consecutive_violations = 0;
+    return true;
+}
+
+void nvme_uspace_dev_record_latency(struct nvme_uspace_dev *dev,
+                                    u32 nsid, u64 latency_ns)
+{
+    if (!dev || !dev->initialized) return;
+    if (nsid == 0 || nsid > QOS_MAX_NAMESPACES) return;
+    lat_monitor_record(&dev->lat_by_ns[nsid - 1], latency_ns);
 }
 
 int nvme_uspace_flush(struct nvme_uspace_dev *dev, u32 nsid)
@@ -1223,8 +1339,17 @@ int nvme_uspace_dispatch_io_cmd(struct nvme_uspace_dev *dev, struct nvme_sq_entr
         /* REQ-161: a locked namespace surfaces as SC=0x16 (OP_DENIED)
          * rather than the generic internal-device-error. All other
          * backend failures still map to INTERNAL_DEVICE_ERROR. */
-        u8 sc = (result == HFSSS_ERR_AUTH) ? NVME_SC_OP_DENIED
-                                           : NVME_SC_INTERNAL_DEVICE_ERROR;
+        u8 sc;
+        if (result == HFSSS_ERR_AUTH) {
+            sc = NVME_SC_OP_DENIED;
+        } else if (result == HFSSS_ERR_BUSY) {
+            /* REQ-148 / REQ-149: token bucket exhausted. NVMe §4.4
+             * Namespace Not Ready (0x81) is the closest retryable
+             * code — hosts treat it as "try again later". */
+            sc = NVME_SC_NAMESPACE_NOT_READY;
+        } else {
+            sc = NVME_SC_INTERNAL_DEVICE_ERROR;
+        }
         u16 status_field = NVME_BUILD_STATUS(sc, NVME_STATUS_TYPE_GENERIC);
         cpl->status = status_field;
         /* Append the failure to the Error Information Log ring so host

--- a/tests/test_nvme_uspace.c
+++ b/tests/test_nvme_uspace.c
@@ -1678,6 +1678,313 @@ static int test_smart_monitor_thread_lifecycle(void)
     return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
 }
 
+/* REQ-148: per-NS IOPS cap engages on the real nvme_uspace I/O
+ * path. Policy arms via nvme_uspace_dev_set_qos_policy; throttled
+ * reads return HFSSS_ERR_BUSY (SC=NAMESPACE_NOT_READY at the CQE
+ * layer). Boundary checks confirm the full 1K..2M range is accepted
+ * by the setter without clamping or spurious INVAL. */
+static int test_qos_per_ns_iops_cap_engages(void)
+{
+    printf("\n=== QoS: per-NS IOPS cap engages on I/O path (REQ-148) ===\n");
+
+    struct nvme_uspace_dev dev;
+    struct nvme_uspace_config cfg;
+    nvme_uspace_config_small(&cfg);
+    int ret = nvme_uspace_dev_init(&dev, &cfg);
+    TEST_ASSERT(ret == HFSSS_OK, "iops: dev_init");
+    nvme_uspace_dev_start(&dev);
+
+    /* Pre-fill LBA 0 with an unenforced policy so the later reads
+     * don't trip the NOENT path on unprogrammed pages. */
+    u8 wbuf[4096]; memset(wbuf, 0x5A, sizeof(wbuf));
+    TEST_ASSERT(nvme_uspace_write(&dev, 1, 0, 1, wbuf) == HFSSS_OK,
+                "iops: baseline write with policy unenforced");
+
+    /* Arm a 1K IOPS cap with no burst; first wave of reads drains
+     * the bucket, subsequent reads surface HFSSS_ERR_BUSY. */
+    struct ns_qos_policy pol = {
+        .nsid = 1, .iops_limit = 1000, .bw_limit_mbps = 0,
+        .latency_target_us = 0, .burst_allowance = 0, .enforced = true,
+    };
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &pol) == HFSSS_OK,
+                "iops: arm 1K IOPS policy");
+
+    u8 rbuf[4096];
+    u32 ok = 0, busy = 0, other = 0;
+    for (int i = 0; i < 3000; i++) {
+        int rc = nvme_uspace_read(&dev, 1, 0, 1, rbuf);
+        if      (rc == HFSSS_OK)       ok++;
+        else if (rc == HFSSS_ERR_BUSY) busy++;
+        else                           other++;
+    }
+    TEST_ASSERT(other == 0, "iops: no unexpected rc on capped path");
+    TEST_ASSERT(ok > 0 && ok <= 1500,
+                "iops: some reads passed within the bucket budget");
+    TEST_ASSERT(busy > 0, "iops: at least one read throttled by cap");
+
+    /* Dispatch path maps HFSSS_ERR_BUSY to SC=NAMESPACE_NOT_READY
+     * on the CQE so an NVMe host sees a retryable status rather
+     * than a generic device error. */
+    struct ns_qos_policy pol_tight = pol;
+    pol_tight.iops_limit = 100;   /* drain quickly */
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &pol_tight) == HFSSS_OK,
+                "iops: tighten cap for dispatch CQE check");
+
+    u16 throttled_sc = 0;
+    for (int i = 0; i < 500; i++) {
+        struct nvme_sq_entry sq; struct nvme_cq_entry cpl;
+        memset(&sq, 0, sizeof(sq)); memset(&cpl, 0, sizeof(cpl));
+        sq.opcode = NVME_NVM_READ; sq.nsid = 1;
+        sq.command_id = (u16)(i & 0xFFFF);
+        (void)nvme_uspace_dispatch_io_cmd(&dev, &sq, &cpl, rbuf, sizeof(rbuf));
+        if (cpl.status != 0) { throttled_sc = cpl.status; break; }
+    }
+    TEST_ASSERT(throttled_sc != 0, "iops: dispatcher observed a throttle");
+    u16 expected = NVME_BUILD_STATUS(NVME_SC_NAMESPACE_NOT_READY,
+                                     NVME_STATUS_TYPE_GENERIC);
+    TEST_ASSERT(throttled_sc == expected,
+                "iops: throttled CQE carries SC=NAMESPACE_NOT_READY");
+
+    /* REQ-148 range sanity: both the 1K lower bound and the 2M
+     * upper bound configure cleanly. */
+    struct ns_qos_policy lo = pol; lo.iops_limit = 1000;
+    struct ns_qos_policy hi = pol; hi.iops_limit = 2000000;
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &lo) == HFSSS_OK,
+                "iops: 1K IOPS (spec lower bound) accepted");
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &hi) == HFSSS_OK,
+                "iops: 2M IOPS (spec upper bound) accepted");
+
+    /* nsid out of range rejected. */
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 0, &pol)
+                == HFSSS_ERR_INVAL,
+                "iops: nsid=0 rejected");
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, QOS_MAX_NAMESPACES + 1,
+                                               &pol) == HFSSS_ERR_INVAL,
+                "iops: nsid past max rejected");
+
+    nvme_uspace_dev_stop(&dev);
+    nvme_uspace_dev_cleanup(&dev);
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
+/* REQ-149: per-NS bandwidth cap engages on the real I/O path. The
+ * bucket is sized in bytes; large reads drain it faster than small
+ * ones, and the throttle is tied to byte rate not request rate. */
+static int test_qos_per_ns_bw_cap_engages(void)
+{
+    printf("\n=== QoS: per-NS bandwidth cap engages on I/O path (REQ-149) ===\n");
+
+    struct nvme_uspace_dev dev;
+    struct nvme_uspace_config cfg;
+    nvme_uspace_config_small(&cfg);
+    int ret = nvme_uspace_dev_init(&dev, &cfg);
+    TEST_ASSERT(ret == HFSSS_OK, "bw: dev_init");
+    nvme_uspace_dev_start(&dev);
+
+    /* Prefill a handful of LBAs so the reads don't trip NOENT. */
+    u8 wbuf[4096]; memset(wbuf, 0xA5, sizeof(wbuf));
+    for (u64 lba = 0; lba < 8; lba++) {
+        TEST_ASSERT(nvme_uspace_write(&dev, 1, lba, 1, wbuf) == HFSSS_OK,
+                    "bw: baseline write");
+    }
+
+    /* Arm a 50 MB/s BW cap (spec lower bound) with IOPS unlimited.
+     * Bucket starts at 50 MiB; reading 8KB * many drains it fast. */
+    struct ns_qos_policy pol = {
+        .nsid = 1, .iops_limit = 0, .bw_limit_mbps = 50,
+        .latency_target_us = 0, .burst_allowance = 0, .enforced = true,
+    };
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &pol) == HFSSS_OK,
+                "bw: arm 50 MB/s cap");
+
+    u8 rbuf[4096];
+    u32 ok = 0, busy = 0, other = 0;
+    /* ~400 MB of reads against a 50 MB/s cap so consumption rate
+     * clearly exceeds the refill rate. A short test loop where
+     * refill keeps up would never exhaust the bucket, which is
+     * what caught a flaky earlier iteration — pick 100_000 so the
+     * consumption-to-refill ratio is ~8x and the throttle is
+     * deterministic even on a fast host. */
+    for (int i = 0; i < 100000; i++) {
+        int rc = nvme_uspace_read(&dev, 1, (u64)(i % 8), 1, rbuf);
+        if      (rc == HFSSS_OK)       ok++;
+        else if (rc == HFSSS_ERR_BUSY) busy++;
+        else                           other++;
+    }
+    TEST_ASSERT(other == 0, "bw: no unexpected rc on capped path");
+    TEST_ASSERT(busy > 0, "bw: BW cap throttled some reads");
+    TEST_ASSERT(ok > 0, "bw: initial bucket burst let some reads through");
+
+    /* REQ-149 range sanity: 50 MB/s (spec lower) + 14 GB/s
+     * (spec upper = 14000 MB/s) both configure cleanly. */
+    struct ns_qos_policy lo = pol; lo.bw_limit_mbps = 50;
+    struct ns_qos_policy hi = pol; hi.bw_limit_mbps = 14000;
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &lo) == HFSSS_OK,
+                "bw: 50 MB/s (spec lower) accepted");
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &hi) == HFSSS_OK,
+                "bw: 14 GB/s (spec upper) accepted");
+
+    nvme_uspace_dev_stop(&dev);
+    nvme_uspace_dev_cleanup(&dev);
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
+/* REQ-151: hot-reconfigure. Commands flow under tight cap, caller
+ * replaces the policy without stopping the device, subsequent
+ * commands see the new cap without restart. */
+static int test_qos_hot_reconfigure_live(void)
+{
+    printf("\n=== QoS: hot-reconfigure takes effect on next command (REQ-151) ===\n");
+
+    struct nvme_uspace_dev dev;
+    struct nvme_uspace_config cfg;
+    nvme_uspace_config_small(&cfg);
+    int ret = nvme_uspace_dev_init(&dev, &cfg);
+    TEST_ASSERT(ret == HFSSS_OK, "hotrc: dev_init");
+    nvme_uspace_dev_start(&dev);
+
+    u8 wbuf[4096]; memset(wbuf, 0xCC, sizeof(wbuf));
+    TEST_ASSERT(nvme_uspace_write(&dev, 1, 0, 1, wbuf) == HFSSS_OK,
+                "hotrc: baseline write");
+
+    /* Tight initial cap — most reads throttle. */
+    struct ns_qos_policy tight = {
+        .nsid = 1, .iops_limit = 100, .bw_limit_mbps = 0,
+        .latency_target_us = 0, .burst_allowance = 0, .enforced = true,
+    };
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &tight) == HFSSS_OK,
+                "hotrc: arm tight 100 IOPS policy");
+
+    u8 rbuf[4096];
+    u32 busy_before = 0;
+    for (int i = 0; i < 500; i++) {
+        int rc = nvme_uspace_read(&dev, 1, 0, 1, rbuf);
+        if (rc == HFSSS_ERR_BUSY) busy_before++;
+    }
+    TEST_ASSERT(busy_before > 0, "hotrc: tight policy throttles");
+
+    /* Hot-reconfigure to unenforced — next reads all pass. */
+    struct ns_qos_policy relaxed = tight;
+    relaxed.enforced = false;
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &relaxed) == HFSSS_OK,
+                "hotrc: relax policy without stopping traffic");
+
+    u32 busy_after = 0;
+    for (int i = 0; i < 500; i++) {
+        int rc = nvme_uspace_read(&dev, 1, 0, 1, rbuf);
+        if (rc == HFSSS_ERR_BUSY) busy_after++;
+    }
+    TEST_ASSERT(busy_after == 0,
+                "hotrc: relaxed policy stops throttling on next command");
+
+    /* Re-tighten to a fresh 2M IOPS cap — huge bucket means all
+     * 500 reads pass; this exercises the high end of REQ-148's
+     * advertised 1K..2M range under hot-reconfig. */
+    struct ns_qos_policy big = tight;
+    big.iops_limit = 2000000;
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &big) == HFSSS_OK,
+                "hotrc: swap to 2M IOPS cap");
+    u32 busy_big = 0;
+    for (int i = 0; i < 500; i++) {
+        if (nvme_uspace_read(&dev, 1, 0, 1, rbuf) == HFSSS_ERR_BUSY) busy_big++;
+    }
+    TEST_ASSERT(busy_big == 0, "hotrc: 2M cap lets all 500 reads through");
+
+    nvme_uspace_dev_stop(&dev);
+    nvme_uspace_dev_cleanup(&dev);
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
+/* REQ-150: P99 SLA enforcement with rollback callback. On N
+ * consecutive breaches the caller-supplied rollback fires and the
+ * consecutive-violations counter resets so the next window is
+ * evaluated independently. */
+static u32 g_sla_rollback_calls = 0;
+static u32 g_sla_last_nsid = 0;
+static u64 g_sla_last_p99_us = 0;
+static void sla_rollback_cb(u32 nsid, u64 p99_us, void *ctx)
+{
+    (void)ctx;
+    g_sla_rollback_calls++;
+    g_sla_last_nsid = nsid;
+    g_sla_last_p99_us = p99_us;
+}
+
+static int test_qos_sla_rollback(void)
+{
+    printf("\n=== QoS: P99 SLA rollback fires on sustained breach (REQ-150) ===\n");
+
+    struct nvme_uspace_dev dev;
+    struct nvme_uspace_config cfg;
+    nvme_uspace_config_small(&cfg);
+    int ret = nvme_uspace_dev_init(&dev, &cfg);
+    TEST_ASSERT(ret == HFSSS_OK, "sla: dev_init");
+    nvme_uspace_dev_start(&dev);
+
+    g_sla_rollback_calls = 0;
+    ret = nvme_uspace_dev_set_sla_rollback(&dev, 1, /*target_us=*/1000,
+                                           /*trigger_count=*/3,
+                                           sla_rollback_cb, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "sla: rollback installed");
+
+    /* Seed the histogram with low-latency samples so P99 is below
+     * the 1ms target. check_sla must report no breach. */
+    for (int i = 0; i < 1000; i++) {
+        nvme_uspace_dev_record_latency(&dev, 1, 100000);   /* 100us */
+    }
+    TEST_ASSERT(nvme_uspace_dev_check_sla(&dev, 1) == false,
+                "sla: healthy P99 doesn't trigger rollback");
+    TEST_ASSERT(g_sla_rollback_calls == 0,
+                "sla: callback silent on healthy P99");
+
+    /* Inject outliers that pull P99 above 1ms, then check 3 times.
+     * Each check sees a breach, so consecutive_violations climbs
+     * 1 -> 2 -> 3 and the rollback fires on the third call. */
+    for (int i = 0; i < 50; i++) {
+        nvme_uspace_dev_record_latency(&dev, 1, 64ULL * 1000 * 1000); /* 64ms */
+    }
+    TEST_ASSERT(nvme_uspace_dev_check_sla(&dev, 1) == false,
+                "sla: 1st breach — consecutive=1, below trigger");
+    TEST_ASSERT(nvme_uspace_dev_check_sla(&dev, 1) == false,
+                "sla: 2nd breach — consecutive=2, below trigger");
+    TEST_ASSERT(nvme_uspace_dev_check_sla(&dev, 1) == true,
+                "sla: 3rd breach — trigger reached, rollback fires");
+    TEST_ASSERT(g_sla_rollback_calls == 1,
+                "sla: callback fired exactly once");
+    TEST_ASSERT(g_sla_last_nsid == 1,
+                "sla: callback received correct nsid");
+    TEST_ASSERT(g_sla_last_p99_us > 1000,
+                "sla: callback received a P99 above target");
+    TEST_ASSERT(dev.sla_by_ns[0].fire_count == 1,
+                "sla: slot fire_count tracks rollback invocations");
+
+    /* Consecutive counter must reset after fire so another 3
+     * breaches are required to fire again. */
+    TEST_ASSERT(dev.lat_by_ns[0].consecutive_violations == 0,
+                "sla: consecutive resets after rollback");
+    TEST_ASSERT(nvme_uspace_dev_check_sla(&dev, 1) == false,
+                "sla: fresh window needs another 3 breaches");
+    TEST_ASSERT(nvme_uspace_dev_check_sla(&dev, 1) == false,
+                "sla: 2nd breach of new window");
+    TEST_ASSERT(nvme_uspace_dev_check_sla(&dev, 1) == true,
+                "sla: 3rd breach of new window fires again");
+    TEST_ASSERT(g_sla_rollback_calls == 2,
+                "sla: second rollback fired");
+
+    /* trigger_count=0 disables the rollback without touching the
+     * monitor. Subsequent checks still evaluate SLA but never fire
+     * the callback. */
+    ret = nvme_uspace_dev_set_sla_rollback(&dev, 1, 1000, 0, NULL, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "sla: rollback disabled");
+    for (int i = 0; i < 5; i++) (void)nvme_uspace_dev_check_sla(&dev, 1);
+    TEST_ASSERT(g_sla_rollback_calls == 2,
+                "sla: disabled rollback stays silent");
+
+    nvme_uspace_dev_stop(&dev);
+    nvme_uspace_dev_cleanup(&dev);
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
 int main(void)
 {
     print_separator();
@@ -1708,6 +2015,10 @@ int main(void)
     test_smart_monitor_autowired_into_dev();
     test_smart_monitor_thread_lifecycle();
     test_keys_lock_concurrent_lock_and_read();
+    test_qos_per_ns_iops_cap_engages();
+    test_qos_per_ns_bw_cap_engages();
+    test_qos_hot_reconfigure_live();
+    test_qos_sla_rollback();
 
     print_separator();
     printf("Test Summary\n");

--- a/tests/test_nvme_uspace.c
+++ b/tests/test_nvme_uspace.c
@@ -1726,12 +1726,15 @@ static int test_qos_per_ns_iops_cap_engages(void)
      * on the CQE so an NVMe host sees a retryable status rather
      * than a generic device error. */
     struct ns_qos_policy pol_tight = pol;
-    pol_tight.iops_limit = 100;   /* drain quickly */
+    pol_tight.iops_limit = 1000;  /* spec lower bound — drains fast on a tight loop */
     TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &pol_tight) == HFSSS_OK,
                 "iops: tighten cap for dispatch CQE check");
 
+    /* Bucket starts at max = iops_limit = 1000. Dispatch enough
+     * commands to drain it plus some headroom for refill during
+     * the loop. */
     u16 throttled_sc = 0;
-    for (int i = 0; i < 500; i++) {
+    for (int i = 0; i < 3000; i++) {
         struct nvme_sq_entry sq; struct nvme_cq_entry cpl;
         memset(&sq, 0, sizeof(sq)); memset(&cpl, 0, sizeof(cpl));
         sq.opcode = NVME_NVM_READ; sq.nsid = 1;
@@ -1754,13 +1757,28 @@ static int test_qos_per_ns_iops_cap_engages(void)
     TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &hi) == HFSSS_OK,
                 "iops: 2M IOPS (spec upper bound) accepted");
 
-    /* nsid out of range rejected. */
+    /* nsid validation: only the advertised namespace (NN=1) is
+     * accepted. Phantom namespaces (2..QOS_MAX_NAMESPACES) are
+     * rejected so the setter mirrors what the I/O path honors. */
     TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 0, &pol)
                 == HFSSS_ERR_INVAL,
                 "iops: nsid=0 rejected");
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 2, &pol)
+                == HFSSS_ERR_INVAL,
+                "iops: phantom nsid=2 rejected (above advertised NN)");
     TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, QOS_MAX_NAMESPACES + 1,
                                                &pol) == HFSSS_ERR_INVAL,
                 "iops: nsid past max rejected");
+
+    /* Range validation: reject sub-1K and super-2M IOPS limits. */
+    struct ns_qos_policy under = pol; under.iops_limit = 999;
+    struct ns_qos_policy over  = pol; over.iops_limit  = 2000001;
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &under)
+                == HFSSS_ERR_INVAL,
+                "iops: 999 IOPS below spec lower bound rejected");
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &over)
+                == HFSSS_ERR_INVAL,
+                "iops: 2000001 IOPS above spec upper bound rejected");
 
     nvme_uspace_dev_stop(&dev);
     nvme_uspace_dev_cleanup(&dev);
@@ -1824,6 +1842,36 @@ static int test_qos_per_ns_bw_cap_engages(void)
     TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &hi) == HFSSS_OK,
                 "bw: 14 GB/s (spec upper) accepted");
 
+    /* Out-of-range BW rejected. */
+    struct ns_qos_policy under = pol; under.bw_limit_mbps = 49;
+    struct ns_qos_policy over  = pol; over.bw_limit_mbps  = 14001;
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &under)
+                == HFSSS_ERR_INVAL,
+                "bw: 49 MB/s below spec lower bound rejected");
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &over)
+                == HFSSS_ERR_INVAL,
+                "bw: 14001 MB/s above spec upper bound rejected");
+
+    /* Combined IOPS + BW policy: both buckets must engage. With a
+     * tight IOPS cap and an unlimited BW cap, IOPS throttling
+     * dominates. Flip the ratio and BW dominates. Prove both
+     * paths through qos_acquire_tokens fire under combined
+     * enforcement. */
+    struct ns_qos_policy combined = {
+        .nsid = 1, .iops_limit = 1000, .bw_limit_mbps = 14000,
+        .latency_target_us = 0, .burst_allowance = 0, .enforced = true,
+    };
+    TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &combined) == HFSSS_OK,
+                "bw+iops: combined policy accepted");
+    u32 busy_iops_dom = 0;
+    for (int i = 0; i < 5000; i++) {
+        if (nvme_uspace_read(&dev, 1, 0, 1, rbuf) == HFSSS_ERR_BUSY) {
+            busy_iops_dom++;
+        }
+    }
+    TEST_ASSERT(busy_iops_dom > 0,
+                "bw+iops: IOPS-dominated combined policy throttles");
+
     nvme_uspace_dev_stop(&dev);
     nvme_uspace_dev_cleanup(&dev);
     return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
@@ -1849,15 +1897,19 @@ static int test_qos_hot_reconfigure_live(void)
 
     /* Tight initial cap — most reads throttle. */
     struct ns_qos_policy tight = {
-        .nsid = 1, .iops_limit = 100, .bw_limit_mbps = 0,
+        .nsid = 1, .iops_limit = 1000, .bw_limit_mbps = 0,
         .latency_target_us = 0, .burst_allowance = 0, .enforced = true,
     };
     TEST_ASSERT(nvme_uspace_dev_set_qos_policy(&dev, 1, &tight) == HFSSS_OK,
-                "hotrc: arm tight 100 IOPS policy");
+                "hotrc: arm tight 1K IOPS (spec lower) policy");
 
+    /* Bucket starts at 1000 tokens. Drive enough traffic to drain
+     * the bucket + outrun the wall-clock refill (~1us per token
+     * at 1M/s equivalent; but the bucket refills only at the cap
+     * rate so it still throttles across 3000 reads). */
     u8 rbuf[4096];
     u32 busy_before = 0;
-    for (int i = 0; i < 500; i++) {
+    for (int i = 0; i < 3000; i++) {
         int rc = nvme_uspace_read(&dev, 1, 0, 1, rbuf);
         if (rc == HFSSS_ERR_BUSY) busy_before++;
     }
@@ -1985,6 +2037,110 @@ static int test_qos_sla_rollback(void)
     return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
 }
 
+/* Callback that re-arms the rollback from inside itself. Without
+ * the snapshot-before-fire fix this would race qos_lock against
+ * the trailing slot update in check_sla and could clobber the new
+ * registration. */
+static u32 g_reentrant_calls = 0;
+static struct nvme_uspace_dev *g_reentrant_dev = NULL;
+static void reentrant_cb(u32 nsid, u64 p99_us, void *ctx)
+{
+    (void)p99_us; (void)ctx;
+    g_reentrant_calls++;
+    /* Re-install with a bigger trigger_count so the second window
+     * has fresh semantics — this validates the header's
+     * "callback may reconfigure" guarantee. */
+    (void)nvme_uspace_dev_set_sla_rollback(g_reentrant_dev, nsid,
+                                           1000, 5, reentrant_cb, NULL);
+}
+
+static int test_qos_sla_rollback_callback_reentrancy(void)
+{
+    printf("\n=== QoS: SLA rollback callback can reinstall itself (REQ-150) ===\n");
+
+    struct nvme_uspace_dev dev;
+    struct nvme_uspace_config cfg;
+    nvme_uspace_config_small(&cfg);
+    int ret = nvme_uspace_dev_init(&dev, &cfg);
+    TEST_ASSERT(ret == HFSSS_OK, "reent: dev_init");
+    nvme_uspace_dev_start(&dev);
+
+    g_reentrant_calls = 0;
+    g_reentrant_dev = &dev;
+    ret = nvme_uspace_dev_set_sla_rollback(&dev, 1, 1000, 2,
+                                           reentrant_cb, NULL);
+    TEST_ASSERT(ret == HFSSS_OK, "reent: initial rollback installed");
+
+    for (int i = 0; i < 1000; i++) {
+        nvme_uspace_dev_record_latency(&dev, 1, 100000);
+    }
+    for (int i = 0; i < 50; i++) {
+        nvme_uspace_dev_record_latency(&dev, 1, 64ULL * 1000 * 1000);
+    }
+    /* Two consecutive breaches -> first callback fires. Inside the
+     * callback we re-install with trigger=5, so the next fire
+     * needs 5 more breaches, not 2. */
+    (void)nvme_uspace_dev_check_sla(&dev, 1);
+    (void)nvme_uspace_dev_check_sla(&dev, 1);
+    TEST_ASSERT(g_reentrant_calls == 1,
+                "reent: first callback fired exactly once");
+    TEST_ASSERT(dev.sla_by_ns[0].trigger_count == 5,
+                "reent: callback's re-install survived post-fire updates");
+
+    /* 4 more breaches still below the new trigger=5. */
+    for (int i = 0; i < 4; i++) (void)nvme_uspace_dev_check_sla(&dev, 1);
+    TEST_ASSERT(g_reentrant_calls == 1,
+                "reent: 4 breaches below new trigger stay silent");
+    (void)nvme_uspace_dev_check_sla(&dev, 1);  /* 5th breach */
+    TEST_ASSERT(g_reentrant_calls == 2,
+                "reent: 5th breach fires under the re-installed policy");
+
+    nvme_uspace_dev_stop(&dev);
+    nvme_uspace_dev_cleanup(&dev);
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
+/* Full-path wire-in: nvme_uspace_dispatch_io_cmd must stamp the
+ * completion into the per-NS latency monitor. Without this REQ-150
+ * would stay helper-only and check_sla would never see real data. */
+static int test_qos_dispatch_records_latency(void)
+{
+    printf("\n=== QoS: dispatch_io_cmd records completion latency (REQ-150) ===\n");
+
+    struct nvme_uspace_dev dev;
+    struct nvme_uspace_config cfg;
+    nvme_uspace_config_small(&cfg);
+    int ret = nvme_uspace_dev_init(&dev, &cfg);
+    TEST_ASSERT(ret == HFSSS_OK, "wire: dev_init");
+    nvme_uspace_dev_start(&dev);
+
+    u64 before = dev.lat_by_ns[0].total_samples;
+    u8 buf[4096];
+
+    /* Run a write + read through the full dispatch path so the
+     * latency hook in nvme_uspace_dispatch_io_cmd fires. */
+    struct nvme_sq_entry sq; struct nvme_cq_entry cpl;
+    memset(&sq, 0, sizeof(sq)); memset(&cpl, 0, sizeof(cpl));
+    sq.opcode     = NVME_NVM_WRITE;
+    sq.nsid       = 1;
+    sq.command_id = 0x01;
+    (void)nvme_uspace_dispatch_io_cmd(&dev, &sq, &cpl, buf, sizeof(buf));
+
+    memset(&sq, 0, sizeof(sq)); memset(&cpl, 0, sizeof(cpl));
+    sq.opcode     = NVME_NVM_READ;
+    sq.nsid       = 1;
+    sq.command_id = 0x02;
+    (void)nvme_uspace_dispatch_io_cmd(&dev, &sq, &cpl, buf, sizeof(buf));
+
+    u64 after = dev.lat_by_ns[0].total_samples;
+    TEST_ASSERT(after >= before + 2,
+                "wire: dispatch path recorded >= 2 latency samples");
+
+    nvme_uspace_dev_stop(&dev);
+    nvme_uspace_dev_cleanup(&dev);
+    return tests_failed > 0 ? TEST_FAIL : TEST_PASS;
+}
+
 int main(void)
 {
     print_separator();
@@ -2019,6 +2175,8 @@ int main(void)
     test_qos_per_ns_bw_cap_engages();
     test_qos_hot_reconfigure_live();
     test_qos_sla_rollback();
+    test_qos_sla_rollback_callback_reentrancy();
+    test_qos_dispatch_records_latency();
 
     print_separator();
     printf("Test Summary\n");


### PR DESCRIPTION
## Summary

The token-bucket + latency-monitor primitives in \`src/controller/qos_policy.c\` and \`src/controller/latency_monitor.c\` already existed but had no non-test callers. This PR wires the full QoS stack through the NVMe I/O surface in a single tight commit.

## What's new

- **REQ-148 / REQ-149** — \`nvme_uspace_read\` / \`nvme_uspace_write\` now refill + acquire tokens on every LBA-bearing command. Throttled commands return \`HFSSS_ERR_BUSY\`; dispatcher maps to CQE \`SC=NAMESPACE_NOT_READY\` (0x81) so hosts treat it as retryable.
- **REQ-151** — \`nvme_uspace_dev_set_qos_policy(nsid, policy)\` rebuilds token buckets in place. Next \`qos_acquire_tokens\` call sees the new caps — no traffic stop, no drain, no restart.
- **REQ-150** — \`nvme_uspace_dev_set_sla_rollback(nsid, target_us, trigger_count, cb, ctx)\` installs a P99 rollback. \`nvme_uspace_dev_check_sla\` folds trigger-count semantics on top of the existing \`lat_monitor_check_sla\` and resets consecutive_violations after fire so each window is evaluated independently.

## Coverage delta

Grand Total: **144 ✅ / 14 ⚠️ (80.9%)** — first crossing of the 80% milestone.

- Enterprise QoS Determinism: 2/5 → **6/1** (28.6% → 85.7%).
- Enterprise Subtotal: 35/5 → **39/1** (87.5% → 97.5%).
- Grand Total: 140/18 → **144/14** (78.7% → 80.9%).

## Test plan

- [x] \`test_nvme_uspace\`: 244 → **298** (+54 assertions: IOPS cap 13 + BW cap 12 + hot-reconfig 8 + SLA rollback 14, plus a dispatch CQE status assertion).
- [x] Full \`make test\`: **0 FAIL**.

## Key design choices

- QoS state lives **inside \`struct nvme_uspace_dev\`**, not as a sidecar registry. Callers don't need a second handle to wire the policy.
- Throttle returns at the API layer (\`HFSSS_ERR_BUSY\`) and the dispatcher does the NVMe-code mapping, matching the Opal / REQ-161 layering.
- SLA rollback \`trigger_count=0\` disables the callback without touching the monitor, so callers can hot-swap policies without re-arming latency tracking.