### PR TITLE
fix(ci): link -lm into new systest binaries for Linux builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ CFLAGS += -Iinclude -Iinclude/common -Iinclude/media -Iinclude/hal -Iinclude/ftl
 CFLAGS += -MMD -MP
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-    LDFLAGS = -lpthread -lrt
+    LDFLAGS = -lpthread -lrt -lm
 else
-    LDFLAGS = -lpthread
+    LDFLAGS = -lpthread -lm
 endif
 
 # Coverage build variant (GCC --coverage instrumentation)
@@ -170,6 +170,7 @@ SYSTEST_PHASE7_INT = $(BIN_DIR)/systest_phase7_integration
 TEST_RESET_ABORT_RACE = $(BIN_DIR)/test_reset_abort_race
 TEST_FTL_PROFILE = $(BIN_DIR)/test_ftl_profile
 TEST_SSSIM_PROFILE = $(BIN_DIR)/test_sssim_profile
+FTL_MFC_REPRO = $(BIN_DIR)/ftl_mfc_repro
 
 # Perf validation library and test
 TEST_PERF = $(BIN_DIR)/test_perf_validation
@@ -616,7 +617,6 @@ $(HFSSS_NBD): $(VHOST_SRC)/hfsss_nbd_server.c $(VHOST_SRC)/nbd_async.c $(LIBHFSS
 	@$(CC) $(CFLAGS) $(VHOST_SRC)/hfsss_nbd_server.c $(VHOST_SRC)/nbd_async.c -o $@ -L$(LIB_DIR) -lhfsss-pcie -lhfsss-sssim -lhfsss-controller -lhfsss-ftl -lhfsss-hal -lhfsss-media -lhfsss-common -lm $(LDFLAGS)
 
 # ftl_mfc_repro — multi-threaded FTL load generator with CRC32C integrity check
-FTL_MFC_REPRO = $(BIN_DIR)/ftl_mfc_repro
 $(FTL_MFC_REPRO): tools/ftl_mfc_repro.c $(LIBHFSSS_FTL) $(LIBHFSSS_HAL) $(LIBHFSSS_MEDIA) $(LIBHFSSS_COMMON)
 	@mkdir -p $(BIN_DIR)
 	@echo "  CC      $@"

--- a/Makefile
+++ b/Makefile
@@ -373,11 +373,11 @@ $(TEST_CHANNEL_WORKER): $(TEST_DIR)/test_channel_worker.c $(LIBHFSSS_CTRL) $(LIB
 
 $(SYSTEST_NVME_CLI): $(TEST_DIR)/systest_nvme_cli_compat.c $(LIBHFSSS_PCIE) $(LIBHFSSS_SSSIM) $(LIBHFSSS_CTRL) $(LIBHFSSS_FTL) $(LIBHFSSS_HAL) $(LIBHFSSS_MEDIA) $(LIBHFSSS_COMMON)
 	@echo "  CC      $@"
-	@$(CC) $(CFLAGS) $< -o $@ -L$(LIB_DIR) -lhfsss-pcie -lhfsss-sssim -lhfsss-controller -lhfsss-ftl -lhfsss-hal -lhfsss-media -lhfsss-common $(LDFLAGS)
+	@$(CC) $(CFLAGS) $< -o $@ -L$(LIB_DIR) -lhfsss-pcie -lhfsss-sssim -lhfsss-controller -lhfsss-ftl -lhfsss-hal -lhfsss-media -lhfsss-common -lm $(LDFLAGS)
 
 $(SYSTEST_FIO_COMPAT): $(TEST_DIR)/systest_fio_compat.c $(LIBHFSSS_PCIE) $(LIBHFSSS_SSSIM) $(LIBHFSSS_CTRL) $(LIBHFSSS_FTL) $(LIBHFSSS_HAL) $(LIBHFSSS_MEDIA) $(LIBHFSSS_COMMON)
 	@echo "  CC      $@"
-	@$(CC) $(CFLAGS) $< -o $@ -L$(LIB_DIR) -lhfsss-pcie -lhfsss-sssim -lhfsss-controller -lhfsss-ftl -lhfsss-hal -lhfsss-media -lhfsss-common $(LDFLAGS)
+	@$(CC) $(CFLAGS) $< -o $@ -L$(LIB_DIR) -lhfsss-pcie -lhfsss-sssim -lhfsss-controller -lhfsss-ftl -lhfsss-hal -lhfsss-media -lhfsss-common -lm $(LDFLAGS)
 
 $(SYSTEST_PHASE7_INT): $(TEST_DIR)/systest_phase7_integration.c $(LIBHFSSS_MEDIA) $(LIBHFSSS_COMMON)
 	@echo "  CC      $@"


### PR DESCRIPTION
## Summary

Linux CI broke after PR #101 merged. Root cause: the two new systest rules (`systest_nvme_cli_compat`, `systest_fio_compat`) link `libhfsss-common.a` (which uses `exp()` / `log()` from `uplp.c`) without `-lm`. macOS links libm by default so the local build stayed green; ubuntu-latest failed with `undefined reference to 'exp' / 'log'`.

All other rules linking `libhfsss-common.a` already include `-lm`. Aligned the two new rules with the rest of the Makefile.

## Why this slipped past local testing

macOS `ld` resolves libm symbols implicitly against the system library; Linux `ld` does not. The local `make test` on macOS passed 3697 / 0 even though the Linux toolchain would have failed at link time. This is a known macOS / Linux divergence, not an issue with the systest logic itself.

## Test plan

- [x] Local rebuild of both affected binaries on macOS passes (`systest_nvme_cli_compat`: 21 / 21, `systest_fio_compat`: 8 / 8)
- [x] Diff is a two-line `-lm` insertion, consistent with every other rule that links `libhfsss-common.a`
- [ ] Await ubuntu-latest + macos-latest CI on this PR