### PR TITLE
feat(channel_worker): tier-2 CQ latency bench harness (REQ-045)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ TEST_CMD_INTEG_HEAVY = $(BIN_DIR)/test_cmd_integration_heavy
 TEST_PROFILE_MATRIX = $(BIN_DIR)/test_profile_matrix
 TEST_MP_CONCURRENCY = $(BIN_DIR)/test_media_multi_plane_concurrency
 TEST_CHANNEL_WORKER = $(BIN_DIR)/test_channel_worker
+BENCH_CQ = $(BIN_DIR)/bench_channel_worker_cq
 SYSTEST_NVME_CLI = $(BIN_DIR)/systest_nvme_cli_compat
 SYSTEST_FIO_COMPAT = $(BIN_DIR)/systest_fio_compat
 SYSTEST_PHASE7_INT = $(BIN_DIR)/systest_phase7_integration
@@ -243,11 +244,11 @@ COVERAGE_E2E_BINS = $(COVERAGE_BIN_DIR)/hfsss-nbd-server
 COVERAGE_BINS = $(COVERAGE_UT_BINS) $(COVERAGE_E2E_BINS)
 
 # Targets
-.PHONY: all clean directories test systest stress-long stress-burn-in help \
+.PHONY: all clean directories test systest stress-long stress-burn-in bench-cq help \
 	coverage-build coverage-clean coverage-ut coverage-e2e coverage-merge coverage-frontend coverage-frontend-update coverage coverage-selftest \
 	qemu-blackbox qemu-blackbox-list qemu-blackbox-ci qemu-blackbox-soak pre-checkin
 
-all: directories $(LIBHFSSS_COMMON) $(LIBHFSSS_MEDIA) $(LIBHFSSS_HAL) $(LIBHFSSS_FTL) $(LIBHFSSS_CTRL) $(LIBHFSSS_PCIE) $(LIBHFSSS_SSSIM) $(LIBHFSSS_PERF) $(TEST_COMMON) $(TEST_MEDIA) $(TEST_TIMING_JITTER) $(TEST_RETENTION) $(TEST_STRESS_BURN_IN) $(TEST_HAL) $(TEST_FTL) $(TEST_CTRL) $(TEST_SHMEM_IF) $(TEST_PCIE) $(TEST_SSSIM) $(TEST_NVME_USPACE) $(TEST_BOOT) $(TEST_NOR) $(TEST_FTL_REL) $(TEST_RT) $(TEST_OOB) $(TEST_CONFIG) $(TEST_FAULT) $(TEST_RELIABILITY) $(TEST_PERF) $(TEST_DSM) $(TEST_PRP) $(STRESS_RW) $(STRESS_MIXED) $(STRESS_MIXED_TRIM) $(HFSSS_CTRL) $(TEST_FTL_INT) $(STRESS_ADMIN_MIX) $(TEST_SB) $(TEST_POWER_CYCLE) $(TEST_FOUNDATION) $(TEST_T10PI) $(SYSTEST_DI) $(SYSTEST_NC) $(SYSTEST_EB) $(SYSTEST_PS) $(SYSTEST_WG) $(SYSTEST_PR) $(TEST_UPLP) $(TEST_QOS) $(TEST_SECURITY) $(TEST_MULTI_NS) $(TEST_THERMAL_TEL) $(STRESS_ENTERPRISE) $(TEST_PROC) $(STRESS_STABILITY) $(HFSSS_IMG_EXPORT) $(HFSSS_NBD) $(TEST_LARGE_CAP) $(TEST_IO_QUEUE) $(TEST_TAA) $(TEST_TRACE) $(TEST_MT_FTL) $(TEST_GC_MT) $(TEST_INFLIGHT) $(TEST_MSGQ) $(TEST_NVME_ADMIN) $(TEST_NVME_IO) $(TEST_CMD_INTEG_BASIC) $(TEST_CMD_INTEG_MID) $(TEST_CMD_INTEG_HEAVY) $(TEST_PROFILE_MATRIX) $(TEST_MP_CONCURRENCY) $(TEST_CHANNEL_WORKER) $(SYSTEST_NVME_CLI) $(SYSTEST_FIO_COMPAT) $(SYSTEST_PHASE7_INT) $(TEST_RESET_ABORT_RACE) $(TEST_FTL_PROFILE) $(TEST_SSSIM_PROFILE) $(FTL_MFC_REPRO)
+all: directories $(LIBHFSSS_COMMON) $(LIBHFSSS_MEDIA) $(LIBHFSSS_HAL) $(LIBHFSSS_FTL) $(LIBHFSSS_CTRL) $(LIBHFSSS_PCIE) $(LIBHFSSS_SSSIM) $(LIBHFSSS_PERF) $(TEST_COMMON) $(TEST_MEDIA) $(TEST_TIMING_JITTER) $(TEST_RETENTION) $(TEST_STRESS_BURN_IN) $(TEST_HAL) $(TEST_FTL) $(TEST_CTRL) $(TEST_SHMEM_IF) $(TEST_PCIE) $(TEST_SSSIM) $(TEST_NVME_USPACE) $(TEST_BOOT) $(TEST_NOR) $(TEST_FTL_REL) $(TEST_RT) $(TEST_OOB) $(TEST_CONFIG) $(TEST_FAULT) $(TEST_RELIABILITY) $(TEST_PERF) $(TEST_DSM) $(TEST_PRP) $(STRESS_RW) $(STRESS_MIXED) $(STRESS_MIXED_TRIM) $(HFSSS_CTRL) $(TEST_FTL_INT) $(STRESS_ADMIN_MIX) $(TEST_SB) $(TEST_POWER_CYCLE) $(TEST_FOUNDATION) $(TEST_T10PI) $(SYSTEST_DI) $(SYSTEST_NC) $(SYSTEST_EB) $(SYSTEST_PS) $(SYSTEST_WG) $(SYSTEST_PR) $(TEST_UPLP) $(TEST_QOS) $(TEST_SECURITY) $(TEST_MULTI_NS) $(TEST_THERMAL_TEL) $(STRESS_ENTERPRISE) $(TEST_PROC) $(STRESS_STABILITY) $(HFSSS_IMG_EXPORT) $(HFSSS_NBD) $(TEST_LARGE_CAP) $(TEST_IO_QUEUE) $(TEST_TAA) $(TEST_TRACE) $(TEST_MT_FTL) $(TEST_GC_MT) $(TEST_INFLIGHT) $(TEST_MSGQ) $(TEST_NVME_ADMIN) $(TEST_NVME_IO) $(TEST_CMD_INTEG_BASIC) $(TEST_CMD_INTEG_MID) $(TEST_CMD_INTEG_HEAVY) $(TEST_PROFILE_MATRIX) $(TEST_MP_CONCURRENCY) $(TEST_CHANNEL_WORKER) $(BENCH_CQ) $(SYSTEST_NVME_CLI) $(SYSTEST_FIO_COMPAT) $(SYSTEST_PHASE7_INT) $(TEST_RESET_ABORT_RACE) $(TEST_FTL_PROFILE) $(TEST_SSSIM_PROFILE) $(FTL_MFC_REPRO)
 	@echo "========================================"
 	@echo "HFSSS build complete!"
 	@echo "========================================"
@@ -387,6 +388,10 @@ $(TEST_MP_CONCURRENCY): $(TEST_DIR)/test_media_multi_plane_concurrency.c $(LIBHF
 	@$(CC) $(CFLAGS) $< -o $@ -L$(LIB_DIR) -lhfsss-media -lhfsss-common $(LDFLAGS)
 
 $(TEST_CHANNEL_WORKER): $(TEST_DIR)/test_channel_worker.c $(LIBHFSSS_CTRL) $(LIBHFSSS_MEDIA) $(LIBHFSSS_COMMON)
+	@echo "  CC      $@"
+	@$(CC) $(CFLAGS) $< -o $@ -L$(LIB_DIR) -lhfsss-controller -lhfsss-media -lhfsss-common $(LDFLAGS)
+
+$(BENCH_CQ): $(TEST_DIR)/bench_channel_worker_cq.c $(LIBHFSSS_CTRL) $(LIBHFSSS_MEDIA) $(LIBHFSSS_COMMON)
 	@echo "  CC      $@"
 	@$(CC) $(CFLAGS) $< -o $@ -L$(LIB_DIR) -lhfsss-controller -lhfsss-media -lhfsss-common $(LDFLAGS)
 
@@ -689,6 +694,16 @@ systest: directories $(SYSTEST_DI) $(SYSTEST_NC) $(SYSTEST_EB) $(SYSTEST_PS) $(S
 	@echo "All system-level tests complete!"
 	@echo "========================================"
 
+# REQ-045 tier-2 CQ latency bench harness — opt-in only, NOT part of `make test`.
+# Optional: pass STRESS_RESULTS_FILE=/path/to/file.txt to capture a CI-scrapable
+#           key=value summary. Pass BENCH_OPS / BENCH_RATE_OPS_PER_SEC to tune
+#           the workload size / pacing without rebuilding.
+bench-cq: $(BENCH_CQ)
+	@STRESS_RESULTS_FILE='$(STRESS_RESULTS_FILE)' \
+	 BENCH_OPS='$(BENCH_OPS)' \
+	 BENCH_RATE_OPS_PER_SEC='$(BENCH_RATE_OPS_PER_SEC)' \
+	 $(BENCH_CQ)
+
 # Test
 test: all
 	@echo "========================================"
@@ -811,6 +826,7 @@ help:
 	@echo "  systest            - Run system-level tests"
 	@echo "  stress-long        - Run extended stability stress test"
 	@echo "  stress-burn-in     - Run 1h burn-in (REQ-137) with system_monitor sampling"
+	@echo "  bench-cq           - Run REQ-045 tier-2 CQ latency bench harness (opt-in)"
 	@echo "  clean              - Clean build/ directory"
 	@echo "  help               - Show this help message"
 	@echo ""

--- a/tests/bench_channel_worker_cq.c
+++ b/tests/bench_channel_worker_cq.c
@@ -20,16 +20,27 @@
  *   BENCH_RATE_OPS_PER_SEC  — pacing rate (0 = unpaced; default 0).
  *   STRESS_RESULTS_FILE     — when set, key=value summary is appended.
  *
- * PASS criterion: every submitted op was observed by the consumer AND
- * the aggregate p99 latency is below the documented budget. Latency
- * here is wall-clock submit→complete, so an unpaced producer that
- * saturates the SPSC ring naturally accrues queue-wait at the head of
- * each op; with ring depth of 256 and the modeled NAND op time the
- * harness observes p99 in the low tens of milliseconds. The budget is
- * deliberately set to 100 ms so the harness catches order-of-magnitude
- * regressions (e.g. an unbounded spin or a latent deadlock surfacing
- * as a multi-second tail) without flaking on natural queue-depth
- * backpressure. Exit 0 on PASS, non-zero otherwise.
+ * PASS criterion (all four must hold):
+ *   - every submitted op was observed by the consumer through the CQ;
+ *   - every observed op completed with status == HFSSS_OK (failed_ops == 0);
+ *   - no producer/consumer hit a fatal harness error;
+ *   - aggregate p99 latency over the OK-only sample set is below the
+ *     documented budget.
+ *
+ * Failure status from the worker is the gate that distinguishes a
+ * working CQ from a CQ that merely delivers commands. Failed ops are
+ * counted and reported but excluded from the latency percentile pool,
+ * because failures often complete quickly and would skew the
+ * distribution downward and hide real regressions.
+ *
+ * Latency here is wall-clock submit→complete, so an unpaced producer
+ * that saturates the SPSC ring naturally accrues queue-wait at the
+ * head of each op; with ring depth of 256 and the modeled NAND op
+ * time the harness observes p99 in the low tens of milliseconds. The
+ * budget is deliberately set to 100 ms so the harness catches
+ * order-of-magnitude regressions (e.g. an unbounded spin or a latent
+ * deadlock surfacing as a multi-second tail) without flaking on
+ * natural queue-depth backpressure. Exit 0 on PASS, non-zero otherwise.
  *
  * Standalone — not wired into `make test`. Build via `make bench-cq`.
  */
@@ -105,8 +116,11 @@ struct bench_channel {
     _Atomic int            prod_done;
     _Atomic u64            submitted;
     _Atomic u64            completed;
+    _Atomic u64            failed_ops;       /* drained cmds whose status != HFSSS_OK */
+    _Atomic int            first_fail_status;/* first observed non-OK status, or 0 */
     _Atomic int            fatal;            /* 1 if producer/consumer hit a fatal error */
-    /* Latency samples — owned by the consumer, sized to target_ops. */
+    /* Latency samples — owned by the consumer. Only successful (HFSSS_OK)
+     * completions are recorded; sized to target_ops as the worst-case bound. */
     u64                   *samples;
     u32                    sample_count;
 };
@@ -414,16 +428,28 @@ static void *consumer_thread(void *arg)
         for (int i = 0; i < n; i++) {
             struct channel_cmd *cc = batch[i];
             struct bench_cmd   *cmd = (struct bench_cmd *)cc;
-            u64 lat = cc->complete_ts_ns - cc->submit_ts_ns;
-            if (popped_total < bc->target_ops) {
-                bc->samples[popped_total] = lat;
+            if (cc->status == HFSSS_OK) {
+                u64 lat = cc->complete_ts_ns - cc->submit_ts_ns;
+                if (bc->sample_count < bc->target_ops) {
+                    bc->samples[bc->sample_count] = lat;
+                    bc->sample_count++;
+                }
+            } else {
+                /* Record the failure but keep draining; failed cmds still
+                 * own a CQ slot and a heap allocation that must be released.
+                 * Failed-op latency is excluded from the percentile pool
+                 * because failures often complete fast and would skew the
+                 * distribution downward, hiding real CQ regressions. */
+                atomic_fetch_add(&bc->failed_ops, 1);
+                int expected = 0;
+                atomic_compare_exchange_strong(&bc->first_fail_status,
+                                               &expected, cc->status);
             }
             popped_total++;
             atomic_fetch_add(&bc->completed, 1);
             bench_cmd_free(cmd);
         }
     }
-    bc->sample_count = popped_total;
     return NULL;
 }
 
@@ -484,26 +510,32 @@ static void print_report(const struct latency_stats *s,
                          u32 ops_per_channel,
                          u64 wall_ns,
                          double ops_per_sec,
+                         u64 observed_ops,
+                         u64 failed_ops,
+                         int first_fail_status,
                          int pass)
 {
     double wall_sec = (double)wall_ns / 1e9;
     printf("========================================\n");
     printf("REQ-045 tier-2 CQ latency bench\n");
     printf("========================================\n");
-    printf("channels         : %u\n", channels);
-    printf("ops_per_channel  : %u\n", ops_per_channel);
-    printf("total_ops        : %llu\n", (unsigned long long)s->count);
-    printf("wall_time_sec    : %.3f\n", wall_sec);
-    printf("ops_per_sec      : %.1f\n", ops_per_sec);
+    printf("channels             : %u\n", channels);
+    printf("ops_per_channel      : %u\n", ops_per_channel);
+    printf("observed_ops         : %llu\n", (unsigned long long)observed_ops);
+    printf("ok_ops               : %llu\n", (unsigned long long)s->count);
+    printf("failed_ops           : %llu\n", (unsigned long long)failed_ops);
+    printf("first_fail_status    : %d\n",   first_fail_status);
+    printf("wall_time_sec        : %.3f\n", wall_sec);
+    printf("ops_per_sec          : %.1f\n", ops_per_sec);
     printf("----------------------------------------\n");
-    printf("latency_min_ns   : %llu\n", (unsigned long long)s->min_ns);
-    printf("latency_p50_ns   : %llu\n", (unsigned long long)s->p50_ns);
-    printf("latency_p99_ns   : %llu\n", (unsigned long long)s->p99_ns);
-    printf("latency_p999_ns  : %llu\n", (unsigned long long)s->p999_ns);
-    printf("latency_max_ns   : %llu\n", (unsigned long long)s->max_ns);
-    printf("latency_mean_ns  : %.1f\n", s->mean_ns);
+    printf("latency_min_ns       : %llu\n", (unsigned long long)s->min_ns);
+    printf("latency_p50_ns       : %llu\n", (unsigned long long)s->p50_ns);
+    printf("latency_p99_ns       : %llu\n", (unsigned long long)s->p99_ns);
+    printf("latency_p999_ns      : %llu\n", (unsigned long long)s->p999_ns);
+    printf("latency_max_ns       : %llu\n", (unsigned long long)s->max_ns);
+    printf("latency_mean_ns      : %.1f\n", s->mean_ns);
     printf("----------------------------------------\n");
-    printf("result           : %s\n", pass ? "PASS" : "FAIL");
+    printf("result               : %s\n", pass ? "PASS" : "FAIL");
     printf("========================================\n");
 }
 
@@ -517,6 +549,9 @@ static void write_results_file(const char *path,
                                u32 channels,
                                u32 ops_per_channel,
                                u32 expected_total,
+                               u64 observed_ops,
+                               u64 failed_ops,
+                               int first_fail_status,
                                u64 wall_ns,
                                double ops_per_sec,
                                int pass)
@@ -528,13 +563,16 @@ static void write_results_file(const char *path,
         return;
     }
     double wall_sec = (double)wall_ns / 1e9;
-    fprintf(f, "result=%s\n",          pass ? "PASS" : "FAIL");
-    fprintf(f, "channels=%u\n",        channels);
-    fprintf(f, "ops_per_channel=%u\n", ops_per_channel);
-    fprintf(f, "expected_total=%u\n",  expected_total);
-    fprintf(f, "total_ops=%llu\n",     (unsigned long long)s->count);
-    fprintf(f, "wall_time_sec=%.3f\n", wall_sec);
-    fprintf(f, "ops_per_sec=%.1f\n",   ops_per_sec);
+    fprintf(f, "result=%s\n",            pass ? "PASS" : "FAIL");
+    fprintf(f, "channels=%u\n",          channels);
+    fprintf(f, "ops_per_channel=%u\n",   ops_per_channel);
+    fprintf(f, "expected_total=%u\n",    expected_total);
+    fprintf(f, "observed_ops=%llu\n",    (unsigned long long)observed_ops);
+    fprintf(f, "ok_ops=%llu\n",          (unsigned long long)s->count);
+    fprintf(f, "failed_ops=%llu\n",      (unsigned long long)failed_ops);
+    fprintf(f, "first_fail_status=%d\n", first_fail_status);
+    fprintf(f, "wall_time_sec=%.3f\n",   wall_sec);
+    fprintf(f, "ops_per_sec=%.1f\n",     ops_per_sec);
     fprintf(f, "latency_min_ns=%llu\n",  (unsigned long long)s->min_ns);
     fprintf(f, "latency_p50_ns=%llu\n",  (unsigned long long)s->p50_ns);
     fprintf(f, "latency_p99_ns=%llu\n",  (unsigned long long)s->p99_ns);
@@ -649,7 +687,10 @@ int main(void)
         atomic_store(&channels[ch].prod_done, 0);
         atomic_store(&channels[ch].submitted, 0);
         atomic_store(&channels[ch].completed, 0);
+        atomic_store(&channels[ch].failed_ops, 0);
+        atomic_store(&channels[ch].first_fail_status, 0);
         atomic_store(&channels[ch].fatal,     0);
+        channels[ch].sample_count = 0;
         channels[ch].samples = (u64 *)calloc(ops_per_ch, sizeof(u64));
         if (!channels[ch].samples) {
             fprintf(stderr, "[bench] OOM allocating samples ch=%u\n", ch);
@@ -703,15 +744,23 @@ int main(void)
     u64 wall_end = get_time_ns();
     u64 wall_ns  = wall_end - wall_start;
 
-    /* Aggregate samples. */
-    u64 total = 0;
+    /* Aggregate successful-op samples + failure counts across channels. */
+    u64 ok_total      = 0;
+    u64 failed_total  = 0;
+    u64 observed_total = 0;
+    int first_fail    = 0;
     for (u32 ch = 0; ch < BENCH_CHANNELS; ch++) {
-        total += channels[ch].sample_count;
+        ok_total       += channels[ch].sample_count;
+        failed_total   += atomic_load(&channels[ch].failed_ops);
+        observed_total += atomic_load(&channels[ch].completed);
+        if (first_fail == 0) {
+            first_fail = atomic_load(&channels[ch].first_fail_status);
+        }
     }
-    u64 *agg = (u64 *)calloc(total ? total : 1, sizeof(u64));
+    u64 *agg = (u64 *)calloc(ok_total ? ok_total : 1, sizeof(u64));
     if (!agg) {
         fprintf(stderr, "[bench] OOM aggregating samples (total=%llu)\n",
-                (unsigned long long)total);
+                (unsigned long long)ok_total);
         teardown_channels(channels, BENCH_CHANNELS);
         media_cleanup(&media);
         return 2;
@@ -724,22 +773,27 @@ int main(void)
     }
 
     struct latency_stats stats;
-    compute_stats(agg, total, &stats);
+    compute_stats(agg, ok_total, &stats);
     free(agg);
 
     u32 expected_total = ops_per_ch * BENCH_CHANNELS;
-    double ops_per_sec = wall_ns ? ((double)total * 1e9 / (double)wall_ns) : 0.0;
+    double ops_per_sec = wall_ns ? ((double)ok_total * 1e9 / (double)wall_ns) : 0.0;
     int pass = !any_fatal &&
-               (total == expected_total) &&
+               (failed_total == 0) &&
+               (observed_total == expected_total) &&
+               (ok_total == expected_total) &&
                (stats.p99_ns < BENCH_LATENCY_P99_BUDGET_NS);
 
     print_report(&stats, BENCH_CHANNELS, ops_per_ch,
-                 wall_ns, ops_per_sec, pass);
+                 wall_ns, ops_per_sec,
+                 observed_total, failed_total, first_fail, pass);
 
     if (results_path && *results_path) {
         write_results_file(results_path, &stats,
                            BENCH_CHANNELS, ops_per_ch,
-                           expected_total, wall_ns, ops_per_sec, pass);
+                           expected_total, observed_total,
+                           failed_total, first_fail,
+                           wall_ns, ops_per_sec, pass);
     }
 
     teardown_channels(channels, BENCH_CHANNELS);

--- a/tests/bench_channel_worker_cq.c
+++ b/tests/bench_channel_worker_cq.c
@@ -1,0 +1,749 @@
+/*
+ * bench_channel_worker_cq.c — REQ-045 tier-2 controlled CQ latency bench.
+ *
+ * Spawns one channel_worker per channel with the opt-in completion queue
+ * enabled, drives a mixed read/program workload from a per-channel
+ * producer thread, and drains the CQ from a per-channel consumer thread
+ * that records (complete_ts_ns - submit_ts_ns) for every popped command.
+ * After all channels finish, the harness aggregates samples across
+ * channels and reports count, min/max, mean, p50, p99, p99.9 plus
+ * wall-clock throughput.
+ *
+ * Workload mix: 70% READ / 30% PROGRAM. Programs cycle through a fixed
+ * range of pre-erased blocks so reads always land on the most-recent
+ * programmed page within the same channel. Once a block is fully
+ * programmed, it is re-erased and reused. ERASE submissions are
+ * accounted in the same op stream so the consumer sees them too.
+ *
+ * Tunables (env vars):
+ *   BENCH_OPS               — ops per channel (default 10000).
+ *   BENCH_RATE_OPS_PER_SEC  — pacing rate (0 = unpaced; default 0).
+ *   STRESS_RESULTS_FILE     — when set, key=value summary is appended.
+ *
+ * PASS criterion: every submitted op was observed by the consumer AND
+ * the aggregate p99 latency is below the documented budget. Latency
+ * here is wall-clock submit→complete, so an unpaced producer that
+ * saturates the SPSC ring naturally accrues queue-wait at the head of
+ * each op; with ring depth of 256 and the modeled NAND op time the
+ * harness observes p99 in the low tens of milliseconds. The budget is
+ * deliberately set to 100 ms so the harness catches order-of-magnitude
+ * regressions (e.g. an unbounded spin or a latent deadlock surfacing
+ * as a multi-second tail) without flaking on natural queue-depth
+ * backpressure. Exit 0 on PASS, non-zero otherwise.
+ *
+ * Standalone — not wired into `make test`. Build via `make bench-cq`.
+ */
+
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "common/common.h"
+#include "controller/channel_worker.h"
+#include "media/media.h"
+
+/* -------------------------------------------------------------------- */
+/* Configuration                                                        */
+/* -------------------------------------------------------------------- */
+
+#define BENCH_DEFAULT_OPS_PER_CH 10000u
+#define BENCH_DEFAULT_RATE        0u    /* 0 = unpaced */
+#define BENCH_BATCH_CAP           64u
+#define BENCH_RING_CAPACITY      256u   /* power of two */
+#define BENCH_CQ_CAPACITY        256u   /* power of two */
+#define BENCH_READ_PCT            70u
+#define BENCH_LATENCY_P99_BUDGET_NS  (100ULL * 1000ULL * 1000ULL)  /* 100 ms */
+
+/* NAND geometry mirroring tests/test_channel_worker.c::make_cfg(). Two
+ * channels × 2 planes × 4 blocks × 16 pages keeps the simulated state
+ * tiny and lets the harness recycle blocks during the run. */
+#define BENCH_CHANNELS         2u
+#define BENCH_CHIPS            1u
+#define BENCH_DIES             1u
+#define BENCH_PLANES           2u
+#define BENCH_BLOCKS_PER_PLANE 4u
+#define BENCH_PAGES_PER_BLOCK 16u
+#define BENCH_PAGE_SIZE     4096u
+#define BENCH_SPARE_SIZE     128u
+
+/* Sentinel that "no page has been programmed yet" for a given (plane,
+ * block) pair within the channel's working set. */
+#define BENCH_PAGE_NONE ((u32)-1)
+
+/* -------------------------------------------------------------------- */
+/* Workload op + heap-pooled command                                    */
+/* -------------------------------------------------------------------- */
+
+/* Bench cmd wraps the worker cmd plus its data buffer, so heap lifetime
+ * spans submit -> drain -> latency record -> free, independent of the
+ * producer's stack. */
+struct bench_cmd {
+    struct channel_cmd ccmd;
+    u8                 data[BENCH_PAGE_SIZE];
+};
+
+/* -------------------------------------------------------------------- */
+/* Per-channel runtime state                                            */
+/* -------------------------------------------------------------------- */
+
+struct bench_channel {
+    u32                    channel_id;
+    struct channel_worker  worker;
+    struct media_ctx      *media;
+    u32                    target_ops;
+    u32                    rate_ops_per_sec;
+    pthread_t              prod_thr;
+    pthread_t              cons_thr;
+    bool                   prod_started;
+    bool                   cons_started;
+    _Atomic int            prod_done;
+    _Atomic u64            submitted;
+    _Atomic u64            completed;
+    _Atomic int            fatal;            /* 1 if producer/consumer hit a fatal error */
+    /* Latency samples — owned by the consumer, sized to target_ops. */
+    u64                   *samples;
+    u32                    sample_count;
+};
+
+/* -------------------------------------------------------------------- */
+/* PRNG (xorshift32)                                                    */
+/* -------------------------------------------------------------------- */
+
+static u32 xorshift32(u32 *state)
+{
+    u32 x = *state;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    *state = x;
+    return x;
+}
+
+static void fill_pattern(u8 *buf, u32 size, u32 seed)
+{
+    u32 s = seed ? seed : 0xDEADBEEFu;
+    for (u32 i = 0; i < size; i++) {
+        s = xorshift32(&s);
+        buf[i] = (u8)(s & 0xFFu);
+    }
+}
+
+/* -------------------------------------------------------------------- */
+/* Env helpers                                                          */
+/* -------------------------------------------------------------------- */
+
+static u32 env_u32(const char *key, u32 fallback)
+{
+    const char *v = getenv(key);
+    if (!v || !*v) return fallback;
+    long n = strtol(v, NULL, 10);
+    if (n <= 0) return fallback;
+    return (u32)n;
+}
+
+/* -------------------------------------------------------------------- */
+/* Working set bookkeeping                                              */
+/* -------------------------------------------------------------------- */
+
+/*
+ * Per-(plane, block) cursor: how many pages have been programmed within
+ * this block since its last erase, and the most recently programmed
+ * page index for read targeting. The worker dispatches synchronously,
+ * so the producer thread is the sole owner of this state and does not
+ * need atomics.
+ */
+struct bench_block_state {
+    u32 next_page;       /* 0..BENCH_PAGES_PER_BLOCK */
+    u32 last_programmed; /* BENCH_PAGE_NONE if none yet */
+};
+
+struct chan_blocks {
+    struct bench_block_state planes[BENCH_PLANES][BENCH_BLOCKS_PER_PLANE];
+};
+
+static void chan_blocks_reset(struct chan_blocks *cb)
+{
+    for (u32 p = 0; p < BENCH_PLANES; p++) {
+        for (u32 b = 0; b < BENCH_BLOCKS_PER_PLANE; b++) {
+            cb->planes[p][b].next_page       = 0;
+            cb->planes[p][b].last_programmed = BENCH_PAGE_NONE;
+        }
+    }
+}
+
+/* Synchronously erase every block in the channel's working set so the
+ * producer can immediately program. Runs once before the producer
+ * thread is spawned. */
+static int prepare_channel_blocks(struct media_ctx *media, u32 ch)
+{
+    for (u32 plane = 0; plane < BENCH_PLANES; plane++) {
+        for (u32 block = 0; block < BENCH_BLOCKS_PER_PLANE; block++) {
+            int rc = media_nand_erase(media, ch, 0, 0, plane, block);
+            if (rc != HFSSS_OK) {
+                fprintf(stderr,
+                        "[bench] pre-erase failed ch=%u plane=%u block=%u rc=%d\n",
+                        ch, plane, block, rc);
+                return rc;
+            }
+        }
+    }
+    return HFSSS_OK;
+}
+
+/* -------------------------------------------------------------------- */
+/* Pacing                                                               */
+/* -------------------------------------------------------------------- */
+
+/*
+ * If rate > 0, returns the absolute deadline for op index `op_idx`
+ * relative to start_ns; the producer sleeps until then. Rate 0 disables
+ * pacing entirely.
+ */
+static u64 deadline_for(u64 start_ns, u32 rate, u64 op_idx)
+{
+    if (rate == 0) return 0;
+    u64 ns_per_op = 1000000000ULL / rate;
+    return start_ns + ns_per_op * op_idx;
+}
+
+static void wait_until(u64 deadline_ns)
+{
+    if (deadline_ns == 0) return;
+    u64 now = get_time_ns();
+    if (now >= deadline_ns) return;
+    sleep_ns(deadline_ns - now);
+}
+
+/* -------------------------------------------------------------------- */
+/* bench_cmd allocation                                                 */
+/* -------------------------------------------------------------------- */
+
+static struct bench_cmd *bench_cmd_new(void)
+{
+    struct bench_cmd *bc = (struct bench_cmd *)calloc(1, sizeof(*bc));
+    return bc;
+}
+
+static void bench_cmd_free(struct bench_cmd *bc)
+{
+    free(bc);
+}
+
+/* -------------------------------------------------------------------- */
+/* Producer                                                             */
+/* -------------------------------------------------------------------- */
+
+/*
+ * Pick the next op type and fully populate cmd. Returns false if no
+ * read target is available yet (consumer hasn't seen any program land).
+ * The caller retries with a different op in that case.
+ */
+static bool fill_program_cmd(struct bench_cmd *bc, u32 ch,
+                             struct chan_blocks *cb, u32 *cursor)
+{
+    /* Scan forward from cursor for any block with free pages. If all
+     * blocks are full, re-erase the next one in rotation and reuse. */
+    for (u32 sweep = 0; sweep < BENCH_PLANES * BENCH_BLOCKS_PER_PLANE; sweep++) {
+        u32 idx   = (*cursor + sweep) % (BENCH_PLANES * BENCH_BLOCKS_PER_PLANE);
+        u32 plane = idx / BENCH_BLOCKS_PER_PLANE;
+        u32 block = idx % BENCH_BLOCKS_PER_PLANE;
+        if (cb->planes[plane][block].next_page < BENCH_PAGES_PER_BLOCK) {
+            u32 page = cb->planes[plane][block].next_page++;
+            cb->planes[plane][block].last_programmed = page;
+            bc->ccmd.op    = CHANNEL_CMD_PROGRAM;
+            bc->ccmd.ch    = ch;
+            bc->ccmd.chip  = 0;
+            bc->ccmd.die   = 0;
+            bc->ccmd.plane = plane;
+            bc->ccmd.block = block;
+            bc->ccmd.page  = page;
+            bc->ccmd.data_buf = bc->data;
+            fill_pattern(bc->data, BENCH_PAGE_SIZE,
+                         (ch << 24) ^ (plane << 16) ^ (block << 8) ^ page);
+            *cursor = idx;
+            return true;
+        }
+    }
+    /* All blocks are full — issue a synchronous erase on the cursor
+     * block via the worker is unsafe here (would deadlock the producer
+     * waiting on its own consumer). Instead, encode an ERASE cmd and
+     * let the worker run it; mark the block as "in flight" by resetting
+     * its cursor immediately so subsequent program ops can target it
+     * once the erase completes (the worker dispatches FIFO so by the
+     * time the next program for this block reaches the worker, the
+     * erase has already returned). */
+    u32 idx   = *cursor % (BENCH_PLANES * BENCH_BLOCKS_PER_PLANE);
+    u32 plane = idx / BENCH_BLOCKS_PER_PLANE;
+    u32 block = idx % BENCH_BLOCKS_PER_PLANE;
+    cb->planes[plane][block].next_page       = 0;
+    cb->planes[plane][block].last_programmed = BENCH_PAGE_NONE;
+    bc->ccmd.op    = CHANNEL_CMD_ERASE;
+    bc->ccmd.ch    = ch;
+    bc->ccmd.chip  = 0;
+    bc->ccmd.die   = 0;
+    bc->ccmd.plane = plane;
+    bc->ccmd.block = block;
+    bc->ccmd.page  = 0;
+    bc->ccmd.data_buf = NULL;
+    return true;
+}
+
+/*
+ * Pick a read target from the channel's working set. Returns false if
+ * no page has been programmed yet (caller falls back to a program).
+ */
+static bool fill_read_cmd(struct bench_cmd *bc, u32 ch,
+                          struct chan_blocks *cb, u32 *prng)
+{
+    /* Sample up to N attempts; if none of the random picks is
+     * programmed, the caller should fall back to a program. */
+    for (int attempt = 0; attempt < 8; attempt++) {
+        u32 r     = xorshift32(prng);
+        u32 plane = r % BENCH_PLANES;
+        u32 block = (r / BENCH_PLANES) % BENCH_BLOCKS_PER_PLANE;
+        u32 last  = cb->planes[plane][block].last_programmed;
+        if (last == BENCH_PAGE_NONE) continue;
+        bc->ccmd.op    = CHANNEL_CMD_READ;
+        bc->ccmd.ch    = ch;
+        bc->ccmd.chip  = 0;
+        bc->ccmd.die   = 0;
+        bc->ccmd.plane = plane;
+        bc->ccmd.block = block;
+        bc->ccmd.page  = last;
+        bc->ccmd.data_buf = bc->data;
+        return true;
+    }
+    return false;
+}
+
+static void *producer_thread(void *arg)
+{
+    struct bench_channel *bc  = (struct bench_channel *)arg;
+    struct chan_blocks    cb;
+    chan_blocks_reset(&cb);
+    u32 prng   = 0xC0FFEE00u ^ (bc->channel_id * 0x9E3779B1u);
+    u32 cursor = 0;
+    u64 start  = get_time_ns();
+
+    for (u32 i = 0; i < bc->target_ops; i++) {
+        if (atomic_load(&bc->fatal)) break;
+
+        struct bench_cmd *cmd = bench_cmd_new();
+        if (!cmd) {
+            fprintf(stderr, "[bench] OOM allocating cmd ch=%u i=%u\n",
+                    bc->channel_id, i);
+            atomic_store(&bc->fatal, 1);
+            break;
+        }
+
+        u32 r       = xorshift32(&prng);
+        bool is_read = (r % 100u) < BENCH_READ_PCT;
+        bool ok      = false;
+        if (is_read) {
+            ok = fill_read_cmd(cmd, bc->channel_id, &cb, &prng);
+        }
+        if (!ok) {
+            ok = fill_program_cmd(cmd, bc->channel_id, &cb, &cursor);
+        }
+        if (!ok) {
+            bench_cmd_free(cmd);
+            atomic_store(&bc->fatal, 1);
+            break;
+        }
+
+        wait_until(deadline_for(start, bc->rate_ops_per_sec, i));
+
+        /* Submit with retry on BUSY (CQ back-pressure flows through to
+         * the submit ring). yield-spin keeps the producer responsive
+         * to cleanup. */
+        for (;;) {
+            int rc = channel_worker_submit(&bc->worker, &cmd->ccmd);
+            if (rc == HFSSS_OK) break;
+            if (rc == HFSSS_ERR_BUSY) {
+                sched_yield();
+                continue;
+            }
+            fprintf(stderr,
+                    "[bench] submit failed ch=%u i=%u rc=%d\n",
+                    bc->channel_id, i, rc);
+            bench_cmd_free(cmd);
+            atomic_store(&bc->fatal, 1);
+            goto out;
+        }
+        atomic_fetch_add(&bc->submitted, 1);
+    }
+out:
+    atomic_store(&bc->prod_done, 1);
+    return NULL;
+}
+
+/* -------------------------------------------------------------------- */
+/* Consumer                                                             */
+/* -------------------------------------------------------------------- */
+
+static void *consumer_thread(void *arg)
+{
+    struct bench_channel *bc = (struct bench_channel *)arg;
+    struct channel_cmd *batch[BENCH_BATCH_CAP];
+    u32 popped_total = 0;
+
+    while (popped_total < bc->target_ops) {
+        if (atomic_load(&bc->fatal)) break;
+        int n = channel_worker_drain(&bc->worker, batch, BENCH_BATCH_CAP);
+        if (n < 0) {
+            fprintf(stderr, "[bench] drain ch=%u rc=%d\n",
+                    bc->channel_id, n);
+            atomic_store(&bc->fatal, 1);
+            break;
+        }
+        if (n == 0) {
+            /* Producer finished and CQ is empty — bail. */
+            if (atomic_load(&bc->prod_done) &&
+                atomic_load(&bc->submitted) == popped_total) {
+                break;
+            }
+            sched_yield();
+            continue;
+        }
+        for (int i = 0; i < n; i++) {
+            struct channel_cmd *cc = batch[i];
+            struct bench_cmd   *cmd = (struct bench_cmd *)cc;
+            u64 lat = cc->complete_ts_ns - cc->submit_ts_ns;
+            if (popped_total < bc->target_ops) {
+                bc->samples[popped_total] = lat;
+            }
+            popped_total++;
+            atomic_fetch_add(&bc->completed, 1);
+            bench_cmd_free(cmd);
+        }
+    }
+    bc->sample_count = popped_total;
+    return NULL;
+}
+
+/* -------------------------------------------------------------------- */
+/* Stats                                                                */
+/* -------------------------------------------------------------------- */
+
+struct latency_stats {
+    u64 count;
+    u64 min_ns;
+    u64 max_ns;
+    double mean_ns;
+    u64 p50_ns;
+    u64 p99_ns;
+    u64 p999_ns;
+};
+
+static int u64_cmp(const void *a, const void *b)
+{
+    u64 x = *(const u64 *)a;
+    u64 y = *(const u64 *)b;
+    if (x < y) return -1;
+    if (x > y) return  1;
+    return 0;
+}
+
+static u64 percentile(const u64 *sorted, u64 count, double pct)
+{
+    if (count == 0) return 0;
+    /* Nearest-rank percentile, clamped to last index. */
+    u64 idx = (u64)(pct * (double)count);
+    if (idx >= count) idx = count - 1;
+    return sorted[idx];
+}
+
+static void compute_stats(u64 *samples, u64 count, struct latency_stats *out)
+{
+    memset(out, 0, sizeof(*out));
+    if (count == 0) return;
+    qsort(samples, count, sizeof(u64), u64_cmp);
+    out->count   = count;
+    out->min_ns  = samples[0];
+    out->max_ns  = samples[count - 1];
+    long double sum = 0.0L;
+    for (u64 i = 0; i < count; i++) sum += (long double)samples[i];
+    out->mean_ns = (double)(sum / (long double)count);
+    out->p50_ns  = percentile(samples, count, 0.50);
+    out->p99_ns  = percentile(samples, count, 0.99);
+    out->p999_ns = percentile(samples, count, 0.999);
+}
+
+/* -------------------------------------------------------------------- */
+/* Reporting                                                            */
+/* -------------------------------------------------------------------- */
+
+static void print_report(const struct latency_stats *s,
+                         u32 channels,
+                         u32 ops_per_channel,
+                         u64 wall_ns,
+                         double ops_per_sec,
+                         int pass)
+{
+    double wall_sec = (double)wall_ns / 1e9;
+    printf("========================================\n");
+    printf("REQ-045 tier-2 CQ latency bench\n");
+    printf("========================================\n");
+    printf("channels         : %u\n", channels);
+    printf("ops_per_channel  : %u\n", ops_per_channel);
+    printf("total_ops        : %llu\n", (unsigned long long)s->count);
+    printf("wall_time_sec    : %.3f\n", wall_sec);
+    printf("ops_per_sec      : %.1f\n", ops_per_sec);
+    printf("----------------------------------------\n");
+    printf("latency_min_ns   : %llu\n", (unsigned long long)s->min_ns);
+    printf("latency_p50_ns   : %llu\n", (unsigned long long)s->p50_ns);
+    printf("latency_p99_ns   : %llu\n", (unsigned long long)s->p99_ns);
+    printf("latency_p999_ns  : %llu\n", (unsigned long long)s->p999_ns);
+    printf("latency_max_ns   : %llu\n", (unsigned long long)s->max_ns);
+    printf("latency_mean_ns  : %.1f\n", s->mean_ns);
+    printf("----------------------------------------\n");
+    printf("result           : %s\n", pass ? "PASS" : "FAIL");
+    printf("========================================\n");
+}
+
+/*
+ * key=value summary for CI consumption. Mirrors the shape used by
+ * tests/stress_stability.c::write_results_file so the same scrape
+ * pipeline can lift values out of the artifact.
+ */
+static void write_results_file(const char *path,
+                               const struct latency_stats *s,
+                               u32 channels,
+                               u32 ops_per_channel,
+                               u32 expected_total,
+                               u64 wall_ns,
+                               double ops_per_sec,
+                               int pass)
+{
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        fprintf(stderr, "[bench] cannot open results file '%s' (errno=%d)\n",
+                path, errno);
+        return;
+    }
+    double wall_sec = (double)wall_ns / 1e9;
+    fprintf(f, "result=%s\n",          pass ? "PASS" : "FAIL");
+    fprintf(f, "channels=%u\n",        channels);
+    fprintf(f, "ops_per_channel=%u\n", ops_per_channel);
+    fprintf(f, "expected_total=%u\n",  expected_total);
+    fprintf(f, "total_ops=%llu\n",     (unsigned long long)s->count);
+    fprintf(f, "wall_time_sec=%.3f\n", wall_sec);
+    fprintf(f, "ops_per_sec=%.1f\n",   ops_per_sec);
+    fprintf(f, "latency_min_ns=%llu\n",  (unsigned long long)s->min_ns);
+    fprintf(f, "latency_p50_ns=%llu\n",  (unsigned long long)s->p50_ns);
+    fprintf(f, "latency_p99_ns=%llu\n",  (unsigned long long)s->p99_ns);
+    fprintf(f, "latency_p999_ns=%llu\n", (unsigned long long)s->p999_ns);
+    fprintf(f, "latency_max_ns=%llu\n",  (unsigned long long)s->max_ns);
+    fprintf(f, "latency_mean_ns=%.1f\n", s->mean_ns);
+    fprintf(f, "latency_p99_budget_ns=%llu\n",
+            (unsigned long long)BENCH_LATENCY_P99_BUDGET_NS);
+    fclose(f);
+}
+
+/* -------------------------------------------------------------------- */
+/* Cleanup helpers                                                      */
+/* -------------------------------------------------------------------- */
+
+/*
+ * Drain any commands still queued on a channel's CQ after the consumer
+ * thread has been joined. Runs before channel_worker_cleanup so we do
+ * not leak heap-allocated bench_cmd payloads on early-exit paths.
+ */
+static void drain_residual(struct bench_channel *bc)
+{
+    struct channel_cmd *batch[BENCH_BATCH_CAP];
+    for (;;) {
+        int n = channel_worker_drain(&bc->worker, batch, BENCH_BATCH_CAP);
+        if (n <= 0) break;
+        for (int i = 0; i < n; i++) {
+            bench_cmd_free((struct bench_cmd *)batch[i]);
+        }
+    }
+}
+
+static void teardown_channels(struct bench_channel *channels, u32 n)
+{
+    /* Signal stop on every worker first so any producer/consumer that
+     * is still spinning unblocks promptly. */
+    for (u32 i = 0; i < n; i++) {
+        atomic_store(&channels[i].fatal, 1);
+        channel_worker_stop(&channels[i].worker);
+    }
+    for (u32 i = 0; i < n; i++) {
+        if (channels[i].prod_started) pthread_join(channels[i].prod_thr, NULL);
+        if (channels[i].cons_started) pthread_join(channels[i].cons_thr, NULL);
+        drain_residual(&channels[i]);
+        channel_worker_cleanup(&channels[i].worker);
+        free(channels[i].samples);
+        channels[i].samples = NULL;
+    }
+}
+
+/* -------------------------------------------------------------------- */
+/* main                                                                 */
+/* -------------------------------------------------------------------- */
+
+static struct media_config make_bench_cfg(void)
+{
+    struct media_config cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.channel_count       = BENCH_CHANNELS;
+    cfg.chips_per_channel   = BENCH_CHIPS;
+    cfg.dies_per_chip       = BENCH_DIES;
+    cfg.planes_per_die      = BENCH_PLANES;
+    cfg.blocks_per_plane    = BENCH_BLOCKS_PER_PLANE;
+    cfg.pages_per_block     = BENCH_PAGES_PER_BLOCK;
+    cfg.page_size           = BENCH_PAGE_SIZE;
+    cfg.spare_size          = BENCH_SPARE_SIZE;
+    cfg.nand_type           = NAND_TYPE_SLC;
+    cfg.enable_multi_plane  = true;
+    return cfg;
+}
+
+int main(void)
+{
+    u32 ops_per_ch = env_u32("BENCH_OPS",              BENCH_DEFAULT_OPS_PER_CH);
+    u32 rate       = env_u32("BENCH_RATE_OPS_PER_SEC", BENCH_DEFAULT_RATE);
+    const char *results_path = getenv("STRESS_RESULTS_FILE");
+
+    printf("REQ-045 tier-2 CQ bench — channels=%u ops_per_channel=%u rate=%u (%s)\n",
+           BENCH_CHANNELS, ops_per_ch, rate,
+           rate == 0 ? "unpaced" : "paced");
+    printf("workload: %u%% READ / %u%% PROGRAM, page=%u, ring=%u, cq=%u\n",
+           BENCH_READ_PCT, 100 - BENCH_READ_PCT,
+           BENCH_PAGE_SIZE, BENCH_RING_CAPACITY, BENCH_CQ_CAPACITY);
+
+    struct media_config cfg = make_bench_cfg();
+    struct media_ctx media;
+    int rc = media_init(&media, &cfg);
+    if (rc != HFSSS_OK) {
+        fprintf(stderr, "[bench] media_init failed rc=%d\n", rc);
+        return 2;
+    }
+
+    struct bench_channel channels[BENCH_CHANNELS];
+    memset(channels, 0, sizeof(channels));
+
+    /* Pre-erase all blocks before any worker starts so the producer can
+     * issue programs immediately. */
+    for (u32 ch = 0; ch < BENCH_CHANNELS; ch++) {
+        rc = prepare_channel_blocks(&media, ch);
+        if (rc != HFSSS_OK) {
+            media_cleanup(&media);
+            return 2;
+        }
+    }
+
+    /* Init workers + per-channel state. */
+    for (u32 ch = 0; ch < BENCH_CHANNELS; ch++) {
+        channels[ch].channel_id       = ch;
+        channels[ch].media            = &media;
+        channels[ch].target_ops       = ops_per_ch;
+        channels[ch].rate_ops_per_sec = rate;
+        atomic_store(&channels[ch].prod_done, 0);
+        atomic_store(&channels[ch].submitted, 0);
+        atomic_store(&channels[ch].completed, 0);
+        atomic_store(&channels[ch].fatal,     0);
+        channels[ch].samples = (u64 *)calloc(ops_per_ch, sizeof(u64));
+        if (!channels[ch].samples) {
+            fprintf(stderr, "[bench] OOM allocating samples ch=%u\n", ch);
+            teardown_channels(channels, ch);
+            media_cleanup(&media);
+            return 2;
+        }
+        rc = channel_worker_init(&channels[ch].worker, ch, &media,
+                                 BENCH_RING_CAPACITY, BENCH_CQ_CAPACITY);
+        if (rc != HFSSS_OK) {
+            fprintf(stderr, "[bench] channel_worker_init ch=%u rc=%d\n", ch, rc);
+            teardown_channels(channels, ch);
+            media_cleanup(&media);
+            return 2;
+        }
+    }
+
+    /* Spawn producers + consumers. */
+    u64 wall_start = get_time_ns();
+    for (u32 ch = 0; ch < BENCH_CHANNELS; ch++) {
+        if (pthread_create(&channels[ch].cons_thr, NULL,
+                           consumer_thread, &channels[ch]) != 0) {
+            fprintf(stderr, "[bench] pthread_create consumer ch=%u failed\n", ch);
+            teardown_channels(channels, BENCH_CHANNELS);
+            media_cleanup(&media);
+            return 2;
+        }
+        channels[ch].cons_started = true;
+        if (pthread_create(&channels[ch].prod_thr, NULL,
+                           producer_thread, &channels[ch]) != 0) {
+            fprintf(stderr, "[bench] pthread_create producer ch=%u failed\n", ch);
+            teardown_channels(channels, BENCH_CHANNELS);
+            media_cleanup(&media);
+            return 2;
+        }
+        channels[ch].prod_started = true;
+    }
+
+    /* Join producers, then consumers. */
+    int any_fatal = 0;
+    for (u32 ch = 0; ch < BENCH_CHANNELS; ch++) {
+        pthread_join(channels[ch].prod_thr, NULL);
+        channels[ch].prod_started = false;
+        if (atomic_load(&channels[ch].fatal)) any_fatal = 1;
+    }
+    for (u32 ch = 0; ch < BENCH_CHANNELS; ch++) {
+        pthread_join(channels[ch].cons_thr, NULL);
+        channels[ch].cons_started = false;
+        if (atomic_load(&channels[ch].fatal)) any_fatal = 1;
+    }
+    u64 wall_end = get_time_ns();
+    u64 wall_ns  = wall_end - wall_start;
+
+    /* Aggregate samples. */
+    u64 total = 0;
+    for (u32 ch = 0; ch < BENCH_CHANNELS; ch++) {
+        total += channels[ch].sample_count;
+    }
+    u64 *agg = (u64 *)calloc(total ? total : 1, sizeof(u64));
+    if (!agg) {
+        fprintf(stderr, "[bench] OOM aggregating samples (total=%llu)\n",
+                (unsigned long long)total);
+        teardown_channels(channels, BENCH_CHANNELS);
+        media_cleanup(&media);
+        return 2;
+    }
+    u64 cursor = 0;
+    for (u32 ch = 0; ch < BENCH_CHANNELS; ch++) {
+        memcpy(agg + cursor, channels[ch].samples,
+               channels[ch].sample_count * sizeof(u64));
+        cursor += channels[ch].sample_count;
+    }
+
+    struct latency_stats stats;
+    compute_stats(agg, total, &stats);
+    free(agg);
+
+    u32 expected_total = ops_per_ch * BENCH_CHANNELS;
+    double ops_per_sec = wall_ns ? ((double)total * 1e9 / (double)wall_ns) : 0.0;
+    int pass = !any_fatal &&
+               (total == expected_total) &&
+               (stats.p99_ns < BENCH_LATENCY_P99_BUDGET_NS);
+
+    print_report(&stats, BENCH_CHANNELS, ops_per_ch,
+                 wall_ns, ops_per_sec, pass);
+
+    if (results_path && *results_path) {
+        write_results_file(results_path, &stats,
+                           BENCH_CHANNELS, ops_per_ch,
+                           expected_total, wall_ns, ops_per_sec, pass);
+    }
+
+    teardown_channels(channels, BENCH_CHANNELS);
+    media_cleanup(&media);
+
+    return pass ? 0 : 1;
+}

--- a/tests/bench_channel_worker_cq.c
+++ b/tests/bench_channel_worker_cq.c
@@ -374,12 +374,19 @@ static void *producer_thread(void *arg)
         wait_until(deadline_for(start, bc->rate_ops_per_sec, i));
 
         /* Submit with retry on BUSY (CQ back-pressure flows through to
-         * the submit ring). yield-spin keeps the producer responsive
-         * to cleanup. */
+         * the submit ring). The fatal-check in the BUSY branch is
+         * load-bearing: once teardown signals stop, channel_worker_submit
+         * returns HFSSS_ERR_BUSY indefinitely, so a plain yield-spin
+         * would hang the producer and deadlock pthread_join in
+         * teardown_channels. */
         for (;;) {
             int rc = channel_worker_submit(&bc->worker, &cmd->ccmd);
             if (rc == HFSSS_OK) break;
             if (rc == HFSSS_ERR_BUSY) {
+                if (atomic_load(&bc->fatal)) {
+                    bench_cmd_free(cmd);
+                    goto out;
+                }
                 sched_yield();
                 continue;
             }


### PR DESCRIPTION
## Summary

Tier-2 follow-up to PR #111 (REQ-045 tier-1 completion queue). Adds a controlled benchmark harness that exercises the opt-in CQ under a mixed read/program workload and reports submit-to-complete latency percentiles. **Opt-in only — not wired into `make test`.** No production-path retarget (that's tier-3).

Spec reference: `docs/superpowers/specs/2026-04-24-req-045-completion-queue-design.md` §9.1.

## Changes

- **New** `tests/bench_channel_worker_cq.c` (~750 LOC)
  - One `channel_worker` per channel, `cq_capacity=256`, one producer + one consumer thread per channel
  - Producer issues 70/30 R/W mix against pre-erased blocks; recycles blocks via ERASE submissions when a block fills up
  - Consumer drains the CQ in batches of 64, records `complete_ts_ns - submit_ts_ns` per cmd
  - Aggregates across channels, prints count, min/max, mean, p50, p99, p99.9 + wall time + ops/sec
  - When `STRESS_RESULTS_FILE` is set, also writes a `key=value` summary (same shape as `tests/stress_stability.c`)
- **Modified** `Makefile`
  - New `BENCH_CQ` binary, build recipe matching the other channel-worker test
  - New `bench-cq` phony target, env-var passthrough (`STRESS_RESULTS_FILE`, `BENCH_OPS`, `BENCH_RATE_OPS_PER_SEC`)
  - Listed under `make help` as ` Run REQ-045 tier-2 CQ latency bench harness (opt-in)`
  - **Not** added to `make test`

## Workload knobs

| Env var | Default | Purpose |
|---|---|---|
| `BENCH_OPS` | 10000 | ops per channel |
| `BENCH_RATE_OPS_PER_SEC` | 0 (unpaced) | producer pacing rate |
| `STRESS_RESULTS_FILE` | unset | path for key=value scrape file |

## PASS criterion

Every submitted op observed by consumer **AND** aggregate p99 < **100 ms**.

The 100 ms budget is intentionally a 3× headroom over the natural unpaced p99 (~30 ms) seen on this in-memory simulator. The producer saturates the 256-deep SPSC ring on first turn so each cmd accrues queue-wait latency — that's expected backpressure, not a defect. The budget is sized to catch order-of-magnitude regressions (deadlock, unbounded spin, livelock) without flaking on natural queueing. Tighten by passing `BENCH_RATE_OPS_PER_SEC` to pace the producer.

## Representative output

\`\`\`
total_ops        : 20000
wall_time_sec    : 0.986
ops_per_sec      : 20277.0
latency_min_ns   : 202000
latency_p50_ns   : 25145000
latency_p99_ns   : 29496000
latency_p999_ns  : 30425000
latency_max_ns   : 31139000
latency_mean_ns  : 24946545.8
result           : PASS
\`\`\`

## Scope boundary (explicit)

In scope:
- Standalone bench harness on \`channel_worker\` API only
- p50 / p99 / p99.9 latency reporting
- key=value scrape summary

Out of scope (tier-3, separate plan):
- FTL / HAL hot-path retarget onto \`channel_worker\`
- fio-visible latency export
- Production NBD / NVMe path changes

## Test plan

- [x] \`make -j12 all\` — clean build, \`build/bin/bench_channel_worker_cq\` produced
- [x] \`make bench-cq\` — runs to completion, prints latency report, exit 0 on PASS
- [x] \`STRESS_RESULTS_FILE=/tmp/bench_cq_results.txt make bench-cq\` — key=value file written with documented keys
- [x] \`make test\` — regression unchanged (tripped the known REQ-122 wall-clock flake on first run; clean on re-run, confirming pre-existing flake unrelated to this change)
- [ ] CI build matrix (ubuntu-latest, macos-latest, kernel-module) green
- [ ] Sanity-run \`make bench-cq\` once locally on Linux to confirm portability of \`clock_gettime(CLOCK_MONOTONIC)\` + \`pthread\` paths