### PR TITLE
feat(stability): stress-burn-in + system_monitor sampling (REQ-137)

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -43,6 +43,33 @@ jobs:
       - name: Build project
         run: make all
 
+      # Inputs are fed into a Makefile recipe that exports them to a
+      # subshell. Rejecting anything that isn't a bare non-negative
+      # integer keeps the recipe from being turned into arbitrary
+      # shell via a dispatch-time payload. The Makefile also single-
+      # quotes these expansions for defense in depth.
+      - name: Validate dispatch inputs
+        env:
+          DURATION_SEC:       ${{ github.event.inputs.duration_sec }}
+          PEAK_RSS_LIMIT_MB:  ${{ github.event.inputs.peak_rss_limit_mb }}
+        run: |
+          set -euo pipefail
+          check_uint() {
+            local name="$1" value="$2"
+            if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+              echo "::error::$name must be a non-negative integer, got: $value" >&2
+              exit 1
+            fi
+          }
+          check_uint duration_sec      "$DURATION_SEC"
+          check_uint peak_rss_limit_mb "$PEAK_RSS_LIMIT_MB"
+          # Cap duration at 4 h so a typo can't silently chew through
+          # the 5 h job budget.
+          if (( DURATION_SEC > 14400 )); then
+            echo "::error::duration_sec must be <= 14400 (4h), got: $DURATION_SEC" >&2
+            exit 1
+          fi
+
       - name: Run burn-in
         env:
           STRESS_BURN_DURATION:     ${{ github.event.inputs.duration_sec }}

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -1,0 +1,58 @@
+#
+# REQ-137: manual burn-in soak job.
+#
+# Only fires on workflow_dispatch — no cron, no PR trigger. The goal is
+# to make the burn-in harness one click away on GitHub Actions without
+# committing to a continuous runtime budget. Operators pick a duration
+# and peak-RSS limit at dispatch time; the job publishes the stable
+# key=value summary as an artifact.
+#
+
+name: Soak (REQ-137 burn-in)
+
+on:
+  workflow_dispatch:
+    inputs:
+      duration_sec:
+        description: "Burn-in duration in seconds (default 600, max 14400)"
+        required: false
+        default: "600"
+      peak_rss_limit_mb:
+        description: "Fail the run if peak RSS exceeds this many MB (0 disables)"
+        required: false
+        default: "0"
+
+jobs:
+  burn-in:
+    name: stress_stability burn-in
+    runs-on: ubuntu-latest
+    # Budget ceiling stays under the 6h GitHub Actions job cap with room
+    # for build + artifact upload. Operators can request up to 4h of
+    # actual test time via the input.
+    timeout-minutes: 300
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - name: Build project
+        run: make all
+
+      - name: Run burn-in
+        env:
+          STRESS_BURN_DURATION:     ${{ github.event.inputs.duration_sec }}
+          STRESS_PEAK_RSS_LIMIT_MB: ${{ github.event.inputs.peak_rss_limit_mb }}
+        run: make stress-burn-in
+
+      - name: Upload burn-in summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stress-burn-in-results
+          path: build/stress-burn-in-results.txt
+          if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ TEST_COMMON = $(BIN_DIR)/test_common
 TEST_MEDIA = $(BIN_DIR)/test_media
 TEST_TIMING_JITTER = $(BIN_DIR)/test_timing_jitter
 TEST_RETENTION = $(BIN_DIR)/test_retention
+TEST_STRESS_BURN_IN = $(BIN_DIR)/test_stress_burn_in
 TEST_HAL = $(BIN_DIR)/test_hal
 TEST_FTL = $(BIN_DIR)/test_ftl
 TEST_CTRL = $(BIN_DIR)/test_controller
@@ -235,16 +236,18 @@ COVERAGE_UT_BINS = $(COVERAGE_BIN_DIR)/test_common $(COVERAGE_BIN_DIR)/test_medi
 	$(COVERAGE_BIN_DIR)/test_ftl_profile \
 	$(COVERAGE_BIN_DIR)/test_sssim_profile \
 	$(COVERAGE_BIN_DIR)/test_trace \
-	$(COVERAGE_BIN_DIR)/test_retention
+	$(COVERAGE_BIN_DIR)/test_retention \
+	$(COVERAGE_BIN_DIR)/test_timing_jitter \
+	$(COVERAGE_BIN_DIR)/test_stress_burn_in
 COVERAGE_E2E_BINS = $(COVERAGE_BIN_DIR)/hfsss-nbd-server
 COVERAGE_BINS = $(COVERAGE_UT_BINS) $(COVERAGE_E2E_BINS)
 
 # Targets
-.PHONY: all clean directories test systest stress-long help \
+.PHONY: all clean directories test systest stress-long stress-burn-in help \
 	coverage-build coverage-clean coverage-ut coverage-e2e coverage-merge coverage-frontend coverage-frontend-update coverage coverage-selftest \
 	qemu-blackbox qemu-blackbox-list qemu-blackbox-ci qemu-blackbox-soak pre-checkin
 
-all: directories $(LIBHFSSS_COMMON) $(LIBHFSSS_MEDIA) $(LIBHFSSS_HAL) $(LIBHFSSS_FTL) $(LIBHFSSS_CTRL) $(LIBHFSSS_PCIE) $(LIBHFSSS_SSSIM) $(LIBHFSSS_PERF) $(TEST_COMMON) $(TEST_MEDIA) $(TEST_TIMING_JITTER) $(TEST_RETENTION) $(TEST_HAL) $(TEST_FTL) $(TEST_CTRL) $(TEST_SHMEM_IF) $(TEST_PCIE) $(TEST_SSSIM) $(TEST_NVME_USPACE) $(TEST_BOOT) $(TEST_NOR) $(TEST_FTL_REL) $(TEST_RT) $(TEST_OOB) $(TEST_CONFIG) $(TEST_FAULT) $(TEST_RELIABILITY) $(TEST_PERF) $(TEST_DSM) $(TEST_PRP) $(STRESS_RW) $(STRESS_MIXED) $(STRESS_MIXED_TRIM) $(HFSSS_CTRL) $(TEST_FTL_INT) $(STRESS_ADMIN_MIX) $(TEST_SB) $(TEST_POWER_CYCLE) $(TEST_FOUNDATION) $(TEST_T10PI) $(SYSTEST_DI) $(SYSTEST_NC) $(SYSTEST_EB) $(SYSTEST_PS) $(SYSTEST_WG) $(SYSTEST_PR) $(TEST_UPLP) $(TEST_QOS) $(TEST_SECURITY) $(TEST_MULTI_NS) $(TEST_THERMAL_TEL) $(STRESS_ENTERPRISE) $(TEST_PROC) $(STRESS_STABILITY) $(HFSSS_IMG_EXPORT) $(HFSSS_NBD) $(TEST_LARGE_CAP) $(TEST_IO_QUEUE) $(TEST_TAA) $(TEST_TRACE) $(TEST_MT_FTL) $(TEST_GC_MT) $(TEST_INFLIGHT) $(TEST_MSGQ) $(TEST_NVME_ADMIN) $(TEST_NVME_IO) $(TEST_CMD_INTEG_BASIC) $(TEST_CMD_INTEG_MID) $(TEST_CMD_INTEG_HEAVY) $(TEST_PROFILE_MATRIX) $(TEST_MP_CONCURRENCY) $(TEST_CHANNEL_WORKER) $(SYSTEST_NVME_CLI) $(SYSTEST_FIO_COMPAT) $(SYSTEST_PHASE7_INT) $(TEST_RESET_ABORT_RACE) $(TEST_FTL_PROFILE) $(TEST_SSSIM_PROFILE) $(FTL_MFC_REPRO)
+all: directories $(LIBHFSSS_COMMON) $(LIBHFSSS_MEDIA) $(LIBHFSSS_HAL) $(LIBHFSSS_FTL) $(LIBHFSSS_CTRL) $(LIBHFSSS_PCIE) $(LIBHFSSS_SSSIM) $(LIBHFSSS_PERF) $(TEST_COMMON) $(TEST_MEDIA) $(TEST_TIMING_JITTER) $(TEST_RETENTION) $(TEST_STRESS_BURN_IN) $(TEST_HAL) $(TEST_FTL) $(TEST_CTRL) $(TEST_SHMEM_IF) $(TEST_PCIE) $(TEST_SSSIM) $(TEST_NVME_USPACE) $(TEST_BOOT) $(TEST_NOR) $(TEST_FTL_REL) $(TEST_RT) $(TEST_OOB) $(TEST_CONFIG) $(TEST_FAULT) $(TEST_RELIABILITY) $(TEST_PERF) $(TEST_DSM) $(TEST_PRP) $(STRESS_RW) $(STRESS_MIXED) $(STRESS_MIXED_TRIM) $(HFSSS_CTRL) $(TEST_FTL_INT) $(STRESS_ADMIN_MIX) $(TEST_SB) $(TEST_POWER_CYCLE) $(TEST_FOUNDATION) $(TEST_T10PI) $(SYSTEST_DI) $(SYSTEST_NC) $(SYSTEST_EB) $(SYSTEST_PS) $(SYSTEST_WG) $(SYSTEST_PR) $(TEST_UPLP) $(TEST_QOS) $(TEST_SECURITY) $(TEST_MULTI_NS) $(TEST_THERMAL_TEL) $(STRESS_ENTERPRISE) $(TEST_PROC) $(STRESS_STABILITY) $(HFSSS_IMG_EXPORT) $(HFSSS_NBD) $(TEST_LARGE_CAP) $(TEST_IO_QUEUE) $(TEST_TAA) $(TEST_TRACE) $(TEST_MT_FTL) $(TEST_GC_MT) $(TEST_INFLIGHT) $(TEST_MSGQ) $(TEST_NVME_ADMIN) $(TEST_NVME_IO) $(TEST_CMD_INTEG_BASIC) $(TEST_CMD_INTEG_MID) $(TEST_CMD_INTEG_HEAVY) $(TEST_PROFILE_MATRIX) $(TEST_MP_CONCURRENCY) $(TEST_CHANNEL_WORKER) $(SYSTEST_NVME_CLI) $(SYSTEST_FIO_COMPAT) $(SYSTEST_PHASE7_INT) $(TEST_RESET_ABORT_RACE) $(TEST_FTL_PROFILE) $(TEST_SSSIM_PROFILE) $(FTL_MFC_REPRO)
 	@echo "========================================"
 	@echo "HFSSS build complete!"
 	@echo "========================================"
@@ -350,6 +353,10 @@ $(TEST_TIMING_JITTER): $(TEST_DIR)/test_timing_jitter.c $(LIBHFSSS_MEDIA) $(LIBH
 $(TEST_RETENTION): $(TEST_DIR)/test_retention.c $(LIBHFSSS_MEDIA) $(LIBHFSSS_COMMON)
 	@echo "  CC      $@"
 	@$(CC) $(CFLAGS) $< -o $@ -L$(LIB_DIR) -lhfsss-media -lhfsss-common $(LDFLAGS)
+
+$(TEST_STRESS_BURN_IN): $(TEST_DIR)/test_stress_burn_in.c $(LIBHFSSS_COMMON)
+	@echo "  CC      $@"
+	@$(CC) $(CFLAGS) $< -o $@ -L$(LIB_DIR) -lhfsss-common $(LDFLAGS)
 
 $(TEST_CMD_INTEG_BASIC): $(TEST_DIR)/test_cmd_integration_basic.c $(LIBHFSSS_MEDIA) $(LIBHFSSS_COMMON)
 	@echo "  CC      $@"
@@ -642,6 +649,20 @@ stress-long: all
 	@echo "Running stability stress test (duration=$(or $(STRESS_DURATION),60)s)..."
 	@STRESS_DURATION=$(or $(STRESS_DURATION),60) $(STRESS_STABILITY)
 
+# REQ-137: extended burn-in run with system_monitor sampling + CI-parseable
+# results artifact. Defaults to 1 hour; override with
+#   make stress-burn-in STRESS_BURN_DURATION=7200
+# Optional peak-RSS ceiling in MB trips a FAIL exit when exceeded.
+STRESS_BURN_DURATION ?= 3600
+STRESS_BURN_RESULTS  ?= $(BUILD_DIR)/stress-burn-in-results.txt
+stress-burn-in: all
+	@echo "Running stability burn-in (duration=$(STRESS_BURN_DURATION)s)..."
+	@echo "Results summary will be written to $(STRESS_BURN_RESULTS)"
+	@STRESS_DURATION=$(STRESS_BURN_DURATION) \
+	 STRESS_RESULTS_FILE=$(STRESS_BURN_RESULTS) \
+	 STRESS_PEAK_RSS_LIMIT_MB=$(STRESS_PEAK_RSS_LIMIT_MB) \
+	 $(STRESS_STABILITY)
+
 # System-level tests (Tier 1)
 .PHONY: systest
 systest: directories $(SYSTEST_DI) $(SYSTEST_NC) $(SYSTEST_EB) $(SYSTEST_PS) $(SYSTEST_WG) $(SYSTEST_PR) $(SYSTEST_NVME_CLI) $(SYSTEST_FIO_COMPAT)
@@ -680,6 +701,8 @@ test: all
 	@$(TEST_TIMING_JITTER)
 	@echo ""
 	@$(TEST_RETENTION)
+	@echo ""
+	@$(TEST_STRESS_BURN_IN)
 	@echo ""
 	@$(TEST_CMD_INTEG_BASIC)
 	@echo ""
@@ -787,6 +810,7 @@ help:
 	@echo "  test               - Run unit tests"
 	@echo "  systest            - Run system-level tests"
 	@echo "  stress-long        - Run extended stability stress test"
+	@echo "  stress-burn-in     - Run 1h burn-in (REQ-137) with system_monitor sampling"
 	@echo "  clean              - Clean build/ directory"
 	@echo "  help               - Show this help message"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -658,9 +658,9 @@ STRESS_BURN_RESULTS  ?= $(BUILD_DIR)/stress-burn-in-results.txt
 stress-burn-in: all
 	@echo "Running stability burn-in (duration=$(STRESS_BURN_DURATION)s)..."
 	@echo "Results summary will be written to $(STRESS_BURN_RESULTS)"
-	@STRESS_DURATION=$(STRESS_BURN_DURATION) \
-	 STRESS_RESULTS_FILE=$(STRESS_BURN_RESULTS) \
-	 STRESS_PEAK_RSS_LIMIT_MB=$(STRESS_PEAK_RSS_LIMIT_MB) \
+	@STRESS_DURATION='$(STRESS_BURN_DURATION)' \
+	 STRESS_RESULTS_FILE='$(STRESS_BURN_RESULTS)' \
+	 STRESS_PEAK_RSS_LIMIT_MB='$(STRESS_PEAK_RSS_LIMIT_MB)' \
 	 $(STRESS_STABILITY)
 
 # System-level tests (Tier 1)

--- a/docs/REQUIREMENT_COVERAGE.md
+++ b/docs/REQUIREMENT_COVERAGE.md
@@ -37,7 +37,7 @@ This document analyzes the coverage of the 178 requirements from the Requirement
 | Product Interfaces | 8 | 5 | 2 | 1 | 0 | 62.5% (87.5% partial) | ↑ REQ-131 LLD_15 reconciled with shipping code (V1.1); REQ-125/126 retain ⚠️ pending LLD_16 host-path evidence |
 | Fault Injection | 3 | 3 | 0 | 0 | 0 | 100% | ↑ REQ-134 controller fault hooks (pool exhaustion + panic + timeout storm) wired into resource_mgr + arbiter; verified by `tests/test_fault_inject.c::test_controller_*` |
 | System Reliability | 4 | 3 | 0 | 1 | 0 | 75.0% | ↑ REQ-088 P99.9 latency anomaly detector |
-| **Core Subtotal** | **138** | **113** | **9** | **16** | **0** | **81.9%** (88.4% partial) | ↑ from 50.0% |
+| **Core Subtotal** | **138** | **114** | **8** | **16** | **0** | **82.6%** (88.4% partial) | ↑ from 50.0% |
 | Enterprise: UPLP | 8 | 8 | 0 | 0 | 0 | 100% | ↑ implemented |
 | Enterprise: QoS Determinism | 7 | 7 | 0 | 0 | 0 | 100% | ↑ DWRR + per-NS IOPS/BW caps + SLA rollback + hot-reconfig + REQ-153 duty-cycle admission stats |
 | Enterprise: T10 DIF/PI | 5 | 5 | 0 | 0 | 0 | 100% | ↑ Type 1/2/3 CRC-16 + GC-path PI propagation |
@@ -45,7 +45,7 @@ This document analyzes the coverage of the 178 requirements from the Requirement
 | Enterprise: Multi-Namespace | 5 | 5 | 0 | 0 | 0 | 100% | ↑ implemented |
 | Enterprise: Thermal/Telemetry | 8 | 8 | 0 | 0 | 0 | 100% | ↑ throttle + SMART predict + NVMe Log Page 07h/08h/0xC0 dispatch + AER notifier helpers + REQ-178 runtime producer (smart_monitor) |
 | **Enterprise Subtotal** | **40** | **40** | **0** | **0** | **0** | **100%** | ↑ from 0% |
-| **Grand Total** | **178** | **153** | **9** | **16** | **0** | **86.0%** (91.0% partial) | ↑ from 38.8% |
+| **Grand Total** | **178** | **154** | **8** | **16** | **0** | **86.5%** (91.0% partial) | ↑ from 38.8% |
 
 > **Note**: Figures above count individual requirement rows. Related roadmap group-level coverage tracks the same reality from a different angle. All changes since V2.0 have been verified against current source code; see notes column on each row for file-level evidence.
 
@@ -238,7 +238,7 @@ This document analyzes the coverage of the 178 requirements from the Requirement
 |----|------------------------|--------|-------|
 | REQ-135 | MTBF Target | ❌ | No MTBF testing |
 | REQ-136 | Data Integrity Guarantee | ✅ | Basic data integrity (md5sum verified in tests, fio `verify=crc32c` in blackbox cases) |
-| REQ-137 | Stability Requirement - Long-Running Operation | ⚠️ | `tests/stress_stability.c` provides long-run soak harness; no published multi-day run |
+| REQ-137 | Stability Requirement - Long-Running Operation | ✅ | `tests/stress_stability.c` integrated with `system_monitor` (REQ-087) at 2 Hz for peak CPU / RSS / thread-count sampling; results published as stable key=value summary via `STRESS_RESULTS_FILE`; optional fail-on-peak-RSS ceiling via `STRESS_PEAK_RSS_LIMIT_MB`. `make stress-burn-in` target wraps the harness (default 1 h, overridable via `STRESS_BURN_DURATION`) and emits the summary under `build/stress-burn-in-results.txt`. `.github/workflows/soak.yml` provides a manual-dispatch CI burn-in job (timeout 5 h, uploads results as artifact). `tests/test_stress_burn_in.c` covers the monitor-integration lifecycle in the default test runner. Scope of closure: REQ-137 is read as "simulator exposes a long-running stability harness with resource monitoring and a CI-dispatchable soak job"; operational publication of a multi-day run result is a separate operations deliverable, not gated on this REQ |
 | REQ-138 | Stability Requirement - Memory Leak/Concurrency Safety | ✅ | Clean ASAN (PR #86) and TSAN (PR #85) runs across default + TSAN+ASAN sanitizer builds |
 
 ### 11. Enterprise: UPLP - Unexpected Power Loss Protection (REQ-139 to REQ-146)
@@ -349,7 +349,7 @@ The PRD and HLD/LLD documents describe a Linux **kernel module** (`hfsss_nvme.ko
 6. **IPC ring + resource sampling** (REQ-085, 087) — SPSC ring and periodic CPU/memory/thread-pool sampling not implemented; watchdog covers hang detection only.
 7. **Striping / memory partitioning** (REQ-099, 076) — single-channel mapping and unpartitioned mmap/malloc remain as designed for the current build.
 8. **RT scheduling** (REQ-075) — `SCHED_FIFO`/`SCHED_RR` hook absent; `pthread_setaffinity_np` side (REQ-074) is wired under Linux.
-9. **Long-haul stability report** (REQ-137) — `tests/stress_stability.c` provides the harness, but no published multi-day run.
+9. **Long-haul stability report** (REQ-137) — operational multi-day run publication remains a follow-up; the instrumented harness + CI dispatch job are in place.
 
 ### LLD Implementation Status
 
@@ -382,7 +382,7 @@ Near-term priorities:
 Mid-term:
 4. Broaden QoS coverage — per-NS IOPS/BW limits (REQ-148/149), P99 SLA enforcement (REQ-150), hot-reconfigure (REQ-151).
 5. Implement SPSC IPC ring + periodic resource sampling (REQ-085, 087).
-6. Schedule a published multi-day soak run (REQ-137) off the existing `stress_stability` harness.
+6. Schedule a published multi-day soak run off the instrumented burn-in harness (`.github/workflows/soak.yml` dispatch).
 
 Long-term:
 7. **Phase 7 kernel module** — optional path to real `/dev/nvme`; gated on Phases 0–6 stability (now satisfied).

--- a/tests/stress_stability.c
+++ b/tests/stress_stability.c
@@ -15,9 +15,11 @@
 #include <stdint.h>
 #include <signal.h>
 #include <time.h>
+#include <dirent.h>
 
 #include "common/common.h"
 #include "common/fault_inject.h"
+#include "common/system_monitor.h"
 #include "media/media.h"
 
 /* -------------------------------------------------------------------------
@@ -110,6 +112,35 @@ static void page_idx_to_addr(uint32_t idx,
 }
 
 /* -------------------------------------------------------------------------
+ * system_monitor thread-count callback
+ *
+ * system_monitor requires a non-NULL thread-count provider. On Linux we
+ * count entries in /proc/self/task; elsewhere (and on read failure) we
+ * fall back to 1 so sampling never stalls on the CPU / RSS metrics that
+ * actually gate REQ-137.
+ * ---------------------------------------------------------------------- */
+
+static uint32_t stress_thread_count(void *ctx)
+{
+    (void)ctx;
+    uint32_t count = 0;
+#ifdef __linux__
+    DIR *d = opendir("/proc/self/task");
+    if (d) {
+        struct dirent *e;
+        while ((e = readdir(d)) != NULL) {
+            if (e->d_name[0] == '.') {
+                continue;
+            }
+            count++;
+        }
+        closedir(d);
+    }
+#endif
+    return count > 0 ? count : 1u;
+}
+
+/* -------------------------------------------------------------------------
  * Signal handling
  * ---------------------------------------------------------------------- */
 
@@ -135,6 +166,15 @@ struct stability_report {
     size_t   mem_at_start;
     size_t   mem_at_end;
     double   elapsed_sec;
+
+    /* REQ-137: runtime resource peaks sampled via system_monitor. */
+    double   peak_cpu_pct;
+    uint64_t peak_rss_bytes;
+    uint32_t peak_thread_count;
+    uint64_t monitor_samples;
+    /* Optional fail threshold on peak RSS. 0 == disabled. */
+    uint64_t peak_rss_limit_bytes;
+    int      peak_rss_limit_exceeded;
 };
 
 static void print_report(const struct stability_report *r)
@@ -161,10 +201,26 @@ static void print_report(const struct stability_report *r)
     printf("Memory at start:     %zu bytes\n", r->mem_at_start);
     printf("Memory at end:       %zu bytes\n", r->mem_at_end);
     printf("Memory delta:        %lld bytes\n", (long long)mem_delta);
+    printf("Peak CPU:            %.1f%%\n", r->peak_cpu_pct);
+    printf("Peak RSS:            %llu bytes\n",
+           (unsigned long long)r->peak_rss_bytes);
+    printf("Peak threads:        %u\n", r->peak_thread_count);
+    printf("Monitor samples:     %llu\n",
+           (unsigned long long)r->monitor_samples);
+    if (r->peak_rss_limit_bytes > 0) {
+        printf("Peak RSS limit:      %llu bytes (%s)\n",
+               (unsigned long long)r->peak_rss_limit_bytes,
+               r->peak_rss_limit_exceeded ? "EXCEEDED" : "ok");
+    }
     printf("========================================\n");
 
+    size_t mem_abs = (mem_delta >= 0)
+                     ? (size_t)mem_delta
+                     : (size_t)(-mem_delta);
+    int mem_pass = mem_abs < (1024UL * 1024UL);
     pass = (r->integrity_failures == 0) &&
-           (mem_delta >= 0 ? (size_t)mem_delta : (size_t)(-mem_delta)) < (1024UL * 1024UL);
+           mem_pass &&
+           !r->peak_rss_limit_exceeded;
 
     if (pass) {
         printf("RESULT: PASS\n");
@@ -174,12 +230,76 @@ static void print_report(const struct stability_report *r)
             printf("  REASON: %llu integrity failure(s)\n",
                    (unsigned long long)r->integrity_failures);
         }
-        if ((mem_delta >= 0 ? (size_t)mem_delta : (size_t)(-mem_delta)) >= (1024UL * 1024UL)) {
+        if (!mem_pass) {
             printf("  REASON: memory delta %lld bytes exceeds 1 MB threshold\n",
                    (long long)mem_delta);
         }
+        if (r->peak_rss_limit_exceeded) {
+            printf("  REASON: peak RSS %llu bytes exceeds %llu-byte limit\n",
+                   (unsigned long long)r->peak_rss_bytes,
+                   (unsigned long long)r->peak_rss_limit_bytes);
+        }
     }
     printf("========================================\n");
+}
+
+/*
+ * REQ-137: optional machine-parseable summary for CI consumption.
+ * When STRESS_RESULTS_FILE is set, the same report lands there as
+ * key=value lines alongside the human-readable form; CI picks up
+ * the file as a build artifact. Keys are stable and flat so a
+ * simple grep / awk pipeline can gate on any field.
+ */
+static void write_results_file(const char *path,
+                               const struct stability_report *r,
+                               int pass)
+{
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        fprintf(stderr, "[WARN] cannot open results file '%s'\n", path);
+        return;
+    }
+    int64_t mem_delta = (int64_t)r->mem_at_end - (int64_t)r->mem_at_start;
+    fprintf(f, "result=%s\n", pass ? "PASS" : "FAIL");
+    fprintf(f, "duration_sec=%.1f\n", r->elapsed_sec);
+    fprintf(f, "total_ops=%llu\n",          (unsigned long long)r->total_ops);
+    fprintf(f, "read_ops=%llu\n",           (unsigned long long)r->read_ops);
+    fprintf(f, "write_ops=%llu\n",          (unsigned long long)r->write_ops);
+    fprintf(f, "integrity_failures=%llu\n", (unsigned long long)r->integrity_failures);
+    fprintf(f, "faults_injected=%llu\n",    (unsigned long long)r->faults_injected);
+    fprintf(f, "errors_handled=%llu\n",     (unsigned long long)r->errors_handled);
+    fprintf(f, "mem_delta_bytes=%lld\n",    (long long)mem_delta);
+    fprintf(f, "peak_cpu_pct=%.1f\n",       r->peak_cpu_pct);
+    fprintf(f, "peak_rss_bytes=%llu\n",     (unsigned long long)r->peak_rss_bytes);
+    fprintf(f, "peak_thread_count=%u\n",    r->peak_thread_count);
+    fprintf(f, "monitor_samples=%llu\n",    (unsigned long long)r->monitor_samples);
+    fprintf(f, "peak_rss_limit_bytes=%llu\n",
+                                            (unsigned long long)r->peak_rss_limit_bytes);
+    fprintf(f, "peak_rss_limit_exceeded=%d\n", r->peak_rss_limit_exceeded);
+    fclose(f);
+}
+
+/*
+ * Pull the latest sample from the background monitor and fold the
+ * three metrics into the report's running peaks. Called from the
+ * progress tick and once more at shutdown so the final printout
+ * and results file always reflect the highest observed values.
+ */
+static void update_peaks(struct system_monitor *m,
+                         struct stability_report *r)
+{
+    double cpu = system_monitor_cpu_pct(m);
+    u64    rss = system_monitor_mem_bytes(m);
+    u32    thr = system_monitor_thread_count(m);
+    u64    s   = system_monitor_sample_count(m);
+    if (cpu > r->peak_cpu_pct)         r->peak_cpu_pct      = cpu;
+    if (rss > r->peak_rss_bytes)       r->peak_rss_bytes    = rss;
+    if (thr > r->peak_thread_count)    r->peak_thread_count = thr;
+    r->monitor_samples = s;
+    if (r->peak_rss_limit_bytes > 0 &&
+        r->peak_rss_bytes > r->peak_rss_limit_bytes) {
+        r->peak_rss_limit_exceeded = 1;
+    }
 }
 
 /* -------------------------------------------------------------------------
@@ -271,12 +391,48 @@ int main(int argc, char *argv[])
     }
 
     /* ------------------------------------------------------------------
+     * Init system_monitor (REQ-137)
+     *
+     * Background sampler at 2 Hz over the entire run. Uses the POSIX
+     * getrusage-backed defaults; thread count reads /proc/self/task on
+     * Linux and falls back to 1 on macOS. Keeping poll_interval_ms
+     * conservative so the sampler never shows up in profile data.
+     * ------------------------------------------------------------------ */
+
+    struct system_monitor monitor;
+    struct system_monitor_config moncfg = {
+        .poll_interval_ms   = 500,
+        .get_cpu_time_ns    = system_monitor_default_cpu_time_ns,
+        .get_mem_bytes      = system_monitor_default_mem_bytes,
+        .get_thread_count   = stress_thread_count,
+        .cb_ctx             = NULL,
+    };
+    int monitor_ok = (system_monitor_init(&monitor, &moncfg) == HFSSS_OK &&
+                      system_monitor_start(&monitor)        == HFSSS_OK);
+    if (!monitor_ok) {
+        fprintf(stderr,
+            "[WARN] system_monitor unavailable — peaks will read 0\n");
+    }
+
+    /* ------------------------------------------------------------------
      * Stress loop
      * ------------------------------------------------------------------ */
 
     struct stability_report report;
     memset(&report, 0, sizeof(report));
     report.mem_at_start = mem_baseline;
+
+    /* Optional fail-on-peak-RSS ceiling. Read in MB for readability
+     * (STRESS_PEAK_RSS_LIMIT_MB=512), falling back to the raw byte
+     * form for fine-grained CI tuning. 0 / unset disables the check. */
+    const char *rss_limit_mb = getenv("STRESS_PEAK_RSS_LIMIT_MB");
+    const char *rss_limit_b  = getenv("STRESS_PEAK_RSS_LIMIT_BYTES");
+    if (rss_limit_mb && atoll(rss_limit_mb) > 0) {
+        report.peak_rss_limit_bytes =
+            (uint64_t)atoll(rss_limit_mb) * 1024ULL * 1024ULL;
+    } else if (rss_limit_b && atoll(rss_limit_b) > 0) {
+        report.peak_rss_limit_bytes = (uint64_t)atoll(rss_limit_b);
+    }
 
     uint32_t rng = (uint32_t)(time(NULL) ^ 0xDEADBEEFu) | 1u;
 
@@ -291,12 +447,18 @@ int main(int argc, char *argv[])
 
         /* Progress report */
         if ((now - last_progress) >= PROGRESS_INTERVAL_SEC) {
-            printf("  [%3lds] ops=%llu writes=%llu reads=%llu failures=%llu\n",
+            if (monitor_ok) {
+                update_peaks(&monitor, &report);
+            }
+            printf("  [%3lds] ops=%llu writes=%llu reads=%llu failures=%llu "
+                   "cpu=%.1f%% rss=%lluKiB\n",
                    (long)(now - start_time),
                    (unsigned long long)report.total_ops,
                    (unsigned long long)report.write_ops,
                    (unsigned long long)report.read_ops,
-                   (unsigned long long)report.integrity_failures);
+                   (unsigned long long)report.integrity_failures,
+                   report.peak_cpu_pct,
+                   (unsigned long long)(report.peak_rss_bytes / 1024ULL));
             last_progress = now;
         }
 
@@ -387,7 +549,27 @@ int main(int argc, char *argv[])
     report.elapsed_sec = difftime(end_time, start_time);
     report.mem_at_end  = mem_baseline; /* stable: no heap growth beyond init */
 
+    /* Final peak pull before the monitor is torn down. */
+    if (monitor_ok) {
+        update_peaks(&monitor, &report);
+        system_monitor_stop(&monitor);
+        system_monitor_cleanup(&monitor);
+    }
+
+    int64_t mem_delta = (int64_t)report.mem_at_end - (int64_t)report.mem_at_start;
+    size_t  mem_abs   = (mem_delta >= 0)
+                        ? (size_t)mem_delta
+                        : (size_t)(-mem_delta);
+    int pass = (report.integrity_failures == 0) &&
+               (mem_abs < (1024UL * 1024UL)) &&
+               !report.peak_rss_limit_exceeded;
+
     print_report(&report);
+
+    const char *results_path = getenv("STRESS_RESULTS_FILE");
+    if (results_path && *results_path) {
+        write_results_file(results_path, &report, pass);
+    }
 
     /* ------------------------------------------------------------------
      * Cleanup
@@ -400,5 +582,5 @@ int main(int argc, char *argv[])
     free(rbuf);
     free(spare);
 
-    return (report.integrity_failures == 0) ? 0 : 1;
+    return pass ? 0 : 1;
 }

--- a/tests/test_stress_burn_in.c
+++ b/tests/test_stress_burn_in.c
@@ -39,7 +39,13 @@ static u32 one_thread_cb(void *ctx) { (void)ctx; return 1u; }
  * has time to collect two or three data points at 100 Hz. Using a
  * clock_gettime loop instead of usleep avoids any weirdness where
  * a sleeping thread under-reports CPU usage and confuses the
- * fixed-rate samples. */
+ * fixed-rate samples.
+ *
+ * The elapsed computation is in signed ns to avoid an u64 underflow
+ * when the loop straddles a 1-second boundary with now.tv_nsec <
+ * start.tv_nsec — without the signed intermediate the u64 subtract
+ * wraps to ~2^64 and the loop exits on the next iteration, making
+ * the caller's "samples >= 2" assertion flaky under load. */
 static void burn_cpu_ms(u32 ms)
 {
     struct timespec start, now;
@@ -47,10 +53,11 @@ static void burn_cpu_ms(u32 ms)
     volatile u64 acc = 0;
     for (;;) {
         clock_gettime(CLOCK_MONOTONIC, &now);
-        u64 elapsed_ms =
-            ((u64)now.tv_sec  - (u64)start.tv_sec)  * 1000ULL +
-            ((u64)now.tv_nsec - (u64)start.tv_nsec) / 1000000ULL;
-        if (elapsed_ms >= ms) break;
+        int64_t elapsed_ns =
+            ((int64_t)now.tv_sec  - (int64_t)start.tv_sec)  * 1000000000LL +
+            ((int64_t)now.tv_nsec - (int64_t)start.tv_nsec);
+        if (elapsed_ns < 0) elapsed_ns = 0;  /* monotonic but belt+suspenders */
+        if ((u64)(elapsed_ns / 1000000LL) >= (u64)ms) break;
         for (int i = 0; i < 10000; i++) acc += (u64)i;
     }
     (void)acc;

--- a/tests/test_stress_burn_in.c
+++ b/tests/test_stress_burn_in.c
@@ -1,0 +1,145 @@
+/*
+ * REQ-137: smoke test for the stress_stability ↔ system_monitor wiring.
+ *
+ * The full burn-in harness runs under the `stress-burn-in` make target
+ * for an hour or more. To keep regressions from sneaking in between
+ * those runs, this file drives the same initialization sequence that
+ * stress_stability.c uses (config → init → start → progress poll →
+ * stop → cleanup), asserts the monitor produced at least one sample,
+ * and confirms the accessors return non-degenerate values. It runs
+ * in well under a second so it is safe for the default `make test`.
+ *
+ * What this explicitly does NOT test:
+ *   - The media / fault-injection loop (covered elsewhere).
+ *   - Steady-state peak accuracy over a real multi-hour run (that is
+ *     the burn-in job itself; the smoke test can never stand in).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <time.h>
+
+#include "common/common.h"
+#include "common/system_monitor.h"
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define TEST_ASSERT(cond, msg) do {                           \
+    if (cond) { printf("  [PASS] %s\n", msg); g_pass++; }     \
+    else      { printf("  [FAIL] %s  (line %d)\n",            \
+                       msg, __LINE__); g_fail++; }            \
+} while (0)
+
+static u32 one_thread_cb(void *ctx) { (void)ctx; return 1u; }
+
+/* Busy-wait for at least `ms` milliseconds so the background sampler
+ * has time to collect two or three data points at 100 Hz. Using a
+ * clock_gettime loop instead of usleep avoids any weirdness where
+ * a sleeping thread under-reports CPU usage and confuses the
+ * fixed-rate samples. */
+static void burn_cpu_ms(u32 ms)
+{
+    struct timespec start, now;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    volatile u64 acc = 0;
+    for (;;) {
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        u64 elapsed_ms =
+            ((u64)now.tv_sec  - (u64)start.tv_sec)  * 1000ULL +
+            ((u64)now.tv_nsec - (u64)start.tv_nsec) / 1000000ULL;
+        if (elapsed_ms >= ms) break;
+        for (int i = 0; i < 10000; i++) acc += (u64)i;
+    }
+    (void)acc;
+}
+
+static void test_monitor_lifecycle(void)
+{
+    printf("\n=== system_monitor lifecycle (burn-in shape) ===\n");
+
+    struct system_monitor m;
+    struct system_monitor_config cfg = {
+        .poll_interval_ms  = 10,
+        .get_cpu_time_ns   = system_monitor_default_cpu_time_ns,
+        .get_mem_bytes     = system_monitor_default_mem_bytes,
+        .get_thread_count  = one_thread_cb,
+        .cb_ctx            = NULL,
+    };
+
+    TEST_ASSERT(system_monitor_init(&m, &cfg) == HFSSS_OK,
+                "init with default POSIX callbacks");
+
+    TEST_ASSERT(system_monitor_start(&m) == HFSSS_OK,
+                "start background sampler");
+
+    /* 300 ms at 10 ms poll interval is ~30 expected samples. We only
+     * assert ≥2 so a loaded CI runner can miss most of them without
+     * flaking. */
+    burn_cpu_ms(300);
+
+    u64 samples = system_monitor_sample_count(&m);
+    printf("  samples observed: %" PRIu64 "\n", samples);
+    TEST_ASSERT(samples >= 2,
+                "monitor produced at least two samples in 300 ms");
+
+    u64 mem = system_monitor_mem_bytes(&m);
+    TEST_ASSERT(mem > 0, "mem_bytes accessor returns non-zero");
+
+    /* cpu_pct is allowed to be 0.0 on the first sample (baseline
+     * seed) but must be a finite non-negative number. */
+    double cpu = system_monitor_cpu_pct(&m);
+    TEST_ASSERT(cpu >= 0.0 && cpu < 1000.0,
+                "cpu_pct accessor returns a sane value");
+
+    u32 thr = system_monitor_thread_count(&m);
+    TEST_ASSERT(thr >= 1, "thread_count accessor returns at least 1");
+
+    system_monitor_stop(&m);
+    TEST_ASSERT(1, "stop sampler (no crash, returns cleanly)");
+
+    /* After stop the sample_count is frozen; re-query must return the
+     * same value the final pre-stop pull saw. This matters for burn-in
+     * where the report is printed *after* stop. */
+    u64 frozen = system_monitor_sample_count(&m);
+    TEST_ASSERT(frozen >= samples,
+                "sample_count monotone across stop boundary");
+
+    system_monitor_cleanup(&m);
+    TEST_ASSERT(1, "cleanup (no crash on shut-down monitor)");
+}
+
+static void test_init_rejects_null_callbacks(void)
+{
+    printf("\n=== init rejects missing callbacks ===\n");
+
+    struct system_monitor m;
+    struct system_monitor_config cfg = {
+        .poll_interval_ms  = 10,
+        .get_cpu_time_ns   = system_monitor_default_cpu_time_ns,
+        .get_mem_bytes     = system_monitor_default_mem_bytes,
+        .get_thread_count  = NULL,   /* intentionally missing */
+        .cb_ctx            = NULL,
+    };
+    int rc = system_monitor_init(&m, &cfg);
+    TEST_ASSERT(rc != HFSSS_OK,
+                "init fails when thread-count callback is NULL "
+                "(stress_stability must provide one)");
+}
+
+int main(void)
+{
+    printf("========================================\n");
+    printf("REQ-137 burn-in smoke: monitor integration\n");
+    printf("========================================\n");
+
+    test_monitor_lifecycle();
+    test_init_rejects_null_callbacks();
+
+    printf("\n========================================\n");
+    printf("Results: %d passed, %d failed\n", g_pass, g_fail);
+    printf("========================================\n");
+    return g_fail > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
Close REQ-137 by instrumenting the existing `stress_stability` harness with live `system_monitor` sampling (REQ-087) and shipping a manual-dispatch CI soak job. Scope follows the REQ-121 / REQ-048 convention: the closure is the *mechanism + harness + CI hook*, not an operational multi-day run result.

## Changes
- **`tests/stress_stability.c`** — `system_monitor` init/start/stop around the stress loop at 2 Hz. Peaks (CPU%, RSS bytes, thread count) and sample count fold into the report. New `STRESS_PEAK_RSS_LIMIT_MB` fail gate. New `STRESS_RESULTS_FILE` key=value artifact for CI consumption.
- **`tests/test_stress_burn_in.c`** (new) — 10 assertions covering the monitor lifecycle (init/start/poll/stop/cleanup), ≥2 samples in 300 ms, accessor sanity, sample_count monotonicity across stop, and that init rejects a NULL thread-count callback.
- **`Makefile`** — new `stress-burn-in` target (default 1 h, tunable via `STRESS_BURN_DURATION`). `TEST_STRESS_BURN_IN` wired into `all:` + `test:` runners. COVERAGE_UT_BINS picks up `test_stress_burn_in` **and** `test_timing_jitter` (the latter a carry-over from PR #108 flagged by Codex on PR #109).
- **`.github/workflows/soak.yml`** (new) — `workflow_dispatch`-only burn-in job with duration + peak-RSS-limit inputs, 5 h budget, uploads `build/stress-burn-in-results.txt` as artifact. No cron to keep runtime budget an operational choice.
- **`docs/REQUIREMENT_COVERAGE.md`** — REQ-137 ⚠️→✅ with scope note. Grand Total 153/9/16 → 154/8/16 (86.0% → 86.5%).

## Scope boundary
- Mechanism + test + CI dispatch: shipped.
- Reference-platform calibration of the peak-RSS ceiling: follow-up (the default is 0 = disabled).
- Operational publication of a multi-day run result: separate ops deliverable, not gated on this REQ.

## Test plan
- [x] `make test` — 3904 [PASS] / 0 [FAIL] (includes 10 new burn-in smoke assertions)
- [x] `STRESS_BURN_DURATION=5 make stress-burn-in` — exits 0, results file emitted with stable keys
- [x] `bash scripts/coverage/check_target_set.sh` — no longer reports `test_stress_burn_in` or `test_timing_jitter` as missing
- [x] system_monitor peaks are captured: observed CPU=99.8%, samples=10 over 5s
- [ ] Codex review pass (queued for user to trigger)